### PR TITLE
Refactor models and enhance session handling with new features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.out
 .claude
 .wiki
+.agenvoy
 
 docker-compose.yml
 test/copilot_token.json

--- a/cmd/app/addProvider.go
+++ b/cmd/app/addProvider.go
@@ -76,22 +76,21 @@ func runAdd() {
 	}
 
 	p := providers[index]
-	defaultModel := provider.Default(p.name())
 
 	var model, description string
 	switch p.name() {
 	case "copilot":
-		model, description = addCopilot(p.Prefix, defaultModel)
+		model, description = addCopilot(p.Prefix)
 
 	case "compat":
 		model, description = addCompat()
 
 	case "codex":
-		model, description = addOpenAICodex(p.Prefix, defaultModel)
+		model, description = addOpenAICodex(p.Prefix)
 
 	default:
 		addAPIKey(p.label(), p.envKey())
-		model, description = getModelName(p.Prefix, defaultModel)
+		model, description = getModelName(p.Prefix)
 	}
 
 	if model != "" {
@@ -99,7 +98,26 @@ func runAdd() {
 	}
 }
 
-func addCopilot(prefix, defaultModel string) (string, string) {
+func addCopilot(prefix string) (string, string) {
+	if copilot.HasToken() {
+		confirm := promptui.Select{
+			Label:        "Copilot token exists, re-login?",
+			Items:        []string{"No", "Yes"},
+			HideSelected: true,
+		}
+		idx, _, err := confirm.Run()
+		if err != nil {
+			os.Exit(1)
+		}
+		if idx == 0 {
+			return getModelName(prefix)
+		}
+		if err := copilot.ClearToken(); err != nil {
+			slog.Error("copilot.ClearToken", slog.String("error", err.Error()))
+			os.Exit(1)
+		}
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
 	defer cancel()
 	if err := copilot.Authenticate(ctx); err != nil {
@@ -107,7 +125,7 @@ func addCopilot(prefix, defaultModel string) (string, string) {
 			slog.String("error", err.Error()))
 		os.Exit(1)
 	}
-	return getModelName(prefix, defaultModel)
+	return getModelName(prefix)
 }
 
 func addCompat() (string, string) {
@@ -181,7 +199,7 @@ func addCompat() (string, string) {
 	}
 
 	prefix := fmt.Sprintf("compat[%s]@", providor)
-	model, _ := getModelName(prefix, "")
+	model, _ := getModelName(prefix)
 	return model, ""
 }
 
@@ -226,14 +244,14 @@ func addAPIKey(label, envKey string) {
 	fmt.Printf("[*] %s saved\n", envKey)
 }
 
-func getModelName(prefix, defaultModel string) (string, string) {
+func getModelName(prefix string) (string, string) {
 	p := strings.TrimSuffix(prefix, "@")
 	if idx := strings.Index(p, "["); idx != -1 {
 		p = ""
 	}
 
 	if p != "" {
-		if model, desc, ok := selectModelFromList(prefix, p, defaultModel); ok {
+		if model, desc, ok := selectModelFromList(prefix, p); ok {
 			return model, desc
 		}
 	}
@@ -252,7 +270,7 @@ func getModelName(prefix, defaultModel string) (string, string) {
 	return prefix + model, ""
 }
 
-func selectModelFromList(prefix, providerName, defaultModel string) (model, desc string, ok bool) {
+func selectModelFromList(prefix, providerName string) (model, desc string, ok bool) {
 	models := provider.Models(providerName)
 	if len(models) == 0 {
 		return "", "", false
@@ -263,18 +281,20 @@ func selectModelFromList(prefix, providerName, defaultModel string) (model, desc
 		info provider.ModelItem
 	}
 
-	entries := make([]entry, 0, len(models))
-	if info, exists := models[defaultModel]; exists {
-		entries = append(entries, entry{defaultModel, info})
-	}
-	others := make([]string, 0, len(models))
+	names := make([]string, 0, len(models))
 	for name := range models {
-		if name != defaultModel {
-			others = append(others, name)
-		}
+		names = append(names, name)
 	}
-	sort.Strings(others)
-	for _, name := range others {
+	sort.SliceStable(names, func(i, j int) bool {
+		pi, pj := isPreviewModel(names[i]), isPreviewModel(names[j])
+		if pi != pj {
+			return !pi
+		}
+		return names[i] < names[j]
+	})
+
+	entries := make([]entry, 0, len(names))
+	for _, name := range names {
 		entries = append(entries, entry{name, models[name]})
 	}
 
@@ -383,7 +403,8 @@ func runPlanner() {
 
 func upsertModel(name, defaultDesc string) {
 	descriptionInput := promptui.Prompt{
-		Label: "Model description",
+		Label:   "Model description",
+		Default: defaultDesc,
 	}
 	description, err := descriptionInput.Run()
 	if err != nil {
@@ -440,7 +461,7 @@ func upsertModel(name, defaultDesc string) {
 	}
 }
 
-func addOpenAICodex(prefix, defaultModel string) (string, string) {
+func addOpenAICodex(prefix string) (string, string) {
 	if openaicodex.HasToken() {
 		confirm := promptui.Select{
 			Label:        "OpenAI Codex token exists, re-login?",
@@ -452,7 +473,7 @@ func addOpenAICodex(prefix, defaultModel string) (string, string) {
 			os.Exit(1)
 		}
 		if idx == 0 {
-			return getModelName(prefix, defaultModel)
+			return getModelName(prefix)
 		}
 		if err := openaicodex.ClearToken(); err != nil {
 			slog.Error("openaicodex.ClearToken", slog.String("error", err.Error()))
@@ -476,7 +497,11 @@ func addOpenAICodex(prefix, defaultModel string) (string, string) {
 		os.Exit(1)
 	}
 
-	return getModelName(prefix, defaultModel)
+	return getModelName(prefix)
+}
+
+func isPreviewModel(name string) bool {
+	return strings.Contains(name, "-preview") || strings.Contains(name, "-experimental")
 }
 
 type brokenModel struct {

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -240,7 +240,7 @@ func setSummaryCron() {
 				continue
 			}
 			bgCtx := context.Background()
-			summaryAgent := exec.SelectAgent(bgCtx, host.Planner(), host.Registry(), "[summary] 整理對話摘要，選擇最輕量可完成任務的模型", false, sid)
+			summaryAgent := exec.SelectAgent(bgCtx, host.Planner(), host.Registry(), "[summary] background summary cron", false, sid)
 			summary.Generate(bgCtx, summaryAgent, sid, summaryHistories)
 			slog.Info("summary done",
 				slog.String("session", sid))

--- a/configs/jsons/providors/claude.json
+++ b/configs/jsons/providors/claude.json
@@ -1,22 +1,38 @@
 {
-  "claude-opus-4-6": {
-    "description": "最強大的 Claude 模型，適合複雜推理與長篇任務",
-    "thinking_type": "adaptive"
+  "claude-sonnet-4-20250514": {
+    "description": "Balanced reasoning and speed for production workloads",
+    "thinking_type": "enabled"
+  },
+  "claude-opus-4-20250514": {
+    "description": "High capability for complex reasoning and long-form tasks",
+    "thinking_type": "enabled"
+  },
+  "claude-opus-4-1-20250805": {
+    "description": "Refined high-capability reasoning",
+    "thinking_type": "enabled"
+  },
+  "claude-haiku-4-5-20251001": {
+    "description": "Lightweight, lowest latency, suited for simple tasks",
+    "thinking_type": "enabled"
+  },
+  "claude-sonnet-4-5-20250929": {
+    "description": "Balanced with strong coding and analysis capability",
+    "thinking_type": "enabled"
+  },
+  "claude-opus-4-5-20251101": {
+    "description": "High capability for demanding reasoning workloads",
+    "thinking_type": "enabled"
   },
   "claude-sonnet-4-6": {
-    "description": "效能與速度平衡，適合多數生產環境",
+    "description": "Balanced performance with adaptive thinking",
     "thinking_type": "adaptive"
   },
-  "claude-opus-4-5": {
-    "description": "高效能 Claude 模型，適合高要求任務",
-    "thinking_type": "enabled"
+  "claude-opus-4-6": {
+    "description": "Top capability with adaptive thinking",
+    "thinking_type": "adaptive"
   },
-  "claude-sonnet-4-5": {
-    "description": "穩定的中階模型，具備強大程式碼與分析能力",
-    "thinking_type": "enabled"
-  },
-  "claude-haiku-4-5": {
-    "description": "輕量模型，適合簡單任務，延遲極低",
-    "thinking_type": "enabled"
+  "claude-opus-4-7": {
+    "description": "Strongest reasoning capability with adaptive thinking",
+    "thinking_type": "adaptive"
   }
 }

--- a/configs/jsons/providors/claude.json
+++ b/configs/jsons/providors/claude.json
@@ -1,25 +1,22 @@
 {
-  "default": "claude-sonnet-4-5",
-  "models": {
-    "claude-opus-4-6": {
-      "description": "最強大的 Claude 模型，適合複雜推理與長篇任務",
-      "thinking_type": "adaptive"
-    },
-    "claude-sonnet-4-6": {
-      "description": "效能與速度平衡，適合多數生產環境",
-      "thinking_type": "adaptive"
-    },
-    "claude-opus-4-5": {
-      "description": "高效能 Claude 模型，適合高要求任務",
-      "thinking_type": "enabled"
-    },
-    "claude-sonnet-4-5": {
-      "description": "穩定的中階模型，具備強大程式碼與分析能力",
-      "thinking_type": "enabled"
-    },
-    "claude-haiku-4-5": {
-      "description": "輕量模型，適合簡單任務，延遲極低",
-      "thinking_type": "enabled"
-    }
+  "claude-opus-4-6": {
+    "description": "最強大的 Claude 模型，適合複雜推理與長篇任務",
+    "thinking_type": "adaptive"
+  },
+  "claude-sonnet-4-6": {
+    "description": "效能與速度平衡，適合多數生產環境",
+    "thinking_type": "adaptive"
+  },
+  "claude-opus-4-5": {
+    "description": "高效能 Claude 模型，適合高要求任務",
+    "thinking_type": "enabled"
+  },
+  "claude-sonnet-4-5": {
+    "description": "穩定的中階模型，具備強大程式碼與分析能力",
+    "thinking_type": "enabled"
+  },
+  "claude-haiku-4-5": {
+    "description": "輕量模型，適合簡單任務，延遲極低",
+    "thinking_type": "enabled"
   }
 }

--- a/configs/jsons/providors/codex.json
+++ b/configs/jsons/providors/codex.json
@@ -1,38 +1,35 @@
 {
-  "default": "gpt-5.3-codex",
-  "models": {
-    "gpt-5.5": {
-      "description": "OpenAI 最新旗艦模型，強化 agentic coding／電腦控制／知識工作能力，可調推理深度（low／medium／high／xhigh），1.05M 上下文"
-    },
-    "gpt-5.5-pro": {
-      "description": "GPT-5.5 Pro 版，針對複雜長程推理場景強化，輸出品質更高，僅限 Pro／Business／Enterprise"
-    },
-    "gpt-5.4": {
-      "description": "前代旗艦推理模型，支援多層次推理深度，具備原生電腦控制與超長上下文"
-    },
-    "gpt-5.4-mini": {
-      "description": "GPT-5.4 高效版，保留超長上下文與電腦控制能力，速度更快且成本更低"
-    },
-    "gpt-5.3-codex": {
-      "description": "GPT-5.3 Codex，強化程式生成與 Agentic coding 能力"
-    },
-    "gpt-5.3-codex-spark": {
-      "description": "GPT-5.3 Codex Spark（Research Preview），純文字模型，針對近即時程式碼迭代場景優化，僅限 ChatGPT Pro"
-    },
-    "gpt-5.2-codex": {
-      "description": "GPT-5.2 Codex，穩定的程式生成模型"
-    },
-    "gpt-5.1-codex-max": {
-      "description": "GPT-5.1 Codex Max，最大上下文程式生成版本"
-    },
-    "gpt-5.1-codex": {
-      "description": "GPT-5.1 Codex，適合程式補全與 Agentic 任務"
-    },
-    "gpt-5-codex": {
-      "description": "GPT-5 Codex，基礎程式生成模型"
-    },
-    "gpt-5-codex-mini": {
-      "description": "GPT-5 Codex Mini，輕量程式生成模型"
-    }
+  "gpt-5.5": {
+    "description": "OpenAI 最新旗艦模型，強化 agentic coding／電腦控制／知識工作能力，可調推理深度（low／medium／high／xhigh），1.05M 上下文"
+  },
+  "gpt-5.5-pro": {
+    "description": "GPT-5.5 Pro 版，針對複雜長程推理場景強化，輸出品質更高，僅限 Pro／Business／Enterprise"
+  },
+  "gpt-5.4": {
+    "description": "前代旗艦推理模型，支援多層次推理深度，具備原生電腦控制與超長上下文"
+  },
+  "gpt-5.4-mini": {
+    "description": "GPT-5.4 高效版，保留超長上下文與電腦控制能力，速度更快且成本更低"
+  },
+  "gpt-5.3-codex": {
+    "description": "GPT-5.3 Codex，強化程式生成與 Agentic coding 能力"
+  },
+  "gpt-5.3-codex-spark": {
+    "description": "GPT-5.3 Codex Spark（Research Preview），純文字模型，針對近即時程式碼迭代場景優化，僅限 ChatGPT Pro"
+  },
+  "gpt-5.2-codex": {
+    "description": "GPT-5.2 Codex，穩定的程式生成模型"
+  },
+  "gpt-5.1-codex-max": {
+    "description": "GPT-5.1 Codex Max，最大上下文程式生成版本"
+  },
+  "gpt-5.1-codex": {
+    "description": "GPT-5.1 Codex，適合程式補全與 Agentic 任務"
+  },
+  "gpt-5-codex": {
+    "description": "GPT-5 Codex，基礎程式生成模型"
+  },
+  "gpt-5-codex-mini": {
+    "description": "GPT-5 Codex Mini，輕量程式生成模型"
   }
 }

--- a/configs/jsons/providors/codex.json
+++ b/configs/jsons/providors/codex.json
@@ -1,35 +1,17 @@
 {
-  "gpt-5.5": {
-    "description": "OpenAI 最新旗艦模型，強化 agentic coding／電腦控制／知識工作能力，可調推理深度（low／medium／high／xhigh），1.05M 上下文"
-  },
-  "gpt-5.5-pro": {
-    "description": "GPT-5.5 Pro 版，針對複雜長程推理場景強化，輸出品質更高，僅限 Pro／Business／Enterprise"
-  },
-  "gpt-5.4": {
-    "description": "前代旗艦推理模型，支援多層次推理深度，具備原生電腦控制與超長上下文"
-  },
-  "gpt-5.4-mini": {
-    "description": "GPT-5.4 高效版，保留超長上下文與電腦控制能力，速度更快且成本更低"
+  "gpt-5.2": {
+    "description": "Optimized for professional work and long-running agents"
   },
   "gpt-5.3-codex": {
-    "description": "GPT-5.3 Codex，強化程式生成與 Agentic coding 能力"
+    "description": "Coding-optimized for code generation and agentic tasks"
   },
-  "gpt-5.3-codex-spark": {
-    "description": "GPT-5.3 Codex Spark（Research Preview），純文字模型，針對近即時程式碼迭代場景優化，僅限 ChatGPT Pro"
+  "gpt-5.4-mini": {
+    "description": "Small, fast, cost-efficient, suited for simpler coding tasks"
   },
-  "gpt-5.2-codex": {
-    "description": "GPT-5.2 Codex，穩定的程式生成模型"
+  "gpt-5.4": {
+    "description": "Strong general coding capability for everyday work"
   },
-  "gpt-5.1-codex-max": {
-    "description": "GPT-5.1 Codex Max，最大上下文程式生成版本"
-  },
-  "gpt-5.1-codex": {
-    "description": "GPT-5.1 Codex，適合程式補全與 Agentic 任務"
-  },
-  "gpt-5-codex": {
-    "description": "GPT-5 Codex，基礎程式生成模型"
-  },
-  "gpt-5-codex-mini": {
-    "description": "GPT-5 Codex Mini，輕量程式生成模型"
+  "gpt-5.5": {
+    "description": "Frontier capability for complex coding, research, and real-world work"
   }
 }

--- a/configs/jsons/providors/copilot.json
+++ b/configs/jsons/providors/copilot.json
@@ -1,74 +1,74 @@
 {
-  "gpt-5.4": {
-    "description": "OpenAI 最新旗艦模型，支援多層次推理深度，具備原生電腦控制與超長上下文"
-  },
-  "gpt-5.4-mini": {
-    "description": "GPT-5.4 高效版，接近旗艦 coding/computer-use 表現，速度為 GPT-5 mini 2x+，適合 subagent executor 與高吞吐工作負載"
-  },
-  "gpt-5.3-codex": {
-    "description": "GPT-5.3 Codex，強化程式生成與 Agentic coding 能力",
-    "no_temperature": true
-  },
-  "gpt-5.2-codex": {
-    "description": "GPT-5.2 Codex，穩定的程式生成模型",
-    "no_temperature": true
-  },
-  "gpt-5.1-codex-max": {
-    "description": "GPT-5.1 Codex Max，最大上下文程式生成版本",
-    "no_temperature": true
-  },
-  "gpt-5.1-codex": {
-    "description": "GPT-5.1 Codex，適合程式補全與 Agentic 任務",
-    "no_temperature": true
-  },
-  "gpt-5.1-codex-mini": {
-    "description": "GPT-5.1 Codex Mini，輕量程式生成，低延遲",
-    "no_temperature": true
-  },
   "gpt-5-mini": {
-    "description": "GPT-5 高效版，速度更快且成本更低，適合明確定義的任務",
+    "description": "Mid-tier reasoning, faster and cheaper, suited for well-defined tasks",
     "no_temperature": true,
     "reasoning_effort": true
   },
-  "gpt-4.1": {
-    "description": "非推理旗艦模型，指令遵循與工具呼叫最佳化，低延遲快速推理"
+  "gpt-5.2-codex": {
+    "description": "Stable code generation",
+    "no_temperature": true
+  },
+  "gpt-5.2": {
+    "description": "Reasoning model with configurable depth",
+    "no_temperature": true,
+    "reasoning_effort": true
+  },
+  "gpt-5.3-codex": {
+    "description": "Code generation and agentic tasks",
+    "no_temperature": true
+  },
+  "gpt-5.4-mini": {
+    "description": "Extra-long context with computer use, efficient and low cost"
+  },
+  "gpt-5.4": {
+    "description": "Multi-level reasoning depth, native computer use, extra-long context"
+  },
+  "gpt-5.5": {
+    "description": "Configurable reasoning depth (low/medium/high/xhigh), 1.05M context; requires Copilot Pro+ or higher",
+    "no_temperature": true,
+    "reasoning_effort": true
+  },
+  "gpt-4o-mini": {
+    "description": "Compact multimodal, low latency and cost"
   },
   "gpt-4o": {
-    "description": "多模態旗艦模型，支援文字、圖像與音訊輸入"
+    "description": "Multimodal flagship with text, image, and audio input"
   },
-  "claude-sonnet-4.6": {
-    "description": "效能與速度平衡，適合多數生產環境",
-    "no_temperature": true
+  "gpt-4.1": {
+    "description": "Non-reasoning instruction-tuned model with low-latency tool calling"
   },
-  "claude-opus-4.6": {
-    "description": "最強大的 Claude 模型，適合複雜推理與長篇任務",
-    "no_temperature": true
-  },
-  "claude-opus-4.5": {
-    "description": "高效能 Claude 模型，適合高要求任務",
+  "claude-haiku-4.5": {
+    "description": "Lightweight, lowest latency, suited for simple tasks",
     "no_temperature": true
   },
   "claude-sonnet-4.5": {
-    "description": "穩定的中階模型，具備強大程式碼與分析能力",
+    "description": "Balanced with strong coding and analysis capability",
     "no_temperature": true
   },
-  "claude-haiku-4.5": {
-    "description": "輕量模型，適合簡單任務，延遲極低",
+  "claude-opus-4.5": {
+    "description": "High capability for demanding reasoning workloads; requires Copilot Pro+ or higher",
     "no_temperature": true
   },
-  "gemini-3.1-pro-preview": {
-    "description": "Gemini 3.1 旗艦模型，具備強大推理與 Agentic 程式能力",
+  "claude-sonnet-4.6": {
+    "description": "Balanced performance with adaptive thinking",
     "no_temperature": true
   },
-  "gemini-3-pro-preview": {
-    "description": "Gemini 3 旗艦模型，強化多步驟推理與工具呼叫能力",
+  "claude-opus-4.7": {
+    "description": "Strongest reasoning capability with adaptive thinking; requires Copilot Pro+ or higher",
     "no_temperature": true
   },
   "gemini-2.5-pro": {
-    "description": "Google 最強大的多模態模型，支援超長上下文與深度推理"
+    "description": "Strong multimodal with extra-long context and deep reasoning"
   },
   "gemini-3-flash-preview": {
-    "description": "Gemini 3 Flash，支援可配置思考深度，適合結構化輸出與工具呼叫",
+    "description": "Mid-tier reasoning balancing quality and cost",
     "no_temperature": true
+  },
+  "gemini-3.1-pro-preview": {
+    "description": "Flagship reasoning and agentic coding capability",
+    "no_temperature": true
+  },
+  "grok-code-fast-1": {
+    "description": "Fast code-focused model optimized for agentic coding"
   }
 }

--- a/configs/jsons/providors/copilot.json
+++ b/configs/jsons/providors/copilot.json
@@ -1,75 +1,74 @@
 {
-  "default": "gpt-4.1",
-  "models": {
-    "gpt-5.4": {
-      "description": "OpenAI 最新旗艦模型，支援多層次推理深度，具備原生電腦控制與超長上下文"
-    },
-    "gpt-5.4-mini": {
-      "description": "GPT-5.4 高效版，接近旗艦 coding/computer-use 表現，速度為 GPT-5 mini 2x+，適合 subagent executor 與高吞吐工作負載"
-    },
-    "gpt-5.3-codex": {
-      "description": "GPT-5.3 Codex，強化程式生成與 Agentic coding 能力",
-      "no_temperature": true
-    },
-    "gpt-5.2-codex": {
-      "description": "GPT-5.2 Codex，穩定的程式生成模型",
-      "no_temperature": true
-    },
-    "gpt-5.1-codex-max": {
-      "description": "GPT-5.1 Codex Max，最大上下文程式生成版本",
-      "no_temperature": true
-    },
-    "gpt-5.1-codex": {
-      "description": "GPT-5.1 Codex，適合程式補全與 Agentic 任務",
-      "no_temperature": true
-    },
-    "gpt-5.1-codex-mini": {
-      "description": "GPT-5.1 Codex Mini，輕量程式生成，低延遲",
-      "no_temperature": true
-    },
-    "gpt-5-mini": {
-      "description": "GPT-5 高效版，速度更快且成本更低，適合明確定義的任務",
-      "no_temperature": true,
-      "reasoning_effort": true
-    },
-    "gpt-4.1": {
-      "description": "非推理旗艦模型，指令遵循與工具呼叫最佳化，低延遲快速推理"
-    },
-    "gpt-4o": { "description": "多模態旗艦模型，支援文字、圖像與音訊輸入" },
-    "claude-sonnet-4.6": {
-      "description": "效能與速度平衡，適合多數生產環境",
-      "no_temperature": true
-    },
-    "claude-opus-4.6": {
-      "description": "最強大的 Claude 模型，適合複雜推理與長篇任務",
-      "no_temperature": true
-    },
-    "claude-opus-4.5": {
-      "description": "高效能 Claude 模型，適合高要求任務",
-      "no_temperature": true
-    },
-    "claude-sonnet-4.5": {
-      "description": "穩定的中階模型，具備強大程式碼與分析能力",
-      "no_temperature": true
-    },
-    "claude-haiku-4.5": {
-      "description": "輕量模型，適合簡單任務，延遲極低",
-      "no_temperature": true
-    },
-    "gemini-3.1-pro-preview": {
-      "description": "Gemini 3.1 旗艦模型，具備強大推理與 Agentic 程式能力",
-      "no_temperature": true
-    },
-    "gemini-3-pro-preview": {
-      "description": "Gemini 3 旗艦模型，強化多步驟推理與工具呼叫能力",
-      "no_temperature": true
-    },
-    "gemini-2.5-pro": {
-      "description": "Google 最強大的多模態模型，支援超長上下文與深度推理"
-    },
-    "gemini-3-flash-preview": {
-      "description": "Gemini 3 Flash，支援可配置思考深度，適合結構化輸出與工具呼叫",
-      "no_temperature": true
-    }
+  "gpt-5.4": {
+    "description": "OpenAI 最新旗艦模型，支援多層次推理深度，具備原生電腦控制與超長上下文"
+  },
+  "gpt-5.4-mini": {
+    "description": "GPT-5.4 高效版，接近旗艦 coding/computer-use 表現，速度為 GPT-5 mini 2x+，適合 subagent executor 與高吞吐工作負載"
+  },
+  "gpt-5.3-codex": {
+    "description": "GPT-5.3 Codex，強化程式生成與 Agentic coding 能力",
+    "no_temperature": true
+  },
+  "gpt-5.2-codex": {
+    "description": "GPT-5.2 Codex，穩定的程式生成模型",
+    "no_temperature": true
+  },
+  "gpt-5.1-codex-max": {
+    "description": "GPT-5.1 Codex Max，最大上下文程式生成版本",
+    "no_temperature": true
+  },
+  "gpt-5.1-codex": {
+    "description": "GPT-5.1 Codex，適合程式補全與 Agentic 任務",
+    "no_temperature": true
+  },
+  "gpt-5.1-codex-mini": {
+    "description": "GPT-5.1 Codex Mini，輕量程式生成，低延遲",
+    "no_temperature": true
+  },
+  "gpt-5-mini": {
+    "description": "GPT-5 高效版，速度更快且成本更低，適合明確定義的任務",
+    "no_temperature": true,
+    "reasoning_effort": true
+  },
+  "gpt-4.1": {
+    "description": "非推理旗艦模型，指令遵循與工具呼叫最佳化，低延遲快速推理"
+  },
+  "gpt-4o": {
+    "description": "多模態旗艦模型，支援文字、圖像與音訊輸入"
+  },
+  "claude-sonnet-4.6": {
+    "description": "效能與速度平衡，適合多數生產環境",
+    "no_temperature": true
+  },
+  "claude-opus-4.6": {
+    "description": "最強大的 Claude 模型，適合複雜推理與長篇任務",
+    "no_temperature": true
+  },
+  "claude-opus-4.5": {
+    "description": "高效能 Claude 模型，適合高要求任務",
+    "no_temperature": true
+  },
+  "claude-sonnet-4.5": {
+    "description": "穩定的中階模型，具備強大程式碼與分析能力",
+    "no_temperature": true
+  },
+  "claude-haiku-4.5": {
+    "description": "輕量模型，適合簡單任務，延遲極低",
+    "no_temperature": true
+  },
+  "gemini-3.1-pro-preview": {
+    "description": "Gemini 3.1 旗艦模型，具備強大推理與 Agentic 程式能力",
+    "no_temperature": true
+  },
+  "gemini-3-pro-preview": {
+    "description": "Gemini 3 旗艦模型，強化多步驟推理與工具呼叫能力",
+    "no_temperature": true
+  },
+  "gemini-2.5-pro": {
+    "description": "Google 最強大的多模態模型，支援超長上下文與深度推理"
+  },
+  "gemini-3-flash-preview": {
+    "description": "Gemini 3 Flash，支援可配置思考深度，適合結構化輸出與工具呼叫",
+    "no_temperature": true
   }
 }

--- a/configs/jsons/providors/gemini.json
+++ b/configs/jsons/providors/gemini.json
@@ -1,25 +1,30 @@
 {
-  "default": "gemini-2.5-pro",
-  "models": {
-    "gemini-3.1-pro-preview": {
-      "description": "Gemini 3.1 旗艦模型，具備強大推理與 Agentic 程式能力",
-      "thinking_config": "level"
-    },
-    "gemini-3.1-flash-lite-preview": {
-      "description": "高效輕量版，以極低成本達到接近旗艦的效能，適合大規模任務",
-      "thinking_config": "level"
-    },
-    "gemini-3.1-pro-preview-customtools": {
-      "description": "Gemini 3.1 Pro 工具優先版，專為 Agentic 工作流與自訂工具整合優化",
-      "thinking_config": "level"
-    },
-    "gemini-2.5-pro": {
-      "description": "Google 最強大的多模態模型，支援超長上下文與深度推理",
-      "thinking_config": "budget"
-    },
-    "gemini-2.5-flash": {
-      "description": "高速版 Gemini 2.5，低延遲高吞吐量，兼具推理與多模態能力",
-      "thinking_config": "budget"
-    }
+  "gemini-3.1-pro-preview": {
+    "description": "Gemini 3.1 旗艦模型，具備強大推理與 Agentic 程式能力",
+    "thinking_config": "level"
+  },
+  "gemini-3.1-pro-preview-customtools": {
+    "description": "Gemini 3.1 Pro 工具優先版，專為 Agentic 工作流與自訂工具整合優化",
+    "thinking_config": "level"
+  },
+  "gemini-3.1-flash-lite": {
+    "description": "Gemini 3.1 輕量版，極低成本達到接近旗艦的效能，適合大規模任務",
+    "thinking_config": "level"
+  },
+  "gemini-3-flash-preview": {
+    "description": "Gemini 3 Flash，中階定位，平衡推理品質與成本",
+    "thinking_config": "level"
+  },
+  "gemini-2.5-pro": {
+    "description": "Google 最強大的多模態模型，支援超長上下文與深度推理",
+    "thinking_config": "budget"
+  },
+  "gemini-2.5-flash": {
+    "description": "高速版 Gemini 2.5，低延遲高吞吐量，兼具推理與多模態能力",
+    "thinking_config": "budget"
+  },
+  "gemini-2.5-flash-lite": {
+    "description": "Gemini 2.5 最輕量版，極低延遲與成本，適合大量批次任務",
+    "thinking_config": "budget"
   }
 }

--- a/configs/jsons/providors/gemini.json
+++ b/configs/jsons/providors/gemini.json
@@ -1,30 +1,34 @@
 {
-  "gemini-3.1-pro-preview": {
-    "description": "Gemini 3.1 旗艦模型，具備強大推理與 Agentic 程式能力",
-    "thinking_config": "level"
-  },
-  "gemini-3.1-pro-preview-customtools": {
-    "description": "Gemini 3.1 Pro 工具優先版，專為 Agentic 工作流與自訂工具整合優化",
-    "thinking_config": "level"
-  },
-  "gemini-3.1-flash-lite": {
-    "description": "Gemini 3.1 輕量版，極低成本達到接近旗艦的效能，適合大規模任務",
-    "thinking_config": "level"
-  },
-  "gemini-3-flash-preview": {
-    "description": "Gemini 3 Flash，中階定位，平衡推理品質與成本",
-    "thinking_config": "level"
-  },
-  "gemini-2.5-pro": {
-    "description": "Google 最強大的多模態模型，支援超長上下文與深度推理",
+  "gemini-2.5-flash-lite": {
+    "description": "Lowest latency and cost with thinking budget control, suited for batch tasks",
     "thinking_config": "budget"
   },
   "gemini-2.5-flash": {
-    "description": "高速版 Gemini 2.5，低延遲高吞吐量，兼具推理與多模態能力",
+    "description": "High-throughput multimodal with reasoning and thinking budget control",
     "thinking_config": "budget"
   },
-  "gemini-2.5-flash-lite": {
-    "description": "Gemini 2.5 最輕量版，極低延遲與成本，適合大量批次任務",
+  "gemini-2.5-pro": {
+    "description": "Strong multimodal with extra-long context and deep reasoning",
     "thinking_config": "budget"
+  },
+  "gemini-3-flash-preview": {
+    "description": "Mid-tier reasoning balancing quality and cost",
+    "thinking_config": "level"
+  },
+  "gemini-3-pro-preview": {
+    "description": "Strong reasoning with configurable thinking level",
+    "thinking_config": "level"
+  },
+  "gemini-3.1-flash-lite": {
+    "description": "Lightweight, near-flagship performance at low cost, suited for large-scale tasks",
+    "thinking_config": "level"
+  },
+  "gemini-3.1-pro-preview": {
+    "description": "Flagship reasoning and agentic coding capability",
+    "thinking_config": "level"
+  },
+  "gemini-3.1-pro-preview-customtools": {
+    "description": "Tool-first variant optimized for agentic workflows and custom tool integration",
+    "thinking_config": "level"
   }
 }

--- a/configs/jsons/providors/nvidia.json
+++ b/configs/jsons/providors/nvidia.json
@@ -1,17 +1,14 @@
 {
-  "default": "openai/gpt-oss-120b",
-  "models": {
-    "openai/gpt-oss-120b": {
-      "description": "OpenAI 開源 120B 模型，平衡效能與推理能力"
-    },
-    "meta/llama-3.3-70b-instruct": {
-      "description": "OpenAI 開源 120B 模型，平衡效能與推理能力"
-    },
-    "qwen/qwen3.5-122b-a10b": {
-      "description": "Qwen3.5 122B MoE 多模態視覺語言模型，支援文字、圖片與影片輸入，適用於 Agent 應用"
-    },
-    "nvidia/nemotron-3-super-120b-a12b": {
-      "description": "NVIDIA Nemotron-3 Super 120B（12B active）Hybrid LatentMoE 模型，支援 Tool Use、多語言與 Agentic 推理工作流"
-    }
+  "openai/gpt-oss-120b": {
+    "description": "OpenAI 開源 120B 模型，平衡效能與推理能力"
+  },
+  "meta/llama-3.3-70b-instruct": {
+    "description": "OpenAI 開源 120B 模型，平衡效能與推理能力"
+  },
+  "qwen/qwen3.5-122b-a10b": {
+    "description": "Qwen3.5 122B MoE 多模態視覺語言模型，支援文字、圖片與影片輸入，適用於 Agent 應用"
+  },
+  "nvidia/nemotron-3-super-120b-a12b": {
+    "description": "NVIDIA Nemotron-3 Super 120B（12B active）Hybrid LatentMoE 模型，支援 Tool Use、多語言與 Agentic 推理工作流"
   }
 }

--- a/configs/jsons/providors/openai.json
+++ b/configs/jsons/providors/openai.json
@@ -1,51 +1,80 @@
 {
-  "gpt-5.5": {
-    "description": "OpenAI 最新旗艦模型，可調推理深度（low／medium／high／xhigh），1.05M 上下文",
+  "gpt-5-nano": {
+    "description": "Lightweight reasoning for summarization and classification, lowest latency and cost",
     "no_temperature": true,
     "reasoning_effort": true
   },
-  "gpt-5.4": {
-    "description": "前代旗艦推理模型，支援多層次推理深度，具備原生電腦控制與超長上下文"
-  },
-  "gpt-5.4-mini": {
-    "description": "GPT-5.4 高效版，保留超長上下文與電腦控制能力，速度更快且成本更低"
-  },
-  "gpt-5.4-nano": {
-    "description": "GPT-5.4 最輕量版，超長上下文支援，專為低延遲與高吞吐場景設計"
-  },
-  "gpt-5.2-codex": {
-    "description": "GPT-5.2 Codex，穩定的程式生成模型",
-    "no_temperature": true
-  },
-  "gpt-5.1-codex-max": {
-    "description": "GPT-5.1 Codex Max，最大上下文程式生成版本",
-    "no_temperature": true
-  },
-  "gpt-5.1-codex": {
-    "description": "GPT-5.1 Codex，適合程式補全與 Agentic 任務",
-    "no_temperature": true
-  },
-  "gpt-5.1-codex-mini": {
-    "description": "GPT-5.1 Codex Mini，輕量程式生成，低延遲",
-    "no_temperature": true
-  },
-  "gpt-5": {
-    "description": "智慧推理模型，支援可配置推理深度，適合程式與 Agentic 任務",
+  "gpt-5-mini": {
+    "description": "Mid-tier reasoning, faster and cheaper, suited for well-defined tasks",
     "no_temperature": true,
     "reasoning_effort": true
   },
   "gpt-5-codex": {
-    "description": "GPT-5 Codex，基礎程式生成模型",
+    "description": "Code generation",
     "no_temperature": true
   },
-  "gpt-5-mini": {
-    "description": "GPT-5 高效版，速度更快且成本更低，適合明確定義的任務",
+  "gpt-5": {
+    "description": "Smart reasoning with configurable depth, suited for coding and agentic tasks",
     "no_temperature": true,
     "reasoning_effort": true
   },
-  "gpt-5-nano": {
-    "description": "GPT-5 最輕量版，專為摘要與分類設計，延遲與成本最低",
+  "gpt-5-pro": {
+    "description": "Highest reasoning capability, suited for complex tasks",
+    "no_temperature": true
+  },
+  "gpt-5.1-codex-mini": {
+    "description": "Lightweight code generation, low latency",
+    "no_temperature": true
+  },
+  "gpt-5.1-codex": {
+    "description": "Code completion and agentic tasks",
+    "no_temperature": true
+  },
+  "gpt-5.1-codex-max": {
+    "description": "Code generation with maximum context",
+    "no_temperature": true
+  },
+  "gpt-5.1": {
+    "description": "General-purpose reasoning, balanced performance and depth",
     "no_temperature": true,
     "reasoning_effort": true
+  },
+  "gpt-5.2-codex": {
+    "description": "Stable code generation",
+    "no_temperature": true
+  },
+  "gpt-5.2": {
+    "description": "Reasoning model with configurable depth",
+    "no_temperature": true,
+    "reasoning_effort": true
+  },
+  "gpt-5.2-pro": {
+    "description": "High reasoning capability for professional use cases",
+    "no_temperature": true
+  },
+  "gpt-5.3-codex": {
+    "description": "Code generation and agentic tasks",
+    "no_temperature": true
+  },
+  "gpt-5.4-nano": {
+    "description": "Extra-long context, low latency and high throughput, suited for summarization and classification"
+  },
+  "gpt-5.4-mini": {
+    "description": "Extra-long context with computer use, efficient and low cost"
+  },
+  "gpt-5.4": {
+    "description": "Multi-level reasoning depth, native computer use, extra-long context"
+  },
+  "gpt-5.4-pro": {
+    "description": "Highest reasoning capability, long context with computer use"
+  },
+  "gpt-5.5": {
+    "description": "Configurable reasoning depth (low/medium/high/xhigh), 1.05M context",
+    "no_temperature": true,
+    "reasoning_effort": true
+  },
+  "gpt-5.5-pro": {
+    "description": "Strongest reasoning capability, suited for the most complex tasks",
+    "no_temperature": true
   }
 }

--- a/configs/jsons/providors/openai.json
+++ b/configs/jsons/providors/openai.json
@@ -1,63 +1,51 @@
 {
-  "default": "gpt-5-mini",
-  "models": {
-    "gpt-5.5": {
-      "description": "OpenAI 最新旗艦模型，可調推理深度（low／medium／high／xhigh），1.05M 上下文",
-      "no_temperature": true,
-      "reasoning_effort": true
-    },
-    "gpt-5.4": {
-      "description": "前代旗艦推理模型，支援多層次推理深度，具備原生電腦控制與超長上下文"
-    },
-    "gpt-5.4-mini": {
-      "description": "GPT-5.4 高效版，保留超長上下文與電腦控制能力，速度更快且成本更低"
-    },
-    "gpt-5.4-nano": {
-      "description": "GPT-5.4 最輕量版，超長上下文支援，專為低延遲與高吞吐場景設計"
-    },
-    "gpt-5": {
-      "description": "智慧推理模型，支援可配置推理深度，適合程式與 Agentic 任務",
-      "no_temperature": true,
-      "reasoning_effort": true
-    },
-    "gpt-5-mini": {
-      "description": "GPT-5 高效版，速度更快且成本更低，適合明確定義的任務",
-      "no_temperature": true,
-      "reasoning_effort": true
-    },
-    "gpt-5-nano": {
-      "description": "GPT-5 最輕量版，專為摘要與分類設計，延遲與成本最低",
-      "no_temperature": true,
-      "reasoning_effort": true
-    },
-    "gpt-4.1": {
-      "description": "非推理旗艦模型，指令遵循與工具呼叫最佳化，低延遲快速推理",
-      "no_temperature": true
-    },
-    "gpt-4o": { "description": "多模態旗艦模型，支援文字、圖像與音訊輸入" },
-    "gpt-5.3-codex": {
-      "description": "GPT-5.3 Codex，強化程式生成與 Agentic coding 能力",
-      "no_temperature": true
-    },
-    "gpt-5.2-codex": {
-      "description": "GPT-5.2 Codex，穩定的程式生成模型",
-      "no_temperature": true
-    },
-    "gpt-5.1-codex-max": {
-      "description": "GPT-5.1 Codex Max，最大上下文程式生成版本",
-      "no_temperature": true
-    },
-    "gpt-5.1-codex": {
-      "description": "GPT-5.1 Codex，適合程式補全與 Agentic 任務",
-      "no_temperature": true
-    },
-    "gpt-5.1-codex-mini": {
-      "description": "GPT-5.1 Codex Mini，輕量程式生成，低延遲",
-      "no_temperature": true
-    },
-    "gpt-5-codex": {
-      "description": "GPT-5 Codex，基礎程式生成模型",
-      "no_temperature": true
-    }
+  "gpt-5.5": {
+    "description": "OpenAI 最新旗艦模型，可調推理深度（low／medium／high／xhigh），1.05M 上下文",
+    "no_temperature": true,
+    "reasoning_effort": true
+  },
+  "gpt-5.4": {
+    "description": "前代旗艦推理模型，支援多層次推理深度，具備原生電腦控制與超長上下文"
+  },
+  "gpt-5.4-mini": {
+    "description": "GPT-5.4 高效版，保留超長上下文與電腦控制能力，速度更快且成本更低"
+  },
+  "gpt-5.4-nano": {
+    "description": "GPT-5.4 最輕量版，超長上下文支援，專為低延遲與高吞吐場景設計"
+  },
+  "gpt-5.2-codex": {
+    "description": "GPT-5.2 Codex，穩定的程式生成模型",
+    "no_temperature": true
+  },
+  "gpt-5.1-codex-max": {
+    "description": "GPT-5.1 Codex Max，最大上下文程式生成版本",
+    "no_temperature": true
+  },
+  "gpt-5.1-codex": {
+    "description": "GPT-5.1 Codex，適合程式補全與 Agentic 任務",
+    "no_temperature": true
+  },
+  "gpt-5.1-codex-mini": {
+    "description": "GPT-5.1 Codex Mini，輕量程式生成，低延遲",
+    "no_temperature": true
+  },
+  "gpt-5": {
+    "description": "智慧推理模型，支援可配置推理深度，適合程式與 Agentic 任務",
+    "no_temperature": true,
+    "reasoning_effort": true
+  },
+  "gpt-5-codex": {
+    "description": "GPT-5 Codex，基礎程式生成模型",
+    "no_temperature": true
+  },
+  "gpt-5-mini": {
+    "description": "GPT-5 高效版，速度更快且成本更低，適合明確定義的任務",
+    "no_temperature": true,
+    "reasoning_effort": true
+  },
+  "gpt-5-nano": {
+    "description": "GPT-5 最輕量版，專為摘要與分類設計，延遲與成本最低",
+    "no_temperature": true,
+    "reasoning_effort": true
   }
 }

--- a/configs/prompts/agent_selector.md
+++ b/configs/prompts/agent_selector.md
@@ -1,87 +1,65 @@
 You are an AGENT Selector.
 Given a user request and a list of available agents (JSON array, each with `name` and `description`), select the most suitable agent.
 
-**Important: output must exactly match one of the `name` values in the available list. Never invent a name.**
+**Critical: output must exactly match one of the `name` values in the available list. Never invent a name. No explanation. No additional text. No markdown. No prefix or suffix. Output exactly one bare name string.**
+
+## Naming Conventions
+
+- `codex-*` = OpenAI models accessed via ChatGPT OAuth (fixed monthly cost, rate-limited)
+- `openai-*` = OpenAI models accessed via API key (per-token billing, no rate limit)
+- `codex` and `openai` share the same underlying model family; only billing/quota differs
+- Same-capability tiebreaker: `codex > openai` (OAuth marginal cost advantage)
+
+## Version Axis (applies globally)
+
+Within each node, newer version wins:
+- OpenAI / Codex: `5.5 > 5.4 > 5.3 > ...`
+- Claude: `4.7 > 4.6 > 4.5 > ...`
+- Gemini: `3.1 > 3 > 2.5 > ...`
+
+A node label like `codex-mini` means: pick the highest-version codex-mini available (e.g. `codex-5.5-mini` over `codex-5.4-mini`).
 
 ## Selection Rules (priority order — stop at first match)
 
 ### P0: User explicitly specifies
 Request contains "use <name>", "用 <名稱>", "指定 <名稱>", "select <name>"
-→ Fuzzy prefix-match against `name` in the available list (part before @), return the full `name`
+→ Fuzzy prefix-match against `name` in the available list, return the full `name`.
 
-### Exclusion Rule
-Agents whose name contains any of the following keywords must NOT be selected (unless P0 explicitly specifies, or no other agents are available **across all tiers**):
-`flash-lite`, `nano`, `haiku`, `flash`, `lite`
-→ These lightweight models have insufficient instruction-following capability to handle Agenvoy's dense system prompt (forced routing table, §7–§9 autonomous loops, tool-chain up to 128 iterations, pivot ladder). They cannot reliably produce structured summaries, leading to unstable conversation memory and broken heal flow.
+### P0.5: Summary task routing
+Request begins with `[summary]` prefix → pure JSON output task, no dense system prompt.
+→ Apply summary chain (see below) directly.
 
-**Note**: `mini` is **not** in the exclusion list — modern `mini` variants (e.g. `gpt-5.4-mini`) are capable enough for lightweight tasks. See the Lightweight tier below for permitted use.
+### P1: Task-type chain matching
 
-### Tier Definition (global — applies to all P1 task types)
+Identify which task scenario the request belongs to, then apply the corresponding preference chain. Scan from left to right; return the first `name` in the available list that matches a node. Within a node, prefer the highest-version variant.
 
-**Recommended tier** — pick from these first; required for any task marked "Recommended" in P1:
-- Claude: `opus-4.6` / `sonnet-4.6` (current top-tier; any future `opus-4.7+` / `sonnet-4.7+` also qualifies)
-- OpenAI: any `gpt-5.x` family full variant (`gpt-5.3`, `gpt-5.4`, `gpt-5.4-pro`, `gpt-5.4-thinking`, and future `gpt-5.x`) — **must not contain `mini` / `nano` / `lite`**
-- Gemini: Gemini 3.1 Pro or newer (`3.1-pro`, future `3.2-pro`, `4.x-pro`) — **must not contain `flash`**
-- Codex: `gpt-5.x`-based codex variant (`gpt-5.3-codex`, future `gpt-5.x-codex`)
+Chain order is pure priority — leftmost is most preferred, rightmost is least preferred. Lightweight / older variants appear at the tail as last-resort fallback, never blocked.
 
-**Acceptable tier** — use when no Recommended-tier agent is available, or for tasks marked "Acceptable" in P1:
-- Claude: none in current lineup (Opus 4.6 / Sonnet 4.6 are Recommended; Haiku 4.5 is Rejected). Reserved for future sub-top-tier variants if Anthropic releases them.
-- OpenAI: none in current lineup (all GPT-4 / o-series retired 2026-02-13). Reserved for any non-mini / non-nano GPT-5.x variant that underperforms Recommended in future benchmarks.
-- Gemini: `3-pro` (pre-3.1), `2.5-pro` / bare `pro` (must exclude `flash`)
-- Copilot: non-lightweight variants
-- NVIDIA: non-lightweight variants
-
-**Lightweight tier** — capable of simple, single-turn, low-complexity tasks. Usable ONLY for tasks marked "Lightweight" in P1. Must NOT be used for Recommended or Acceptable tasks even when they are the only models available (return Fallback instead):
-- OpenAI: **only the current-generation `mini`** — must match the latest flagship version. As of 2026-04 the only qualifying model is `gpt-5.4-mini`. Older-generation `mini` (`gpt-5.3-mini`, `gpt-5.2-mini`, `gpt-4o-mini`, etc.) are **Rejected**, not Lightweight — they lack the current-generation capability uplift that makes `mini` viable.
-- Claude: none (Haiku is Rejected — too weak for Agenvoy's prompt density even on simple tasks)
-- Gemini: none (all `flash` variants Rejected)
-
-**Current-generation rule**: when a newer flagship ships (e.g. `gpt-5.5` in the future), only the matching `mini` (`gpt-5.5-mini`) inherits Lightweight tier; the previous `gpt-5.4-mini` demotes to Rejected automatically. Never carry forward old-generation `mini` models.
-
-**Rejected in current lineup** — these models are blocked and must never be selected:
-- Claude: `haiku-4.5` and any future `haiku-*`
-- OpenAI: `gpt-5.4-nano`, any future `gpt-5.x-nano` / `gpt-5.x-lite`, and **any older-generation `mini`** (`gpt-5.3-mini`, `gpt-5.2-mini`, `gpt-4o-mini`, etc.)
-- Gemini: any `flash` / `flash-lite` variant
-
-**Note on versioned variants (e.g. `gpt-5.4-mini`, `gemini-3-flash`, `claude-haiku-5`):**
-Always apply the Exclusion Rule keywords (`flash`, `lite`, `nano`, `haiku`, `flash-lite`) BEFORE tier assignment. A model with a strong base version but an excluded suffix (e.g. `gemini-3-flash`, `claude-haiku-5`, `gpt-5.4-nano`) is **Rejected tier** — the suffix dominates. `mini` is the sole lightweight suffix that falls into Lightweight tier instead of Rejected.
-
-**Rejected tier** — already blocked by Exclusion Rule above; only selectable if no agent exists in any other tier AND P0 was not triggered.
-
-**Tier fallback order**: Recommended → Acceptable → Lightweight → Rejected (last resort only).
-If a task requires Recommended tier but none is available, fall through to Acceptable. Lightweight tier is ONLY valid for tasks explicitly marked "Lightweight" in P1 — it is NOT a fallback target for Recommended / Acceptable tasks. Rejected tier is reachable only when no agent exists in any other tier AND P0 was not triggered.
-
-### Skill Model Tier Rule
-Skill execution (`[執行 Skill]` prefix) is always **Recommended tier only** — apply the global Tier Definition above. If no Recommended-tier agent exists under the preferred provider, fall through to the next provider in P1 order rather than dropping to Acceptable tier from the current provider.
-
-### P1: Task-type preference
-Each task type specifies a required tier (see Tier Definition above). Apply the tier filter **first**, then pick the first `name` in the available list whose prefix matches the preferred provider (still excluding the Exclusion Rule blacklist):
-
-| Task characteristic | Required tier | Provider preference (in order) |
-|---------------------|---------------|-------------------------------|
-| Skill execution (Skill already matched) | **Recommended** | claude > openai / codex > gemini > copilot > nvidia |
-| Image analysis, visual understanding, chart interpretation | **Recommended** | claude > gemini > openai / codex > copilot > nvidia |
-| Complex reasoning, deep analysis, long-form generation | **Recommended** | claude > gemini > openai / codex > copilot > nvidia |
-| Code generation, refactor, debug, code review, code completion | **Recommended** | claude(opus) > codex > claude(sonnet≥4.5) > gemini > openai > copilot > nvidia |
-| Multi-source search integration, cross-referencing | **Recommended** | claude > gemini > openai / codex > copilot > nvidia |
-| File operations involving §9 pivot / error heal (patch_file retries, multi-file verification, tool error recovery) | **Recommended** | claude > openai / codex > gemini > copilot > nvidia |
-| Multi-step tool chain (3+ tool calls, forced routing scenarios) | **Recommended** | claude > openai / codex > gemini > copilot > nvidia |
-| Pure data retrieval: weather, exchange rate, news headline | **Acceptable** | claude > gemini > openai / codex > copilot > nvidia |
-| General Q&A, single-turn factual lookup, no distinctive task feature | **Acceptable** | claude > gemini > openai / codex > copilot > nvidia |
-| Short translation (single sentence / paragraph, no context chain) | **Lightweight** | openai(mini) > copilot > nvidia > [fallback to Acceptable if no mini available] |
-| Smalltalk, greetings, brief acknowledgements (should rarely reach agent selection) | **Lightweight** | openai(mini) > copilot > nvidia > [fallback to Acceptable if no mini available] |
-
-**Tier enforcement rules:**
-- A task marked **Recommended** must NOT be routed to an Acceptable or Lightweight agent if any Recommended-tier agent exists in the available list under any provider.
-- A task marked **Acceptable** may use Recommended or Acceptable tier — prefer Acceptable to save Recommended capacity for complex tasks, unless no Acceptable-tier agent is available. Never drop to Lightweight for Acceptable tasks.
-- A task marked **Lightweight** may use Lightweight, Acceptable, or Recommended tier — prefer Lightweight first to save larger-model capacity; fall back to Acceptable only if no Lightweight agent is available.
-- Never drop to Rejected tier unless the available list contains zero agents across Recommended / Acceptable / Lightweight.
-- When uncertain between "Recommended" and "Acceptable" task classification, default to **Recommended** — under-powering is worse than over-powering given the dense system prompt.
-- When uncertain between "Acceptable" and "Lightweight", default to **Acceptable** — same rationale.
+| Scenario | Preference Chain (left = most preferred) |
+|---|---|
+| Background summary (JSON output) / Lightweight agent (no dense system prompt) | `codex-mini > codex > claude-sonnet > openai-mini > openai > gemini-pro > claude-opus > codex-pro > openai-pro > claude-haiku > codex-nano > openai-nano > gemini-flash > gemini-flash-lite` |
+| Summary deduplication / merge | `codex > claude-sonnet > codex-mini > openai > openai-mini > gemini-pro > claude-opus > codex-pro > openai-pro > claude-haiku > codex-nano > openai-nano > gemini-flash > gemini-flash-lite` |
+| Conversational session (multi-turn chat, casual tone) | `codex > claude-sonnet > openai > claude-opus > gemini-pro > codex-pro > openai-pro > codex-mini > openai-mini > claude-haiku > gemini-flash > codex-nano > openai-nano > gemini-flash-lite` |
+| Dense routing / multi-step planning / task decomposition / subagent dispatch / complexity evaluation (autonomous tool-chain loops, fan-out, multi-stage breakdown) | `claude-opus > codex-pro > codex > claude-sonnet > openai-pro > openai > gemini-pro > codex-mini > openai-mini > claude-haiku > gemini-flash > codex-nano > openai-nano > gemini-flash-lite` |
+| Strict step-following, tool name mapping | `claude-sonnet > codex > claude-opus > openai > codex-pro > openai-pro > gemini-pro > codex-mini > openai-mini > claude-haiku > gemini-flash > codex-nano > openai-nano > gemini-flash-lite` |
+| Code generation / refactor / debug / config / DSL / template generation | `claude-opus > codex > claude-sonnet > openai > codex-pro > openai-pro > gemini-pro > codex-mini > openai-mini > claude-haiku > gemini-flash > codex-nano > openai-nano > gemini-flash-lite` |
+| Long-form writing / documentation / README / blog / article / extended prose | `claude-opus > claude-sonnet > codex-pro > codex > openai-pro > openai > gemini-pro > codex-mini > openai-mini > claude-haiku > gemini-flash > codex-nano > openai-nano > gemini-flash-lite` |
+| Web research / multi-source synthesis (multi-fetch + cross-reference + aggregation) | `claude-opus > codex-pro > codex > claude-sonnet > gemini-pro > openai-pro > openai > codex-mini > openai-mini > claude-haiku > gemini-flash > codex-nano > openai-nano > gemini-flash-lite` |
+| Document analysis (PDF / DOCX / long source reading, large-context comprehension) | `claude-opus > codex-pro > gemini-pro > codex > claude-sonnet > openai-pro > openai > codex-mini > openai-mini > claude-haiku > gemini-flash > codex-nano > openai-nano > gemini-flash-lite` |
+| Numerical / mathematical reasoning (multi-step calculation, formula derivation, financial modeling) | `codex-pro > claude-opus > openai-pro > codex > claude-sonnet > openai > gemini-pro > codex-mini > openai-mini > claude-haiku > gemini-flash > codex-nano > openai-nano > gemini-flash-lite` |
+| Image / chart / visual analysis | `claude-opus > claude-sonnet > gemini-pro > codex > openai > codex-pro > openai-pro > codex-mini > openai-mini > claude-haiku > gemini-flash > codex-nano > openai-nano > gemini-flash-lite` |
+| Pure data retrieval / General Q&A / single-turn factual / structured extraction (weather, FX, headline, single-shot fact lookup, JSON / CSV parse) | `codex > claude-sonnet > openai > gemini-pro > claude-opus > codex-pro > openai-pro > codex-mini > openai-mini > claude-haiku > gemini-flash > codex-nano > openai-nano > gemini-flash-lite` |
+| Long-form translation (paragraph / document, nuance-sensitive) | `claude-opus > claude-sonnet > codex > openai > gemini-pro > codex-pro > openai-pro > codex-mini > openai-mini > claude-haiku > gemini-flash > codex-nano > openai-nano > gemini-flash-lite` |
+| Short translation (single sentence) | `codex-mini > openai-mini > codex > claude-sonnet > openai > gemini-pro > claude-opus > codex-pro > openai-pro > claude-haiku > gemini-flash > codex-nano > openai-nano > gemini-flash-lite` |
+| Smalltalk / greetings / brief ack | `codex-mini > openai-mini > codex > openai > claude-sonnet > gemini-pro > claude-opus > codex-pro > openai-pro > claude-haiku > gemini-flash > codex-nano > openai-nano > gemini-flash-lite` |
 
 ### P2: Fallback
-None of the above matched → return the first `name` in the available list
 
-## Output Rules
-- Respond with exactly one agent name, which must exactly match a `name` in the available list
-- No explanation, no additional text
+None of the above matched → return the first `name` in the available list.
+
+## Hard Constraints
+
+- Output is a bare agent name only — no quotes, no markdown, no JSON, no commentary, no "I selected" preamble.
+- Never invent agent names. If no node matches the available list, fall to P2.
+- When two nodes have equal applicability and both have available variants, the leftmost in the chain wins.
+- The Version Axis applies after node selection — first pick the node, then within that node pick the newest version.

--- a/internal/agents/exec/allowList.go
+++ b/internal/agents/exec/allowList.go
@@ -1,0 +1,207 @@
+package exec
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+
+	go_pkg_filesystem "github.com/pardnchiu/go-pkg/filesystem"
+	go_pkg_filesystem_reader "github.com/pardnchiu/go-pkg/filesystem/reader"
+
+	"github.com/pardnchiu/agenvoy/internal/filesystem"
+)
+
+type allowListRule struct {
+	toolName *regexp.Regexp
+	hasArg   bool
+	argGlob  *regexp.Regexp
+}
+
+func loadAllowList(workDir string) []allowListRule {
+	if strings.TrimSpace(workDir) == "" {
+		return nil
+	}
+	path := filesystem.AllowListPath(workDir)
+	if !go_pkg_filesystem_reader.Exists(path) {
+		return nil
+	}
+	text, err := go_pkg_filesystem.ReadText(path)
+	if err != nil {
+		return nil
+	}
+	rules := make([]allowListRule, 0, 16)
+	for line := range strings.SplitSeq(text, "\n") {
+		entry := strings.TrimSpace(line)
+		if entry == "" || strings.HasPrefix(entry, "#") {
+			continue
+		}
+		r, ok := parseAllowListEntry(entry)
+		if !ok {
+			continue
+		}
+		rules = append(rules, r)
+	}
+	return rules
+}
+
+func parseAllowListEntry(entry string) (allowListRule, bool) {
+	open := strings.IndexByte(entry, '(')
+	if open < 0 {
+		name := strings.TrimSpace(entry)
+		if name == "" {
+			return allowListRule{}, false
+		}
+		return allowListRule{toolName: globToRegex(name)}, true
+	}
+	if !strings.HasSuffix(entry, ")") {
+		return allowListRule{}, false
+	}
+	name := strings.TrimSpace(entry[:open])
+	pattern := entry[open+1 : len(entry)-1]
+	if name == "" {
+		return allowListRule{}, false
+	}
+	return allowListRule{
+		toolName: globToRegex(name),
+		hasArg:   true,
+		argGlob:  globToRegex(pattern),
+	}, true
+}
+
+func matchAllowList(rules []allowListRule, toolName, toolArgs string) bool {
+	if len(rules) == 0 {
+		return false
+	}
+	canonical := canonicalToolArgs(toolName, toolArgs)
+	for _, r := range rules {
+		if !r.toolName.MatchString(toolName) {
+			continue
+		}
+		if !r.hasArg {
+			return true
+		}
+		if r.argGlob.MatchString(canonical) {
+			return true
+		}
+	}
+	return false
+}
+
+func appendAllowListRule(workDir, toolName, toolArgs string) error {
+	if strings.TrimSpace(workDir) == "" {
+		return fmt.Errorf("empty workDir")
+	}
+	if strings.TrimSpace(toolName) == "" {
+		return fmt.Errorf("empty toolName")
+	}
+	canonical := canonicalToolArgs(toolName, toolArgs)
+	var entry string
+	if canonical == "" {
+		entry = toolName
+	} else {
+		entry = toolName + "(" + escapeGlob(canonical) + ")"
+	}
+	if err := go_pkg_filesystem.CheckDir(filesystem.AllowListDir(workDir), true); err != nil {
+		return fmt.Errorf("CheckDir: %w", err)
+	}
+	path := filesystem.AllowListPath(workDir)
+	if go_pkg_filesystem_reader.Exists(path) {
+		text, err := go_pkg_filesystem.ReadText(path)
+		if err == nil {
+			for line := range strings.SplitSeq(text, "\n") {
+				if strings.TrimSpace(line) == entry {
+					return nil
+				}
+			}
+		}
+	}
+	if err := go_pkg_filesystem.AppendText(path, entry+"\n"); err != nil {
+		return fmt.Errorf("AppendText: %w", err)
+	}
+	return nil
+}
+
+func canonicalToolArgs(toolName, rawArgs string) string {
+	rawArgs = strings.TrimSpace(rawArgs)
+	if rawArgs == "" {
+		return ""
+	}
+	switch toolName {
+	case "run_command":
+		var p struct {
+			Argv []string `json:"argv"`
+		}
+		if err := json.Unmarshal([]byte(rawArgs), &p); err == nil && len(p.Argv) > 0 {
+			return strings.Join(p.Argv, " ")
+		}
+	}
+	var generic map[string]any
+	if err := json.Unmarshal([]byte(rawArgs), &generic); err == nil {
+		for _, key := range []string{"path", "url", "file", "target", "command"} {
+			if v, ok := generic[key].(string); ok && v != "" {
+				return v
+			}
+		}
+	}
+	return rawArgs
+}
+
+func globToRegex(pattern string) *regexp.Regexp {
+	var b strings.Builder
+	b.WriteByte('^')
+	i := 0
+	for i < len(pattern) {
+		c := pattern[i]
+		switch c {
+		case '\\':
+			if i+1 < len(pattern) {
+				next := pattern[i+1]
+				if next == '*' || next == '?' || next == '\\' {
+					b.WriteByte('\\')
+					b.WriteByte(next)
+					i += 2
+					continue
+				}
+			}
+			b.WriteString(`\\`)
+		case '*':
+			if i+1 < len(pattern) && pattern[i+1] == '*' {
+				b.WriteString(".*")
+				i += 2
+				continue
+			}
+			b.WriteString("[^/]*")
+		case '?':
+			b.WriteString("[^/]")
+		case '.', '+', '(', ')', '|', '^', '$', '{', '}', '[', ']':
+			b.WriteByte('\\')
+			b.WriteByte(c)
+		default:
+			b.WriteByte(c)
+		}
+		i++
+	}
+	b.WriteByte('$')
+	re, err := regexp.Compile(b.String())
+	if err != nil {
+		return regexp.MustCompile("^$a")
+	}
+	return re
+}
+
+func escapeGlob(s string) string {
+	var b strings.Builder
+	b.Grow(len(s) + 4)
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch c {
+		case '*', '?', '\\':
+			b.WriteByte('\\')
+			b.WriteByte(c)
+		default:
+			b.WriteByte(c)
+		}
+	}
+	return b.String()
+}

--- a/internal/agents/exec/execWithSubagent.go
+++ b/internal/agents/exec/execWithSubagent.go
@@ -181,6 +181,7 @@ func passSubagentEvent(parent chan<- agentTypes.Event, name string, ev agentType
 	}
 	switch ev.Type {
 	case agentTypes.EventDone,
+		agentTypes.EventTextDone,
 		agentTypes.EventAgentSelect,
 		agentTypes.EventAgentResult,
 		agentTypes.EventSummaryGenerate,

--- a/internal/agents/exec/execWithSubagent.go
+++ b/internal/agents/exec/execWithSubagent.go
@@ -181,7 +181,6 @@ func passSubagentEvent(parent chan<- agentTypes.Event, name string, ev agentType
 	}
 	switch ev.Type {
 	case agentTypes.EventDone,
-		agentTypes.EventTextDone,
 		agentTypes.EventAgentSelect,
 		agentTypes.EventAgentResult,
 		agentTypes.EventSummaryGenerate,

--- a/internal/agents/exec/execute.go
+++ b/internal/agents/exec/execute.go
@@ -146,10 +146,8 @@ func Execute(ctx context.Context, data ExecData, session *agentTypes.AgentSessio
 		return fmt.Errorf("tools.NewExecutor: %w", err)
 	}
 
-	exec.ActiveSkill = data.Skill
-
 	if data.Skill != nil {
-		assignSkill(session, data.Skill)
+		assignBindingSkill(session, data.Skill)
 	}
 
 	if len(data.ExcludeTools) > 0 {
@@ -355,7 +353,7 @@ func GetSystemPrompt(workDir string, extraSystemPrompt string, scanner *skill.Sk
 
 	skillsSection := ""
 	if list := toolSearcher.ListBlock(scanner); list != "" {
-		skillsSection = "## Skills\n\nThe following skill names are available via `activate_skill`. Only activate when the user explicitly references a skill by its exact name (e.g. `/commit-generate` or the bare `commit-generate` token). Do not infer skills from topic keywords, paraphrases, or partial matches. Once activated, the tool result is binding for subsequent iterations.\n\n" + list
+		skillsSection = "## Skills\n\nThe following skills can be fetched via `activate_skill`. Treat the result as reference material — consult it, integrate parts that fit the user's request, ignore parts that don't. Consider activating a skill when its description matches the user's intent on each turn, even without an explicit `/<name>` invocation. Slash invocations (`/<name>`) are user-explicit and execute the skill's full procedure under binding semantics; the `activate_skill` tool path does not carry that binding.\n\n" + list
 	}
 
 	personaSection := ""
@@ -463,7 +461,7 @@ func writeSessionHistEntry(sessionID string, msg agentTypes.Message) {
 	}
 }
 
-func assignSkill(session *agentTypes.AgentSession, s *skill.Skill) {
+func assignBindingSkill(session *agentTypes.AgentSession, s *skill.Skill) {
 	id := "skill-assign-" + utils.NewID("skill", s.Name)
 	argsJSON, _ := json.Marshal(map[string]string{"skill": s.Name})
 	call := agentTypes.ToolCall{

--- a/internal/agents/exec/execute.go
+++ b/internal/agents/exec/execute.go
@@ -257,10 +257,7 @@ func Execute(ctx context.Context, data ExecData, session *agentTypes.AgentSessio
 			if trimmedToolCalls {
 				responseText += "\n\n> 因超過模型 max input，部分工具查詢資料已被裁減，建議使用更大 context window 的模型再試一次。"
 			}
-			events <- agentTypes.Event{
-				Type: agentTypes.EventText,
-				Text: responseText,
-			}
+			sendText(events, responseText)
 
 			choice.Message.Content = fmt.Sprintf("---\n當前時間: %s\n---\n%s", time.Now().Format("2006-01-02 15:04:05"), stripped)
 			session.ToolHistories = append(session.ToolHistories, choice.Message)
@@ -306,7 +303,7 @@ func Execute(ctx context.Context, data ExecData, session *agentTypes.AgentSessio
 		usage.CacheCreate += resp.Usage.CacheCreate
 		usage.CacheRead += resp.Usage.CacheRead
 		if text, ok := resp.Choices[0].Message.Content.(string); ok && text != "" {
-			events <- agentTypes.Event{Type: agentTypes.EventText, Text: StripModelResponse(text)}
+			sendText(events, StripModelResponse(text))
 			if err := filesystem.UpdateUsage(data.Agent.Name(), usage.Input, usage.Output, usage.CacheCreate, usage.CacheRead); err != nil {
 				slog.Warn("usageManager.Update",
 					slog.String("error", err.Error()))
@@ -316,7 +313,7 @@ func Execute(ctx context.Context, data ExecData, session *agentTypes.AgentSessio
 		}
 	}
 
-	events <- agentTypes.Event{Type: agentTypes.EventText, Text: "工具無法取得資料，請稍後再試或改用其他方式查詢。"}
+	sendText(events, "no usable data, retry later, or using other tools.")
 	if err := filesystem.UpdateUsage(data.Agent.Name(), usage.Input, usage.Output, usage.CacheCreate, usage.CacheRead); err != nil {
 		slog.Warn("usageManager.Update",
 			slog.String("error", err.Error()))
@@ -397,14 +394,21 @@ func buildPermissionModeSection(allowAll bool) string {
 func actionError(emptyCount *int, events chan<- agentTypes.Event) bool {
 	*emptyCount++
 	if *emptyCount >= MaxEmptyResponses {
-		events <- agentTypes.Event{
-			Type: agentTypes.EventText,
-			Text: "工具無法取得資料，請稍後再試或改用其他方式查詢。",
-		}
+		sendText(events, "no usable data, retry later, or using other tools.")
 		events <- agentTypes.Event{Type: agentTypes.EventDone}
 		return true
 	}
 	return false
+}
+
+func sendText(events chan<- agentTypes.Event, text string) {
+	text = strings.TrimRight(text, "\n")
+	if text != "" {
+		for line := range strings.SplitSeq(text, "\n") {
+			events <- agentTypes.Event{Type: agentTypes.EventText, Text: line}
+		}
+	}
+	events <- agentTypes.Event{Type: agentTypes.EventTextDone}
 }
 
 func saveNewHistory(choice agentTypes.OutputChoices, session *agentTypes.AgentSession) error {

--- a/internal/agents/exec/execute.go
+++ b/internal/agents/exec/execute.go
@@ -83,14 +83,24 @@ type ExecData struct {
 }
 
 type (
-	allowAllCtxKey   struct{}
-	parentEventsKey  struct{}
-	parentWorkDirKey struct{}
+	allowAllCtxKey    struct{}
+	allowListRulesKey struct{}
+	parentEventsKey   struct{}
+	parentWorkDirKey  struct{}
 )
+
+func getAllowList(ctx context.Context) []allowListRule {
+	rules, _ := ctx.Value(allowListRulesKey{}).([]allowListRule)
+	return rules
+}
 
 func Execute(ctx context.Context, data ExecData, session *agentTypes.AgentSession, events chan<- agentTypes.Event, allowAll bool) error {
 	executeStart := time.Now()
 	ctx = context.WithValue(ctx, allowAllCtxKey{}, allowAll)
+
+	if !allowAll {
+		ctx = context.WithValue(ctx, allowListRulesKey{}, loadAllowList(data.WorkDir))
+	}
 
 	if events != nil {
 		ctx = context.WithValue(ctx, parentEventsKey{}, events)

--- a/internal/agents/exec/external.go
+++ b/internal/agents/exec/external.go
@@ -13,28 +13,25 @@ func CallExternal(ctx context.Context, sessionID, agent, prompt string, readOnly
 	label := "external:" + agent
 
 	if !slices.Contains(external.Agents(), agent) {
-		msg := fmt.Sprintf("外部 agent %s 不可用（PATH 未偵測到對應 CLI binary）。", agent)
-		events <- agentTypes.Event{Type: agentTypes.EventText, Text: msg}
+		sendText(events, fmt.Sprintf("external agent %s unavailable (not found).", agent))
 		events <- agentTypes.Event{Type: agentTypes.EventDone, Model: label}
 		return nil
 	}
 
 	if err := external.Check(agent); err != nil {
-		msg := fmt.Sprintf("外部 agent %s 不可用：%s", agent, err.Error())
-		events <- agentTypes.Event{Type: agentTypes.EventText, Text: msg}
+		sendText(events, fmt.Sprintf("external agent %s unavailable: %s", agent, err.Error()))
 		events <- agentTypes.Event{Type: agentTypes.EventDone, Model: label}
 		return nil
 	}
 
 	out, err := external.Call(ctx, agent, prompt, readOnly)
 	if err != nil {
-		msg := fmt.Sprintf("外部呼叫失敗（%s）：%s", agent, err.Error())
-		events <- agentTypes.Event{Type: agentTypes.EventText, Text: msg}
+		sendText(events, fmt.Sprintf("failed to call external (%s): %s", agent, err.Error()))
 		events <- agentTypes.Event{Type: agentTypes.EventDone, Model: label}
 		return nil
 	}
 
-	events <- agentTypes.Event{Type: agentTypes.EventText, Text: out}
+	sendText(events, out)
 	if sessionID != "" {
 		writeSessionHistEntry(sessionID, agentTypes.Message{
 			Role:    "assistant",

--- a/internal/agents/exec/selectAgent.go
+++ b/internal/agents/exec/selectAgent.go
@@ -73,7 +73,7 @@ func SelectAgent(ctx context.Context, bot agentTypes.Agent, registry agentTypes.
 
 	userContent := strings.TrimSpace(trimInput)
 	if hasSkill {
-		userContent = "[執行 Skill] " + userContent
+		userContent = "[Run Skill] " + userContent
 	}
 
 	messages := []agentTypes.Message{
@@ -82,12 +82,8 @@ func SelectAgent(ctx context.Context, bot agentTypes.Agent, registry agentTypes.
 			Content: strings.TrimSpace(configs.AgentSelector),
 		},
 		{
-			Role: "user",
-			Content: fmt.Sprintf(
-				"Available agents:\n%s\nUser request: %s",
-				string(agentJson),
-				userContent,
-			),
+			Role:    "user",
+			Content: fmt.Sprintf("Available agents:\n%s\nUser request: %s", string(agentJson), userContent),
 		},
 	}
 

--- a/internal/agents/exec/toolCall.go
+++ b/internal/agents/exec/toolCall.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"strings"
 	"sync"
 
@@ -93,7 +94,8 @@ func toolCall(ctx context.Context, exec *toolTypes.Executor, choice agentTypes.O
 
 		if !allowAll && !toolRegister.IsReadOnly(toolName) {
 			proceed := true
-			if pending.Active.Load() {
+			reason := ""
+			if pending.Active.Load() && !matchAllowList(getAllowList(ctx), toolName, toolArg) {
 				reply, err := pending.Ask(ctx, pending.Request{
 					Kind:      pending.KindToolConfirm,
 					SessionID: sessionData.ID,
@@ -104,17 +106,29 @@ func toolCall(ctx context.Context, exec *toolTypes.Executor, choice agentTypes.O
 					proceed = false
 				} else {
 					proceed = reply.Approve
+					reason = reply.Reason
+					if reply.Approve && reply.Remember {
+						if err = appendAllowListRule(exec.WorkDir, toolName, toolArg); err != nil {
+							slog.Warn("appendAllowListRule",
+								slog.String("error", err.Error()))
+						}
+					}
 				}
 			}
 			if !proceed {
+				message := "Skipped by user"
+				if reason != "" {
+					message = fmt.Sprintf("Skipped by user. Reason: %s", reason)
+				}
 				events <- agentTypes.Event{
 					Type:     agentTypes.EventToolSkipped,
 					ToolName: toolName,
 					ToolArgs: toolArg,
 					ToolID:   toolID,
+					Text:     reason,
 				}
 				slots[i].state = slotSkipped
-				slots[i].preMsg = "Skipped by user"
+				slots[i].preMsg = message
 				continue
 			}
 		}

--- a/internal/agents/provider/claude/new.go
+++ b/internal/agents/provider/claude/new.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pardnchiu/agenvoy/internal/agents/provider"
 	"github.com/pardnchiu/go-pkg/filesystem/keychain"
 )
 
@@ -23,10 +22,11 @@ const (
 )
 
 func New(model ...string) (*Agent, error) {
-	usedModel := provider.Default("claude")
-	if len(model) > 0 && strings.HasPrefix(model[0], prefix) {
-		usedModel = strings.TrimPrefix(model[0], prefix)
+	if len(model) == 0 || !strings.HasPrefix(model[0], prefix) {
+		return nil, fmt.Errorf("claude.New: model arg required with %q prefix", prefix)
 	}
+	usedModel := strings.TrimPrefix(model[0], prefix)
+
 	apiKey := keychain.Get("CLAUDE_API_KEY")
 	if apiKey == "" {
 		return nil, fmt.Errorf("keychain.Get: CLAUDE_API_KEY is required")

--- a/internal/agents/provider/claude/new.go
+++ b/internal/agents/provider/claude/new.go
@@ -50,8 +50,13 @@ func (a *Agent) Name() string {
 }
 
 func (a *Agent) maxOutputTokens() int {
-	if a.model == "claude-opus-4-6" {
+	switch {
+	case strings.HasPrefix(a.model, "claude-opus-4-6"),
+		strings.HasPrefix(a.model, "claude-opus-4-7"):
 		return 128000
+	case strings.HasPrefix(a.model, "claude-opus-4-1-"),
+		strings.HasPrefix(a.model, "claude-opus-4-2"):
+		return 32000
 	}
 	return 64000
 }

--- a/internal/agents/provider/claude/send.go
+++ b/internal/agents/provider/claude/send.go
@@ -63,9 +63,11 @@ func (a *Agent) Send(ctx context.Context, messages []agentTypes.Message, tools [
 	requestBody := map[string]any{
 		"model":      a.model,
 		"max_tokens": a.maxOutputTokens(),
-		"system":     systemPrompts,
 		"messages":   newMessages,
 		"tools":      newTools,
+	}
+	if len(systemPrompts) > 0 {
+		requestBody["system"] = systemPrompts
 	}
 	switch thinkingType {
 	case "adaptive":

--- a/internal/agents/provider/copilot/new.go
+++ b/internal/agents/provider/copilot/new.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pardnchiu/agenvoy/internal/agents/provider"
 	"github.com/pardnchiu/go-pkg/filesystem/keychain"
 )
 
@@ -35,10 +34,10 @@ const (
 )
 
 func New(model ...string) (*Agent, error) {
-	usedModel := provider.Default("copilot")
-	if len(model) > 0 && strings.HasPrefix(model[0], prefix) {
-		usedModel = strings.TrimPrefix(model[0], prefix)
+	if len(model) == 0 || !strings.HasPrefix(model[0], prefix) {
+		return nil, fmt.Errorf("copilot.New: model arg required with %q prefix", prefix)
 	}
+	usedModel := strings.TrimPrefix(model[0], prefix)
 
 	workDir, err := os.Getwd()
 	if err != nil {

--- a/internal/agents/provider/gemini/new.go
+++ b/internal/agents/provider/gemini/new.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pardnchiu/agenvoy/internal/agents/provider"
 	"github.com/pardnchiu/go-pkg/filesystem/keychain"
 )
 
@@ -23,10 +22,10 @@ const (
 )
 
 func New(model ...string) (*Agent, error) {
-	usedModel := provider.Default("gemini")
-	if len(model) > 0 && strings.HasPrefix(model[0], prefix) {
-		usedModel = strings.TrimPrefix(model[0], prefix)
+	if len(model) == 0 || !strings.HasPrefix(model[0], prefix) {
+		return nil, fmt.Errorf("gemini.New: model arg required with %q prefix", prefix)
 	}
+	usedModel := strings.TrimPrefix(model[0], prefix)
 
 	apiKey := keychain.Get("GEMINI_API_KEY")
 	if apiKey == "" {

--- a/internal/agents/provider/nvidia/new.go
+++ b/internal/agents/provider/nvidia/new.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pardnchiu/agenvoy/internal/agents/provider"
 	"github.com/pardnchiu/go-pkg/filesystem/keychain"
 )
 
@@ -23,10 +22,11 @@ const (
 )
 
 func New(model ...string) (*Agent, error) {
-	usedModel := provider.Default("nvidia")
-	if len(model) > 0 && strings.HasPrefix(model[0], prefix) {
-		usedModel = strings.TrimPrefix(model[0], prefix)
+	if len(model) == 0 || !strings.HasPrefix(model[0], prefix) {
+		return nil, fmt.Errorf("nvidia.New: model arg required with %q prefix", prefix)
 	}
+	usedModel := strings.TrimPrefix(model[0], prefix)
+
 	apiKey := keychain.Get("NVIDIA_API_KEY")
 	if apiKey == "" {
 		return nil, fmt.Errorf("keychain.Get: NVIDIA_API_KEY is required")

--- a/internal/agents/provider/openai/new.go
+++ b/internal/agents/provider/openai/new.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pardnchiu/agenvoy/internal/agents/provider"
 	"github.com/pardnchiu/go-pkg/filesystem/keychain"
 )
 
@@ -23,10 +22,11 @@ const (
 )
 
 func New(model ...string) (*Agent, error) {
-	usedModel := provider.Default("openai")
-	if len(model) > 0 && strings.HasPrefix(model[0], prefix) {
-		usedModel = strings.TrimPrefix(model[0], prefix)
+	if len(model) == 0 || !strings.HasPrefix(model[0], prefix) {
+		return nil, fmt.Errorf("openai.New: model arg required with %q prefix", prefix)
 	}
+	usedModel := strings.TrimPrefix(model[0], prefix)
+
 	apiKey := keychain.Get("OPENAI_API_KEY")
 	if apiKey == "" {
 		return nil, fmt.Errorf("keychain.Get: OPENAI_API_KEY is required")

--- a/internal/agents/provider/openai/send.go
+++ b/internal/agents/provider/openai/send.go
@@ -39,7 +39,7 @@ func (a *Agent) Send(ctx context.Context, messages []agentTypes.Message, tools [
 		"Content-Type":  "application/json",
 	}
 
-	if strings.Contains(a.model, "codex") {
+	if strings.Contains(a.model, "codex") || strings.HasSuffix(a.model, "-pro") {
 		var instructions string
 		nonSystem := make([]agentTypes.Message, 0, len(messages))
 		for _, m := range messages {

--- a/internal/agents/provider/openaiCodex/new.go
+++ b/internal/agents/provider/openaiCodex/new.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pardnchiu/agenvoy/internal/agents/provider"
 	"github.com/pardnchiu/go-pkg/filesystem/keychain"
 )
 
@@ -24,10 +23,10 @@ type Agent struct {
 }
 
 func New(model ...string) (*Agent, error) {
-	usedModel := provider.Default("codex")
-	if len(model) > 0 && strings.HasPrefix(model[0], prefix) {
-		usedModel = strings.TrimPrefix(model[0], prefix)
+	if len(model) == 0 || !strings.HasPrefix(model[0], prefix) {
+		return nil, fmt.Errorf("openaicodex.New: model arg required with %q prefix", prefix)
 	}
+	usedModel := strings.TrimPrefix(model[0], prefix)
 
 	workDir, err := os.Getwd()
 	if err != nil {

--- a/internal/agents/provider/provider.go
+++ b/internal/agents/provider/provider.go
@@ -7,11 +7,6 @@ import (
 	"github.com/pardnchiu/agenvoy/configs"
 )
 
-type ProviderItem struct {
-	Default string               `json:"default"`
-	Models  map[string]ModelItem `json:"models"`
-}
-
 type ModelItem struct {
 	Description     string `json:"description"`
 	NoTemperature   bool   `json:"no_temperature,omitempty"`
@@ -58,14 +53,14 @@ func ThinkingBudget(level string) int {
 	}
 }
 
-func parse(data []byte) ProviderItem {
-	var cfg ProviderItem
-	json.Unmarshal(data, &cfg)
-	return cfg
+func parse(data []byte) map[string]ModelItem {
+	var m map[string]ModelItem
+	json.Unmarshal(data, &m)
+	return m
 }
 
-func providers() map[string]ProviderItem {
-	return map[string]ProviderItem{
+func providers() map[string]map[string]ModelItem {
+	return map[string]map[string]ModelItem{
 		"claude":  parse(configs.ClaudeModels),
 		"codex":   parse(configs.CodexModels),
 		"copilot": parse(configs.CopilotModels),
@@ -75,32 +70,19 @@ func providers() map[string]ProviderItem {
 	}
 }
 
-func Default(provider string) string {
-	return providers()[provider].Default
-}
-
 func Get(provider, model string) ModelItem {
-	cfg, exist := providers()[provider]
+	models, exist := providers()[provider]
 	if !exist {
 		return ModelItem{}
 	}
-
-	if info, exist := cfg.Models[model]; exist {
-		return info
-	}
-
-	if info, exist := cfg.Models[cfg.Default]; exist {
+	if info, exist := models[model]; exist {
 		return info
 	}
 	return ModelItem{}
 }
 
 func Models(provider string) map[string]ModelItem {
-	cfg, exist := providers()[provider]
-	if !exist {
-		return nil
-	}
-	return cfg.Models
+	return providers()[provider]
 }
 
 func SupportTemperature(providerName, model string) bool {

--- a/internal/agents/types/event.go
+++ b/internal/agents/types/event.go
@@ -13,6 +13,7 @@ func (e EventType) MarshalJSON() ([]byte, error) {
 
 const (
 	EventText EventType = iota
+	EventTextDone
 	EventSkillResult
 	EventAgentSelect
 	EventAgentResult
@@ -33,6 +34,8 @@ func (e EventType) String() string {
 	switch e {
 	case EventText:
 		return "EventText"
+	case EventTextDone:
+		return "EventTextDone"
 	case EventSkillResult:
 		return "EventSkillResult"
 	case EventAgentSelect:

--- a/internal/filesystem/filesystem.go
+++ b/internal/filesystem/filesystem.go
@@ -118,3 +118,13 @@ func InputHistoryPath(sessionID string) string {
 func McpSessionPath(sessionID string) string {
 	return filepath.Join(SessionsDir, sessionID, "mcp.json")
 }
+
+const AllowListRelPath = ".agenvoy/allow_list"
+
+func AllowListPath(workDir string) string {
+	return filepath.Join(workDir, AllowListRelPath)
+}
+
+func AllowListDir(workDir string) string {
+	return filepath.Join(workDir, filepath.Dir(AllowListRelPath))
+}

--- a/internal/interactive/cli/pending.go
+++ b/internal/interactive/cli/pending.go
@@ -7,12 +7,12 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/manifoldco/promptui"
 	"golang.org/x/term"
 
 	"github.com/pardnchiu/agenvoy/internal/pending"
+	"github.com/pardnchiu/agenvoy/internal/utils"
 )
 
 func NewPending(ctx context.Context) {
@@ -49,7 +49,7 @@ func process(id string, req pending.Request, reader *bufio.Reader) {
 
 	switch req.Kind {
 	case pending.KindToolConfirm:
-		pending.Resolve(id, runToolConfirm(req))
+		pending.Resolve(id, runToolConfirm(req, reader))
 	case pending.KindAskUser:
 		pending.Resolve(id, runAskUser(req, reader))
 	default:
@@ -57,23 +57,33 @@ func process(id string, req pending.Request, reader *bufio.Reader) {
 	}
 }
 
-func runToolConfirm(req pending.Request) pending.Reply {
-	if req.ToolName == "run_command" {
-		writeStdoutLine(ansiYellow + fmt.Sprintf("[$] [%s] %s", time.Now().Format("15:04:05"), printLogCommand(req.ToolArgs)) + ansiReset)
-		dollarLinePending.Store(true)
+func runToolConfirm(req pending.Request, reader *bufio.Reader) pending.Reply {
+	display := utils.FormatTool(req.ToolName, req.ToolArgs)
+	if display == "" {
+		display = req.ToolArgs
 	}
+	writeStdoutLine(ansiYellow + fmt.Sprintf("[$] %s: %s", req.ToolName, display) + ansiReset)
+	dollarLinePending.Store(true)
 	prompt := promptui.Select{
 		Label:        fmt.Sprintf("Run %s?", req.ToolName),
-		Items:        []string{"Yes", "Skip", "Stop"},
-		Size:         3,
+		Items:        []string{"Yes", "Yes, don't ask again", "No", "No, with reason", "Stop"},
+		Size:         5,
 		HideSelected: true,
 	}
 	idx, _, err := prompt.Run()
 	switch {
-	case err != nil || idx == 2:
+	case err != nil || idx == 4:
 		return pending.Reply{Approve: false, Error: fmt.Errorf("user stopped")}
-	case idx == 1:
+	case idx == 3:
+		reason, readErr := askInput(reader, "Reason (Enter to skip without reason)")
+		if readErr != nil {
+			return pending.Reply{Approve: false, Skip: true}
+		}
+		return pending.Reply{Approve: false, Skip: true, Reason: strings.TrimSpace(reason)}
+	case idx == 2:
 		return pending.Reply{Approve: false, Skip: true}
+	case idx == 1:
+		return pending.Reply{Approve: true, Remember: true}
 	default:
 		return pending.Reply{Approve: true}
 	}

--- a/internal/interactive/cli/run.go
+++ b/internal/interactive/cli/run.go
@@ -38,6 +38,7 @@ func Run(fn func(chan<- agentTypes.Event) error) error {
 	}()
 
 	pendingAgentSelect := false
+	var sb strings.Builder
 	for ev := range ch {
 		// store_secret drives its own stdout interaction (prompt + masked input);
 		// any renderer print would race with the prompt and shred the terminal.
@@ -96,10 +97,21 @@ func Run(fn func(chan<- agentTypes.Event) error) error {
 				writeStdoutLine(colorize(ev, fmt.Sprintf("%s%s", soruce, oneLineReplacer.Replace(text))))
 				break
 			}
-			if strings.HasPrefix(text, "Agent:") || strings.HasPrefix(text, "Tool:") || strings.HasPrefix(text, "Result:") {
-				writeStdoutLine("[*] " + text)
+			if sb.Len() > 0 {
+				sb.WriteByte('\n')
+			}
+			sb.WriteString(text)
+
+		case agentTypes.EventTextDone:
+			if ev.Source != "" || sb.Len() == 0 {
+				break
+			}
+			full := sb.String()
+			sb.Reset()
+			if strings.HasPrefix(full, "Agent:") || strings.HasPrefix(full, "Tool:") || strings.HasPrefix(full, "Result:") {
+				writeStdoutLine("[*] " + full)
 			} else {
-				writeStdoutLine("---\n" + text + "\n---")
+				writeStdoutLine("---\n" + full + "\n---")
 			}
 
 		case agentTypes.EventExecError:

--- a/internal/interactive/cli/run.go
+++ b/internal/interactive/cli/run.go
@@ -1,15 +1,14 @@
 package cli
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
-	"strconv"
 	"strings"
 	"sync/atomic"
 	"time"
 
 	agentTypes "github.com/pardnchiu/agenvoy/internal/agents/types"
+	"github.com/pardnchiu/agenvoy/internal/utils"
 )
 
 const (
@@ -75,7 +74,7 @@ func Run(fn func(chan<- agentTypes.Event) error) error {
 			if removeCommandConfirm() {
 				fmt.Print("\033[F\033[2K")
 			}
-			writeStdoutLine(colorize(ev, fmt.Sprintf("%s[*] [%s] Tool: %s - ", soruce, time.Now().Format("15:04:05"), ev.ToolName)) + ansiGray + printLog(ev.ToolName, ev.ToolArgs) + ansiReset)
+			writeStdoutLine(colorize(ev, fmt.Sprintf("%s[*] [%s] Tool: %s - ", soruce, time.Now().Format("15:04:05"), ev.ToolName)) + ansiGray + utils.FormatTool(ev.ToolName, ev.ToolArgs) + ansiReset)
 
 		case agentTypes.EventToolResult:
 			if ev.ToolName == "ask_user" {
@@ -86,7 +85,7 @@ func Run(fn func(chan<- agentTypes.Event) error) error {
 			if removeCommandConfirm() {
 				fmt.Print("\033[F\033[2K")
 			}
-			writeStdoutLine(colorize(ev, fmt.Sprintf("%s[~] [%s] Skipped: %s - ", soruce, time.Now().Format("15:04:05"), ev.ToolName)) + ansiGray + printLog(ev.ToolName, ev.ToolArgs) + ansiReset)
+			writeStdoutLine(colorize(ev, fmt.Sprintf("%s[~] [%s] Skipped: %s - ", soruce, time.Now().Format("15:04:05"), ev.ToolName)) + ansiGray + utils.FormatTool(ev.ToolName, ev.ToolArgs) + ansiReset)
 
 		case agentTypes.EventText:
 			text := ev.Text
@@ -144,113 +143,6 @@ func Run(fn func(chan<- agentTypes.Event) error) error {
 	}
 
 	return execErr
-}
-
-func printLog(name, raw string) string {
-	if raw == "" {
-		return ""
-	}
-	var m map[string]any
-	if err := json.Unmarshal([]byte(raw), &m); err != nil {
-		return raw
-	}
-	pick := func(keys ...string) string {
-		for _, k := range keys {
-			if v, ok := m[k]; ok {
-				if s, ok := v.(string); ok && strings.TrimSpace(s) != "" {
-					return s
-				}
-			}
-		}
-		return ""
-	}
-	switch name {
-	case "invoke_subagent":
-		return printLogSubagent(m, pick)
-	case "activate_skill":
-		if s := pick("skill", "name"); s != "" {
-			return s
-		}
-	case "list_files":
-		dir := pick("dir", "path")
-		if dir == "" {
-			break
-		}
-		if r, ok := m["recursive"].(bool); ok && r {
-			return dir + " (recursive)"
-		}
-		return dir
-	case "read_file", "write_file", "patch_file", "glob_files", "read_image", "save_page_to_file":
-		if s := pick("path", "pattern", "save_to"); s != "" {
-			return s
-		}
-	case "search_web", "fetch_google_rss":
-		if q := pick("query", "keyword"); q != "" {
-			if tr := pick("time_range", "time"); tr != "" {
-				return fmt.Sprintf("%s (%s)", q, tr)
-			}
-			return q
-		}
-	case "fetch_yahoo_finance":
-		if sym := pick("symbol"); sym != "" {
-			if tr := pick("time_range"); tr != "" {
-				return fmt.Sprintf("%s (%s)", sym, tr)
-			}
-			return sym
-		}
-	case "fetch_page", "fetch_youtube_transcript":
-		if s := pick("link", "url"); s != "" {
-			return s
-		}
-	case "calculate":
-		if s := pick("expression"); s != "" {
-			return s
-		}
-	case "remember_error":
-		if s := pick("symptom", "cause", "action"); s != "" {
-			return s
-		}
-	case "search_error_memory", "search_conversation_history":
-		if s := pick("keyword", "query"); s != "" {
-			return s
-		}
-	case "run_command":
-		return printLogCommand(raw)
-	}
-	return raw
-}
-
-func printLogSubagent(_ map[string]any, pick func(...string) string) string {
-	label := pick("name", "session_id")
-	if label == "" {
-		label = "subagent"
-	}
-	if model := pick("model"); model != "" {
-		label = fmt.Sprintf("%s (%s)", label, model)
-	}
-	task := pick("task")
-	if task == "" {
-		return label
-	}
-	return fmt.Sprintf("%s: %s", label, oneLineReplacer.Replace(task))
-}
-
-func printLogCommand(raw string) string {
-	var p struct {
-		Argv []string `json:"argv"`
-	}
-	if err := json.Unmarshal([]byte(raw), &p); err != nil || len(p.Argv) == 0 {
-		return raw
-	}
-	parts := make([]string, len(p.Argv))
-	for i, a := range p.Argv {
-		if a == "" || strings.ContainsAny(a, " \t\n\"'\\") {
-			parts[i] = strconv.Quote(a)
-		} else {
-			parts[i] = a
-		}
-	}
-	return strings.Join(parts, " ")
 }
 
 func colorize(ev agentTypes.Event, line string) string {

--- a/internal/interactive/discord/run.go
+++ b/internal/interactive/discord/run.go
@@ -87,7 +87,13 @@ func run(ctx context.Context, dcBot *discordTypes.DiscordBot, dcSession *discord
 		utils.EventLog("[Discord]", e, session.ID, "")
 		switch e.Type {
 		case agentTypes.EventText:
-			replyText = e.Text
+			if replyText != "" {
+				replyText += "\n"
+			}
+			replyText += e.Text
+
+		case agentTypes.EventTextDone:
+			break
 
 		case agentTypes.EventExecError:
 			slog.Warn("EventExecError",

--- a/internal/pending/pending.go
+++ b/internal/pending/pending.go
@@ -40,10 +40,12 @@ type Request struct {
 }
 
 type Reply struct {
-	Approve bool
-	Skip    bool
-	Answers []any
-	Error   error
+	Approve  bool
+	Skip     bool
+	Remember bool
+	Reason   string
+	Answers  []any
+	Error    error
 }
 
 type entry struct {

--- a/internal/routes/handler/sendResult.go
+++ b/internal/routes/handler/sendResult.go
@@ -45,6 +45,8 @@ func sendResult(c *gin.Context, sessionID string, input string, events <-chan ag
 				sb.WriteByte('\n')
 			}
 			sb.WriteString(event.Text)
+		case agentTypes.EventTextDone:
+
 		case agentTypes.EventDone:
 			resp.Model = event.Model
 			resp.Usage = event.Usage

--- a/internal/session/actionLog.go
+++ b/internal/session/actionLog.go
@@ -21,9 +21,66 @@ const (
 	trimTargetSize   = 768 << 10
 )
 
-var actionLogMu sync.Mutex
+var (
+	actionLogMu     sync.Mutex
+	assistantBodyMu sync.Mutex
+	assistantBody   = map[string]*strings.Builder{}
+)
+
+func appendAssistantLine(sessionID, source, text string) {
+	if sessionID == "" || text == "" {
+		return
+	}
+
+	key := sessionID + "\x00" + source
+	assistantBodyMu.Lock()
+	defer assistantBodyMu.Unlock()
+
+	sb, ok := assistantBody[key]
+	if !ok {
+		sb = &strings.Builder{}
+		assistantBody[key] = sb
+	}
+	if sb.Len() > 0 {
+		sb.WriteByte('\n')
+	}
+	sb.WriteString(text)
+}
+
+func flushAssistantLine(sessionID, source string) {
+	if sessionID == "" {
+		return
+	}
+	key := sessionID + "\x00" + source
+	assistantBodyMu.Lock()
+	buf, ok := assistantBody[key]
+	if !ok || buf.Len() == 0 {
+		assistantBodyMu.Unlock()
+		return
+	}
+	full := buf.String()
+	delete(assistantBody, key)
+	assistantBodyMu.Unlock()
+
+	line := formatActionLine("assistant", flatten(full))
+	appendActionLine(sessionID, line)
+}
 
 func Record(sessionID string, event agentTypes.Event) {
+	switch event.Type {
+	case agentTypes.EventText:
+		text := strings.TrimSpace(event.Text)
+		if text == "" {
+			return
+		}
+		appendAssistantLine(sessionID, event.Source, text)
+		return
+	case agentTypes.EventTextDone:
+		flushAssistantLine(sessionID, event.Source)
+		return
+	}
+
+	flushAssistantLine(sessionID, event.Source)
 	line := formatActionEvent(event)
 	if line == "" {
 		return

--- a/internal/session/actionLog.go
+++ b/internal/session/actionLog.go
@@ -14,6 +14,7 @@ import (
 
 	agentTypes "github.com/pardnchiu/agenvoy/internal/agents/types"
 	"github.com/pardnchiu/agenvoy/internal/filesystem"
+	"github.com/pardnchiu/agenvoy/internal/utils"
 )
 
 const (
@@ -160,8 +161,8 @@ func formatActionEvent(ev agentTypes.Event) string {
 		return formatActionLine("assistant", flatten(text))
 	case agentTypes.EventToolCall:
 		body := ev.ToolName
-		if ev.ToolArgs != "" {
-			body = fmt.Sprintf("%s %s", body, flatten(ev.ToolArgs))
+		if display := utils.FormatTool(ev.ToolName, ev.ToolArgs); display != "" {
+			body = fmt.Sprintf("%s %s", body, flatten(display))
 		}
 		return formatActionLine("tool_call", body)
 	case agentTypes.EventToolResult:

--- a/internal/tools/external/searchWeb/fetch.go
+++ b/internal/tools/external/searchWeb/fetch.go
@@ -21,7 +21,7 @@ import (
 const (
 	path      = "https://lite.duckduckgo.com/lite/"
 	ttl       = 300
-	ddgMinGap = 1 * time.Second
+	ddgMinGap = 2 * time.Second
 )
 
 var (

--- a/internal/tools/searcher/activateSkill.go
+++ b/internal/tools/searcher/activateSkill.go
@@ -15,11 +15,11 @@ import (
 	toolTypes "github.com/pardnchiu/agenvoy/internal/tools/types"
 )
 
-const ToolName = "activate_skill"
-
-const maxDescLen = 200
-
-const staticDescription = "Activate a skill by exact name from the '## Skills' section of the system prompt; pass 'none' to clear."
+const (
+	ToolName          = "activate_skill"
+	maxDescLen        = 200
+	staticDescription = "Fetch a skill's reference material by exact name; treat the result like any other tool output — consult, integrate what fits, ignore what doesn't."
+)
 
 type params struct {
 	SkillName string `json:"skill"`
@@ -37,7 +37,7 @@ func registSelectSkill() {
 			"properties": map[string]any{
 				"skill": map[string]any{
 					"type":        "string",
-					"description": "Exact skill name from the '## Skills' section of the system prompt, or 'none' to clear.",
+					"description": "Exact skill name from the '## Skills' section of the system prompt.",
 				},
 			},
 			"required": []string{"skill"},
@@ -89,32 +89,16 @@ func handle(_ context.Context, e *toolTypes.Executor, args json.RawMessage) (str
 		return availableList(e.SkillScanner, "skill is required"), nil
 	}
 
-	if strings.EqualFold(name, "none") {
-		e.ActiveSkill = nil
-		return "active skill cleared", nil
-	}
-
 	s, ok := e.SkillScanner.Skills.ByName[name]
 	if !ok {
 		return availableList(e.SkillScanner, fmt.Sprintf("skill not found: %q", name)), nil
 	}
 
-	e.ActiveSkill = s
-	return RenderActivation(s), nil
+	return RenderReference(s), nil
 }
 
 func RenderActivation(s *skill.Skill) string {
-	return renderSkill(s)
-}
-
-func renderSkill(s *skill.Skill) string {
-	content := s.Content
-	for _, prefix := range []string{"scripts/", "templates/", "assets/"} {
-		resolved := filepath.Join(s.Path, prefix)
-		if go_pkg_filesystem_reader.Exists(resolved) {
-			content = strings.ReplaceAll(content, prefix, resolved+string(filepath.Separator))
-		}
-	}
+	content := resolveSkillPaths(s)
 
 	var b strings.Builder
 	fmt.Fprintf(&b, "active skill: %s\nskill directory: %s\n\n---\n\n", s.Name, s.Path)
@@ -124,6 +108,29 @@ func renderSkill(s *skill.Skill) string {
 	}
 	b.WriteString(content)
 	return b.String()
+}
+
+// RenderReference returns the skill body without the skill_execution.md
+// preamble. Used by the `activate_skill` tool path so the LLM receives the
+// skill content as ordinary reference material rather than binding directives.
+func RenderReference(s *skill.Skill) string {
+	content := resolveSkillPaths(s)
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "skill: %s\nskill directory: %s\n\n---\n\n", s.Name, s.Path)
+	b.WriteString(content)
+	return b.String()
+}
+
+func resolveSkillPaths(s *skill.Skill) string {
+	content := s.Content
+	for _, prefix := range []string{"scripts/", "templates/", "assets/"} {
+		resolved := filepath.Join(s.Path, prefix)
+		if go_pkg_filesystem_reader.Exists(resolved) {
+			content = strings.ReplaceAll(content, prefix, resolved+string(filepath.Separator))
+		}
+	}
+	return content
 }
 
 func availableList(scanner *skill.SkillScanner, reason string) string {

--- a/internal/tools/types/executor.go
+++ b/internal/tools/types/executor.go
@@ -26,7 +26,6 @@ type Executor struct {
 	APIToolbox     *apiAdapter.Translator
 	ScriptToolbox  ScriptToolExecutor
 
-	ActiveSkill  *skill.Skill
 	SkillScanner *skill.SkillScanner
 }
 

--- a/internal/tui/commandSwitch.go
+++ b/internal/tui/commandSwitch.go
@@ -34,6 +34,9 @@ func (t TUI) commandSwitch(parts []string) (TUI, tea.Cmd, bool) {
 		return t, tea.Println("\n" + hintStyle.Render("no sessions available")), true
 	}
 	popup.onConfirm = func(chosen string) any {
+		if chosen == "" {
+			return SessionNew{}
+		}
 		return SessionSelect{id: chosen}
 	}
 	t.popup = popup
@@ -98,9 +101,6 @@ func listSessions() []Session {
 
 func popupSwitch(sid string) *Popup {
 	sessions := listSessions()
-	if len(sessions) == 0 {
-		return nil
-	}
 
 	sort.SliceStable(sessions, func(i, j int) bool {
 		if sessions[i].id == sid && sessions[j].id != sid {
@@ -112,8 +112,8 @@ func popupSwitch(sid string) *Popup {
 		return sessions[i].id < sessions[j].id
 	})
 
-	names := make([]string, len(sessions))
-	sids := make([]string, len(sessions))
+	names := make([]string, 0, len(sessions)+1)
+	sids := make([]string, 0, len(sessions)+1)
 	cursor := 0
 	for i, e := range sessions {
 		short := utils.ShortenSessionID(e.id)
@@ -125,9 +125,12 @@ func popupSwitch(sid string) *Popup {
 			label += "  [current]"
 			cursor = i
 		}
-		names[i] = label
-		sids[i] = e.id
+		names = append(names, label)
+		sids = append(sids, e.id)
 	}
+
+	names = append(names, "(new session)")
+	sids = append(sids, "")
 
 	return &Popup{
 		kind:    popupSingleSelect,

--- a/internal/tui/handlerCommand.go
+++ b/internal/tui/handlerCommand.go
@@ -10,6 +10,8 @@ type SessionSelect struct {
 	id string
 }
 
+type SessionNew struct{}
+
 func (t TUI) handleCommand(cmd string) (TUI, tea.Cmd, bool) {
 	parts := strings.Fields(cmd)
 	switch parts[0] {

--- a/internal/tui/handlerExec.go
+++ b/internal/tui/handlerExec.go
@@ -77,6 +77,30 @@ func (t TUI) handleAgentEvent(ev agentTypes.Event) (tea.Model, tea.Cmd) {
 	case agentTypes.EventSummaryGenerate:
 		t.activity = "summarizing…"
 
+	case agentTypes.EventText:
+		if ev.Source == "" {
+			line := ev.Text
+			var rendered string
+			if !t.streaming {
+				t.streaming = true
+				t.activity = "responding"
+				prefix := systemStyle.Render("⏺ ")
+				if strings.TrimSpace(t.runTarget) != "" {
+					prefix = warnStyle.Render("⏺ [" + t.runTarget + "] ")
+				}
+				rendered = prefix + line
+			} else {
+				rendered = "  " + line
+			}
+			return t, tea.Println(rendered)
+		}
+
+	case agentTypes.EventTextDone:
+		if ev.Source == "" {
+			t.streaming = false
+		}
+		return t, nil
+
 	case agentTypes.EventDone:
 		if ev.Usage != nil {
 			t.tokens = ev.Usage.Input + ev.Usage.Output

--- a/internal/tui/handlerPopup.go
+++ b/internal/tui/handlerPopup.go
@@ -2,9 +2,11 @@ package tui
 
 import (
 	"fmt"
+	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/pardnchiu/agenvoy/internal/pending"
+	"github.com/pardnchiu/agenvoy/internal/utils"
 )
 
 type popupType int
@@ -29,7 +31,8 @@ type Popup struct {
 	cursor  int
 	multi   map[int]bool
 
-	input string
+	input          string
+	skipWithReason bool
 
 	questions   []pending.Question
 	questionIdx int
@@ -88,6 +91,13 @@ func (t TUI) updateConfirmPopup(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		t = t.closePopup()
 
 	case tea.KeyEnter:
+		if p.cursor == 3 {
+			p.kind = popupText
+			p.skipWithReason = true
+			p.title = "Reason (Enter to skip without reason):"
+			p.input = ""
+			return t, nil
+		}
 		var reply pending.Reply
 		switch p.cursor {
 		case 0:
@@ -97,11 +107,17 @@ func (t TUI) updateConfirmPopup(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 		case 1:
 			reply = pending.Reply{
+				Approve:  true,
+				Remember: true,
+			}
+
+		case 2:
+			reply = pending.Reply{
 				Approve: false,
 				Skip:    true,
 			}
 
-		case 2:
+		case 4:
 			reply = pending.Reply{
 				Approve: false,
 				Error:   fmt.Errorf("user stopped"),
@@ -109,29 +125,6 @@ func (t TUI) updateConfirmPopup(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		pending.Resolve(p.pendingId, reply)
 		t = t.closePopup()
-
-	default:
-		if len(msg.Runes) == 1 {
-			switch msg.Runes[0] {
-			case 'y', 'Y':
-				pending.Resolve(p.pendingId, pending.Reply{
-					Approve: true,
-				})
-				t = t.closePopup()
-			case 's', 'S':
-				pending.Resolve(p.pendingId, pending.Reply{
-					Approve: false,
-					Skip:    true,
-				})
-				t = t.closePopup()
-			case 'n', 'N':
-				pending.Resolve(p.pendingId, pending.Reply{
-					Approve: false,
-					Error:   fmt.Errorf("user stopped"),
-				})
-				t = t.closePopup()
-			}
-		}
 	}
 	return t, nil
 }
@@ -223,6 +216,15 @@ func (t TUI) updateTextInputPopup(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		t = t.closePopup()
 
 	case tea.KeyEnter:
+		if p.skipWithReason {
+			pending.Resolve(p.pendingId, pending.Reply{
+				Approve: false,
+				Skip:    true,
+				Reason:  strings.TrimSpace(p.input),
+			})
+			t = t.closePopup()
+			return t, nil
+		}
 		resolved, reply := p.advanceOrResolve(p.input)
 		if resolved {
 			pending.Resolve(p.pendingId, reply)
@@ -245,14 +247,20 @@ func (t TUI) updateTextInputPopup(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 func newPopup(id string, req pending.Request) *Popup {
 	switch req.Kind {
 	case pending.KindToolConfirm:
+		display := utils.FormatTool(req.ToolName, req.ToolArgs)
+		if display == "" {
+			display = req.ToolArgs
+		}
 		return &Popup{
 			pendingId: id,
 			kind:      popupConfirm,
 			title:     fmt.Sprintf("Run %s?", req.ToolName),
-			subtitle:  truncate(req.ToolArgs, 200),
+			subtitle:  truncate(display, 200),
 			options: []string{
 				"Yes",
-				"Skip",
+				"Yes, don't ask again",
+				"No",
+				"No, with reason",
 				"Stop",
 			},
 		}

--- a/internal/tui/helper.go
+++ b/internal/tui/helper.go
@@ -23,6 +23,9 @@ func activityVerb(activity string) string {
 	case activity == "":
 		return "Thinking"
 
+	case activity == "responding":
+		return "Responsing"
+
 	case activity == "selecting agent…":
 		return "Selecting agent"
 

--- a/internal/tui/init.go
+++ b/internal/tui/init.go
@@ -83,6 +83,7 @@ type TUI struct {
 	daemonStatus  string
 	discordStatus string
 	runTarget     string
+	streaming     bool
 
 	inputHistory    []string
 	inputHistoryIdx int

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -153,6 +153,7 @@ func (t TUI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		t.cancelExec = nil
 		t.activity = ""
 		t.runTarget = ""
+		t.streaming = false
 		if t.currentSessionID != "" {
 			t.currentSessionName, _ = session.GetBot(t.currentSessionID)
 		}

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -186,6 +186,10 @@ func (t TUI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		next, cmd := t.runCommandSwitch(msg.id)
 		return next, cmd
 
+	case SessionNew:
+		next, cmd, _ := t.commandNew(nil)
+		return next, cmd
+
 	case ModelRemove:
 		next, cmd := t.runModelRemove(msg.name)
 		host.Reload()

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -61,7 +61,7 @@ func (t TUI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		case tea.KeyShiftTab:
 			if t.running {
-				return t, nil
+				return t, tea.Println(hintStyle.Render("⎯ is running · shift+tab disabled"))
 			}
 			return t.logMode(t.mode == cliMode)
 

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -60,6 +60,9 @@ func (t TUI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 
 		case tea.KeyShiftTab:
+			if t.running {
+				return t, nil
+			}
 			return t.logMode(t.mode == cliMode)
 
 		case tea.KeyUp:

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 
+	sessionManager "github.com/pardnchiu/agenvoy/internal/session"
 	"github.com/pardnchiu/agenvoy/internal/utils"
 )
 
@@ -156,8 +157,19 @@ func (t TUI) sessionName() string {
 	}
 
 	short := utils.ShortenSessionID(sid)
+	base := short
 	if name != "" && name != sid {
-		return fmt.Sprintf("%s (%s)", name, short)
+		base = fmt.Sprintf("%s (%s)", name, short)
 	}
-	return short
+
+	s := sessionManager.ReadStatus(sid)
+	model := strings.TrimSpace(s.Model)
+	reasoning := strings.TrimSpace(s.Reasoning)
+	if model == "" {
+		model = sessionManager.StatusModel
+	}
+	if reasoning == "" {
+		reasoning = sessionManager.StatusReasoning
+	}
+	return fmt.Sprintf("%s (%s/%s)", base, model, reasoning)
 }

--- a/internal/utils/foramtTool.go
+++ b/internal/utils/foramtTool.go
@@ -1,0 +1,121 @@
+package utils
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+func FormatTool(name, raw string) string {
+	if raw == "" {
+		return ""
+	}
+
+	var argMap map[string]any
+	if err := json.Unmarshal([]byte(raw), &argMap); err != nil {
+		return raw
+	}
+	arg := func(keys ...string) string {
+		for _, k := range keys {
+			if v, ok := argMap[k]; ok {
+				if s, ok := v.(string); ok && strings.TrimSpace(s) != "" {
+					return s
+				}
+			}
+		}
+		return ""
+	}
+
+	switch name {
+	case "invoke_subagent":
+		val := arg("name", "session_id")
+		if val == "" {
+			val = "subagent"
+		}
+		if model := arg("model"); model != "" {
+			val = fmt.Sprintf("%s (%s)", val, model)
+		}
+
+		task := arg("task")
+		if task == "" {
+			return val
+		}
+		return fmt.Sprintf("%s: %s", val, strings.NewReplacer("\r\n", " ", "\n", " ", "\r", " ").Replace(task))
+
+	case "activate_skill":
+		if s := arg("skill", "name"); s != "" {
+			return s
+		}
+
+	case "list_files":
+		val := arg("dir", "path")
+		if val == "" {
+			break
+		}
+		if recursive, ok := argMap["recursive"].(bool); ok && recursive {
+			return val + " (recursive)"
+		}
+		return val
+
+	case "read_file", "write_file", "patch_file", "glob_files", "read_image", "save_page_to_file":
+		if val := arg("path", "pattern", "save_to"); val != "" {
+			return val
+		}
+
+	case "search_web", "fetch_google_rss":
+		if val := arg("query", "keyword"); val != "" {
+			if timeRange := arg("time_range", "time"); timeRange != "" {
+				return fmt.Sprintf("%s (%s)", val, timeRange)
+			}
+			return val
+		}
+
+	case "fetch_yahoo_finance":
+		if val := arg("symbol"); val != "" {
+			if timeRange := arg("time_range"); timeRange != "" {
+				return fmt.Sprintf("%s (%s)", val, timeRange)
+			}
+			return val
+		}
+
+	case "fetch_page", "fetch_youtube_transcript":
+		if val := arg("link", "url"); val != "" {
+			return val
+		}
+
+	case "calculate":
+		if val := arg("expression"); val != "" {
+			return val
+		}
+
+	case "remember_error":
+		if val := arg("symptom", "cause", "action"); val != "" {
+			return val
+		}
+
+	case "search_error_memory", "search_conversation_history":
+		if val := arg("keyword", "query"); val != "" {
+			return val
+		}
+
+	case "run_command":
+		var p struct {
+			Argv []string `json:"argv"`
+		}
+		if err := json.Unmarshal([]byte(raw), &p); err != nil || len(p.Argv) == 0 {
+			return raw
+		}
+
+		parts := make([]string, len(p.Argv))
+		for i, arg := range p.Argv {
+			if arg == "" || strings.ContainsAny(arg, " \t\n\"'\\") {
+				parts[i] = strconv.Quote(arg)
+			} else {
+				parts[i] = arg
+			}
+		}
+		return strings.Join(parts, " ")
+	}
+	return raw
+}

--- a/test/providers_integration_test.go
+++ b/test/providers_integration_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -16,8 +15,17 @@ import (
 	"github.com/pardnchiu/agenvoy/internal/agents/provider/nvidia"
 	"github.com/pardnchiu/agenvoy/internal/agents/provider/openai"
 	agentTypes "github.com/pardnchiu/agenvoy/internal/agents/types"
+	"github.com/pardnchiu/agenvoy/internal/filesystem"
 	"github.com/pardnchiu/go-pkg/filesystem/keychain"
 )
+
+func TestMain(m *testing.M) {
+	if err := filesystem.Init(); err != nil {
+		fmt.Fprintf(os.Stderr, "filesystem.Init: %v\n", err)
+		os.Exit(1)
+	}
+	os.Exit(m.Run())
+}
 
 var minimalMessages = []agentTypes.Message{
 	{Role: "user", Content: "say ok"},
@@ -118,13 +126,8 @@ func TestProviderNvidia(t *testing.T) {
 }
 
 func TestProviderCopilot(t *testing.T) {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		t.Skip("cannot determine home dir")
-	}
-	tokenFile := filepath.Join(homeDir, ".config", "agenvoy", "copilot_token.json")
-	if _, err := os.Stat(tokenFile); os.IsNotExist(err) {
-		t.Skip("copilot_token.json not found, run agenvoy login copilot first")
+	if keychain.Get("agenvoy.copilot.token") == "" {
+		t.Skip("agenvoy.copilot.token not in keychain, run `agen model add` to authenticate")
 	}
 	for model := range provider.Models("copilot") {
 		model := model


### PR DESCRIPTION
Adds a persistent per-project allow list that lets users bypass the confirm prompt for trusted tool calls. Simplifies the provider model registry by dropping the implicit default-model fallback as a breaking config schema change. Polishes the TUI with smoother text streaming, a new-session option in the session switcher, and clearer feedback when shift+tab is blocked.
