### PR TITLE
Return scheduler output to Discord sessions and improve rules

### DIFF
--- a/cmd/app/cmdDeamon.go
+++ b/cmd/app/cmdDeamon.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -266,5 +267,47 @@ func runSkill(ctx context.Context, sessionID, skillName string) (string, error) 
 		return "", err
 	}
 	session.SaveBot(sessionID, sessionID, false)
-	return exec.ExecWithSubagent(ctx, body, sessionID, "", "", nil)
+
+	output, err := exec.ExecWithSubagent(ctx, body, sessionID, "", "", nil)
+	if err != nil {
+		return "", err
+	}
+
+	if strings.HasPrefix(sessionID, "dc-") {
+		body := stripSubagentHeader(output)
+		if body != "" {
+			message := fmt.Sprintf("%s\n-# shchedule | %s", body, skillName)
+			discordMu.Lock()
+			bot := discordBot
+			discordMu.Unlock()
+			if bot != nil && bot.Session != nil {
+				channelID, cerr := session.GetChannelID(sessionID)
+				if cerr != nil {
+					slog.Warn("scheduler.runSkill: GetChannelID",
+						slog.String("session_id", sessionID),
+						slog.String("error", cerr.Error()))
+				} else if channelID != "" {
+					if _, derr := bot.Session.ChannelMessageSend(channelID, message); derr != nil {
+						slog.Warn("scheduler.runSkill: ChannelMessageSend",
+							slog.String("channel_id", channelID),
+							slog.String("error", derr.Error()))
+					}
+				}
+			}
+		}
+	}
+
+	return output, nil
+}
+
+func stripSubagentHeader(out string) string {
+	trimmed := strings.TrimSpace(out)
+	if !strings.HasPrefix(trimmed, "[subagent") {
+		return trimmed
+	}
+	_, rest, found := strings.Cut(trimmed, "\n")
+	if !found {
+		return ""
+	}
+	return strings.TrimSpace(rest)
 }

--- a/extensions/skills/scheduler-skill-creator/SKILL.md
+++ b/extensions/skills/scheduler-skill-creator/SKILL.md
@@ -37,7 +37,7 @@ scheduler 採 skill-based 觸發：到時間時，daemon 讀 `scheduler/<short>/
 ## 成功標準
 
 - 生成檔案: `~/.config/agenvoy/skills/scheduler/<short>-<hash8>/SKILL.md`，frontmatter `name: <short>-<hash8>`（無前綴）
-- skill body 描述任務行為、引用具體 tool、（必要時）含 Notify 段
+- skill body 描述任務行為、引用具體 tool
 - 呼叫 `add_task(time, skill_name=<short>-<hash8>)` 或 `add_cron(time, skill_name=<short>-<hash8>)` 綁定時間成功
 - 回報生成位置、full name（含 hash）、排程類型（one-shot／recurring）、下次觸發時間
 
@@ -148,7 +148,7 @@ python3 scripts/init_scheduler_skill.py <short-name>
 - `## 任務` ← 步驟 1 收集到的「行為細節」，引用具體 tool 名稱與參數
 - `## 輸出格式` ← 期望輸出形式
 
-caller session 為 `dc-*` 起源時，在末段追加 Discord Notify 段（見下方規則）。
+**禁止**在 skill body 內加任何「推送到 channel」「呼叫 send_http_request 給 Discord」「呼叫 MCP discord tool」之類的 notify 指令 —— scheduler 觸發後 runtime 自動把輸出送回原 caller channel（Discord 來源送回原頻道、CLI／HTTP 來源送回 action.log）。Skill body 只需專注產出**任務結果文字**。
 
 ### 5. 綁定時間
 
@@ -185,19 +185,16 @@ add_cron(time="<cron_expression>", skill_name="<short>-<hash8>")
 
 **禁止**自行產生／猜測 hash suffix。Hash **必須**由 init script 用 `secrets.token_hex(4)` 隨機生成，LLM 從 stdout 抓 `[OK] skill name:` 那行的值即可。
 
-## Discord Notify 段（條件性）
+## 輸出路由（runtime 自動處理）
 
-caller session ID 以 `dc-` 開頭時，於 skill body 末段插入：
+scheduler 觸發後，runtime 會把 subagent 產出的最終文字自動送回 caller 端：
 
-```markdown
-## Notify
+| Caller session prefix | 路由行為 |
+|---|---|
+| `dc-*`（Discord） | 自動 `ChannelMessageSend` 回原頻道（含 ` - <skill 短名>` 標籤） |
+| `cli-*`／`http-*`／TUI 觸發 | 留在 session history／action.log，由 caller 端工具讀取 |
 
-完成後將最終結果以 `send_http_request` 或 MCP discord tool 推送至 channel `<channel_id>`。
-```
-
-`<channel_id>` 從 caller session ID 推斷（`dc-<guild>-<channel>-...` 格式抽取）或直接問使用者。
-
-caller 來源非 `dc-*`（TUI/CLI/HTTP）時跳過此段，結果留在 session history 由 caller 查看。
+**所以 skill body 不需要、也禁止**寫「推送到 channel」「呼叫 `send_http_request` 發 Discord webhook」「呼叫 MCP discord tool」之類的 notify 指令。寫了會在觸發時造成多餘的 token 與認證錯誤（subagent 沒 `DISCORD_BOT_TOKEN` 互動環境）。
 
 ## 時間敏感性提醒（寫入 skill body 時注意）
 

--- a/internal/runtime/tui/commandSwitch.go
+++ b/internal/runtime/tui/commandSwitch.go
@@ -85,7 +85,7 @@ func listSessions() []Session {
 	results := make([]Session, 0, len(dirs))
 	for _, dir := range dirs {
 		sid := dir.Name
-		if !strings.HasPrefix(sid, "cli-") && !strings.HasPrefix(sid, "http-") {
+		if !strings.HasPrefix(sid, "cli-") && !strings.HasPrefix(sid, "http-") && !strings.HasPrefix(sid, "dc-") {
 			continue
 		}
 		name, _ := session.GetBot(sid)

--- a/internal/session/bot.go
+++ b/internal/session/bot.go
@@ -80,7 +80,7 @@ func GetSessionIDByName(name string) string {
 
 	for _, dir := range dirs {
 		sid := dir.Name
-		if !strings.HasPrefix(sid, "cli-") && !strings.HasPrefix(sid, "http-") {
+		if !strings.HasPrefix(sid, "cli-") && !strings.HasPrefix(sid, "http-") && !strings.HasPrefix(sid, "dc-") {
 			continue
 		}
 

--- a/internal/tools/scheduler/addCron.go
+++ b/internal/tools/scheduler/addCron.go
@@ -15,7 +15,7 @@ import (
 func registAddCron() {
 	toolRegister.Regist(toolRegister.Def{
 		Name:        "add_cron",
-		Description: "Low-level cron-binding for an existing scheduler skill. DO NOT call directly when the user asks for a new recurring task — use the scheduler-skill-creator skill instead (it creates the skill body then calls this tool). Use this tool directly ONLY when the skill_name already exists under ~/.config/agenvoy/skills/scheduler/<name>/ and the user is rebinding/changing the schedule.",
+		Description: "Internal cron-binding called by the scheduler-skill-creator skill flow. LLM must NOT call directly — every scheduler skill uses a hash-suffixed name that only scheduler-skill-creator generates, so any hand-made skill_name will fail.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -25,7 +25,7 @@ func registAddCron() {
 				},
 				"skill_name": map[string]any{
 					"type":        "string",
-					"description": "Scheduler skill short name (e.g. 'daily-hn-digest'). No 'scheduler-' prefix. Must already exist under ~/.config/agenvoy/skills/scheduler/<name>/.",
+					"description": "Hashed scheduler skill name '<short>-<hash8>' produced by scheduler-skill-creator (no 'scheduler-' prefix). Never hand-craft this value.",
 				},
 			},
 			"required": []string{"time", "skill_name"},
@@ -49,7 +49,7 @@ func registAddCron() {
 				return "", fmt.Errorf("skill_name is required")
 			}
 			if !filesystem.ScheduleSkillExists(skill) {
-				return "", fmt.Errorf("skill %q not found under %s. If the user is requesting a new recurring task, you should be running the scheduler-skill-creator skill (which handles create + bind in one flow), not calling add_cron directly. If you have just created the skill, call add_cron again with the same arguments now to complete the binding", skill, filesystem.ScheduleSkillPath(skill))
+				return "", fmt.Errorf("skill %q not found under %s. add_cron is an internal binding called by the scheduler-skill-creator skill flow. Run scheduler-skill-creator skill which generates a hashed skill name and binds the schedule in one flow. Do not call add_cron with a hand-made name", skill, filesystem.ScheduleSkillPath(skill))
 			}
 
 			entry := runtime.CronEntry{

--- a/internal/tools/scheduler/addTask.go
+++ b/internal/tools/scheduler/addTask.go
@@ -16,7 +16,7 @@ import (
 func registAddTask() {
 	toolRegister.Regist(toolRegister.Def{
 		Name:        "add_task",
-		Description: "Low-level time-binding for an existing scheduler skill. DO NOT call directly when the user asks for a new reminder/scheduled task — use the scheduler-skill-creator skill instead (it creates the skill body then calls this tool). Use this tool directly ONLY when the skill_name already exists under ~/.config/agenvoy/skills/scheduler/<name>/ and the user is rebinding/changing the time.",
+		Description: "Internal time-binding called by the scheduler-skill-creator skill flow. LLM must NOT call directly — every scheduler skill uses a hash-suffixed name that only scheduler-skill-creator generates, so any hand-made skill_name will fail.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -26,7 +26,7 @@ func registAddTask() {
 				},
 				"skill_name": map[string]any{
 					"type":        "string",
-					"description": "Scheduler skill short name (e.g. 'meeting-reminder'). No 'scheduler-' prefix. Must already exist under ~/.config/agenvoy/skills/scheduler/<name>/.",
+					"description": "Hashed scheduler skill name '<short>-<hash8>' produced by scheduler-skill-creator (no 'scheduler-' prefix). Never hand-craft this value.",
 				},
 			},
 			"required": []string{"time", "skill_name"},
@@ -53,7 +53,7 @@ func registAddTask() {
 				return "", fmt.Errorf("skill_name is required")
 			}
 			if !filesystem.ScheduleSkillExists(skill) {
-				return "", fmt.Errorf("skill %q not found under %s. If the user is requesting a new reminder/scheduled task, you should be running the scheduler-skill-creator skill (which handles create + bind in one flow), not calling add_task directly. If you have just created the skill, call add_task again with the same arguments now to complete the binding", skill, filesystem.ScheduleSkillPath(skill))
+				return "", fmt.Errorf("skill %q not found under %s. add_task is an internal binding called by the scheduler-skill-creator skill flow. Run scheduler-skill-creator skill which generates a hashed skill name and binds time in one flow. Do not call add_task with a hand-made name", skill, filesystem.ScheduleSkillPath(skill))
 			}
 
 			entry := runtime.TaskEntry{

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -110,6 +110,13 @@ func FormatInt(number int) string {
 	return string(result)
 }
 
+var (
+	uuidShortRegex   = regexp.MustCompile(`([0-9a-fA-F]{8})-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}`)
+	sha256ShortRegex = regexp.MustCompile(`\b([0-9a-fA-F]{8})[0-9a-fA-F]{56}\b`)
+)
+
 func ShortenSessionID(sid string) string {
-	return regexp.MustCompile(`([0-9a-fA-F]{8})-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}`).ReplaceAllString(sid, "$1")
+	sid = uuidShortRegex.ReplaceAllString(sid, "$1")
+	sid = sha256ShortRegex.ReplaceAllString(sid, "$1")
+	return sid
 }


### PR DESCRIPTION
Scheduler firings originating from Discord now post their final output back to the source channel automatically, eliminating the need for skill bodies to handle outbound HTTP themselves. Scheduler binding tools are explicitly marked internal so they stop being hand-called with fabricated skill names.