### PR TITLE
Add read-only scheduler tools for listing tasks and cron jobs

### DIFF
--- a/internal/tools/scheduler/listCron.go
+++ b/internal/tools/scheduler/listCron.go
@@ -1,0 +1,39 @@
+package scheduler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/pardnchiu/agenvoy/internal/runtime"
+	toolRegister "github.com/pardnchiu/agenvoy/internal/tools/register"
+	toolTypes "github.com/pardnchiu/agenvoy/internal/tools/types"
+)
+
+func registListCron() {
+	toolRegister.Regist(toolRegister.Def{
+		Name:        "list_cron",
+		Description: "List currently scheduled cron jobs from crons.json. No parameters. Returns JSON array of {expression, session_id, skill}; empty array when nothing is scheduled.",
+		Parameters: map[string]any{
+			"type":       "object",
+			"properties": map[string]any{},
+		},
+		AlwaysAllow: true,
+		AlwaysLoad:  true,
+		Concurrent:  true,
+		Handler: func(_ context.Context, _ *toolTypes.Executor, _ json.RawMessage) (string, error) {
+			crons, err := runtime.LoadCrons()
+			if err != nil {
+				return "", fmt.Errorf("LoadCrons: %w", err)
+			}
+			if len(crons) == 0 {
+				return "[]", nil
+			}
+			buf, err := json.Marshal(crons)
+			if err != nil {
+				return "", fmt.Errorf("json.Marshal: %w", err)
+			}
+			return string(buf), nil
+		},
+	})
+}

--- a/internal/tools/scheduler/listTask.go
+++ b/internal/tools/scheduler/listTask.go
@@ -1,0 +1,40 @@
+package scheduler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/pardnchiu/agenvoy/internal/runtime"
+	toolRegister "github.com/pardnchiu/agenvoy/internal/tools/register"
+	toolTypes "github.com/pardnchiu/agenvoy/internal/tools/types"
+)
+
+func registListTask() {
+	toolRegister.Regist(toolRegister.Def{
+		Name:        "list_task",
+		Description: "List currently scheduled one-shot tasks from tasks.json. No parameters. Returns JSON array of {at, session_id, skill}; empty array when nothing is scheduled.",
+		Parameters: map[string]any{
+			"type":       "object",
+			"properties": map[string]any{},
+		},
+		AlwaysAllow: true,
+		AlwaysLoad:  true,
+		Concurrent:  true,
+		Handler: func(_ context.Context, _ *toolTypes.Executor, _ json.RawMessage) (string, error) {
+			tasks, err := runtime.LoadTasks()
+			if err != nil {
+				return "", fmt.Errorf("LoadTasks: %w", err)
+			}
+			if len(tasks) == 0 {
+				return "[]", nil
+			}
+
+			buf, err := json.Marshal(tasks)
+			if err != nil {
+				return "", fmt.Errorf("json.Marshal: %w", err)
+			}
+			return string(buf), nil
+		},
+	})
+}

--- a/internal/tools/scheduler/register.go
+++ b/internal/tools/scheduler/register.go
@@ -7,4 +7,6 @@ func Register() {
 	registPatchCron()
 	registRemoveTask()
 	registRemoveCron()
+	registListTask()
+	registListCron()
 }


### PR DESCRIPTION
Scheduled-state introspection becomes a first-class tool surface. The runtime now exposes read-only listers for one-shot tasks and recurring crons, closing a discovery gap that previously forced the agent to fall back on filesystem traversal.
