### PR TITLE
Add TUI shell command support and guard extension copies

### DIFF
--- a/internal/runtime/tui/cmdSelector.go
+++ b/internal/runtime/tui/cmdSelector.go
@@ -45,6 +45,7 @@ var commands = []Command{
 	{"mode", "switch / change rendering · TUI (cli) or browser (web)"},
 	{"history", "reload visible transcript · last 100 entries from action.log"},
 	{"log", "open / view raw action.log via $PAGER (less)"},
+	{"cmd", "run / exec shell command directly in cwd · sh -c"},
 	{"clear", "clear visible transcript / history · memory untouched"},
 	{"exit", "exit / quit TUI · daemon keeps running"},
 }

--- a/internal/runtime/tui/commandCmd.go
+++ b/internal/runtime/tui/commandCmd.go
@@ -1,0 +1,25 @@
+package tui
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+type CmdDone struct{ err error }
+
+func (t TUI) commandCmd(raw string) (TUI, tea.Cmd, bool) {
+	rest := strings.TrimSpace(strings.TrimPrefix(raw, "/cmd"))
+	if rest == "" {
+		return t, tea.Println(hintStyle.Render("usage: /cmd <shell command>") + "\n"), true
+	}
+
+	cmd := exec.Command("sh", "-c", rest)
+	cmd.Env = os.Environ()
+	cmd.Dir = t.cwd
+	return t, tea.ExecProcess(cmd, func(err error) tea.Msg {
+		return CmdDone{err: err}
+	}), true
+}

--- a/internal/runtime/tui/handlerCommand.go
+++ b/internal/runtime/tui/handlerCommand.go
@@ -74,6 +74,9 @@ func (t TUI) handleCommand(cmd string) (TUI, tea.Cmd, bool) {
 
 	case "/log":
 		return t.commandLog()
+
+	case "/cmd":
+		return t.commandCmd(cmd)
 	}
 	return t, nil, false
 }

--- a/makefile
+++ b/makefile
@@ -39,8 +39,8 @@ build:
 	go build -ldflags "-X github.com/pardnchiu/agenvoy/internal/tui.projectVersion=$$(git describe --tags --abbrev=0 2>/dev/null || echo dev)" -o agen ./cmd/app/ && sudo mv agen /usr/local/bin/agen
 	@rm -rf "$$HOME/.config/agenvoy/skills/.system" "$$HOME/.config/agenvoy/tools/.system"
 	@mkdir -p "$$HOME/.config/agenvoy/skills/.system" "$$HOME/.config/agenvoy/tools/.system"
-	@cp -R extensions/skills/. "$$HOME/.config/agenvoy/skills/.system/"
-	@cp -R extensions/scripts/. "$$HOME/.config/agenvoy/tools/.system/"
+	@[ -d extensions/skills ] && cp -R extensions/skills/. "$$HOME/.config/agenvoy/skills/.system/" || true
+	@[ -d extensions/scripts ] && cp -R extensions/scripts/. "$$HOME/.config/agenvoy/tools/.system/" || true
 	@find "$$HOME/.config/agenvoy/skills/.system" "$$HOME/.config/agenvoy/tools/.system" -name __pycache__ -prune -exec rm -rf {} + 2>/dev/null || true
 
 app:


### PR DESCRIPTION
Scheduled skill output now flows back to chat through a Discord push hook with tightened message formatting. The TUI gains a shell-command launcher alongside history reload and action-log viewers. Tool credential capture moves off ad-hoc environment variables onto keychain-backed storage.