### PR TITLE
Remove matched scheduled task instance

### DIFF
--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -143,8 +143,8 @@ func reload() error {
 		}
 		if !entry.At.After(now) {
 			go func(e TaskEntry) {
-				if _, err := RemoveTask(e.Skill); err != nil {
-					slog.Warn("RemoveTask",
+				if _, err := RemoveTaskByTimeSkill(e.At, e.Skill); err != nil {
+					slog.Warn("RemoveTaskByTimeSkill",
 						slog.String("error", err.Error()))
 				}
 			}(entry)
@@ -158,9 +158,19 @@ func reload() error {
 			st.mu.Lock()
 			delete(st.timers, keyCopy)
 			st.mu.Unlock()
-			if _, err := RemoveTask(entryCopy.Skill); err != nil {
-				slog.Warn("RemoveTask",
+			if _, err := RemoveTaskByTimeSkill(entryCopy.At, entryCopy.Skill); err != nil {
+				slog.Warn("RemoveTaskByTimeSkill",
 					slog.String("error", err.Error()))
+				return
+			}
+			hasMore, err := HasTaskForSkill(entryCopy.Skill)
+			if err != nil {
+				slog.Warn("HasTaskForSkill",
+					slog.String("error", err.Error()))
+				return
+			}
+			if hasMore {
+				return
 			}
 			if err := filesystem.TrashScheduleSkill(entryCopy.Skill); err != nil {
 				slog.Warn("filesystem.TrashScheduleSkill",

--- a/internal/runtime/task.go
+++ b/internal/runtime/task.go
@@ -70,6 +70,40 @@ func RemoveTask(name string) (int, error) {
 	return removed, SaveTasks(filtered)
 }
 
+func RemoveTaskByTimeSkill(at time.Time, skill string) (int, error) {
+	existing, err := LoadTasks()
+	if err != nil {
+		return 0, err
+	}
+	target := at.UnixNano()
+	filtered := make([]TaskEntry, 0, len(existing))
+	removed := 0
+	for _, e := range existing {
+		if e.Skill == skill && e.At.UnixNano() == target {
+			removed++
+			continue
+		}
+		filtered = append(filtered, e)
+	}
+	if removed == 0 {
+		return 0, nil
+	}
+	return removed, SaveTasks(filtered)
+}
+
+func HasTaskForSkill(skill string) (bool, error) {
+	existing, err := LoadTasks()
+	if err != nil {
+		return false, err
+	}
+	for _, e := range existing {
+		if e.Skill == skill {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 func PatchTask(skillName string, newAt time.Time) (int, error) {
 	existing, err := LoadTasks()
 	if err != nil {


### PR DESCRIPTION
Scheduled task firing no longer wipes sibling bindings that share the same skill name. The runtime now removes only the matched time binding and keeps the skill folder until every pending binding has fired.
