### PR TITLE
Refactor attachment delivery flow and decouple media handling

### DIFF
--- a/configs/prompts/discord_format.md
+++ b/configs/prompts/discord_format.md
@@ -81,9 +81,10 @@ go, js, ts, py, rs, java, c, cpp, cs, php, rb, swift, kt, sh, bash, sql, json, y
 
 ## Sending Files
 
-- To send a local file (image, text file, etc.), include `[SEND_FILE:/absolute/path]` in the reply — the system will automatically attach the file
+- To send a local file (image, text file, etc.), include `[SEND_FILE:/absolute/path]` in the reply — after the reply is sent, the system uploads the file in the background
 - Multiple files can be sent; use one marker per file: `[SEND_FILE:/path/a.png][SEND_FILE:/path/b.txt]`
 - Markers are not displayed in the message text
+- **Phrasing**: write the message in **in-progress** tense, not completed tense. Use 「現在傳送中」「正在上傳」「稍後送達」etc.; do NOT use 「已傳送」「已附上」「傳完了」 because the upload has not actually finished when the message is sent
 
 ---
 

--- a/configs/prompts/discord_system_prompt.md
+++ b/configs/prompts/discord_system_prompt.md
@@ -105,7 +105,7 @@ When a user message contains any of the following time-delay intents, **must** g
 When the final output of a task is a **local file** (md, json, txt, etc.):
 - **The 1600-character limit applies only to the Discord message reply itself**, not to the file content
 - File content prioritizes completeness and is not subject to the character limit
-- The Discord message only needs to say "完成，檔案位於 `{path}`" and attach `[SEND_FILE:{path}]` if needed
+- The Discord message only needs to say "現在傳送中，檔案位於 `{path}`" (in-progress tense) and attach `[SEND_FILE:{path}]` if needed
 
 ### When Reply Is Incomplete
 - If the content cannot be fully presented within the character limit, prioritize the most essential conclusion or answer

--- a/configs/prompts/telegram_format.md
+++ b/configs/prompts/telegram_format.md
@@ -101,9 +101,10 @@ Do not use `<ul>` / `<li>`.
 
 ## Sending Files
 
-- To send a local file (image, text file, etc.), include `[SEND_FILE:/absolute/path]` in the reply — the system will automatically attach the file
+- To send a local file (image, text file, etc.), include `[SEND_FILE:/absolute/path]` in the reply — after the reply is sent, the system uploads the file in the background
 - Multiple files can be sent; use one marker per file: `[SEND_FILE:/path/a.png][SEND_FILE:/path/b.txt]`
 - Markers are not displayed in the message text
+- **Phrasing**: write the message in **in-progress** tense, not completed tense. Use 「現在傳送中」「正在上傳」「稍後送達」etc.; do NOT use 「已傳送」「已附上」「傳完了」 because the upload has not actually finished when the message is sent
 - Images conforming to Telegram photo constraints (PNG/JPG/WebP, width+height ≤ 10000 px, ratio ≤ 20:1, ≤ 10 MB) will be sent as inline photos (multiple images in one reply are grouped as a single Telegram media group); non-conforming files (including SVG, oversized images, archives, source files) are sent as documents
 
 ---

--- a/configs/prompts/telegram_system_prompt.md
+++ b/configs/prompts/telegram_system_prompt.md
@@ -106,7 +106,7 @@ When a user message contains any of the following time-delay intents, **must** g
 When the final output of a task is a **local file** (md, json, txt, etc.):
 - **The 3500-character limit applies only to the Telegram message reply itself**, not to the file content
 - File content prioritizes completeness and is not subject to the character limit
-- The Telegram message only needs to say "完成，檔案位於 <code>{path}</code>" and attach `[SEND_FILE:{path}]` if needed
+- The Telegram message only needs to say "現在傳送中，檔案位於 <code>{path}</code>" (in-progress tense) and attach `[SEND_FILE:{path}]` if needed
 
 ### When Reply Is Incomplete
 - If the content cannot be fully presented within the character limit, prioritize the most essential conclusion or answer

--- a/internal/runtime/discord/attachments.go
+++ b/internal/runtime/discord/attachments.go
@@ -17,14 +17,14 @@ func sendAttachments(ctx context.Context, client *go_bot_discord.Bot, channelID,
 		return
 	}
 
-	notifyFailure := func(label, detail, errMsg string) {
-		text := fmt.Sprintf("-# ⎿ ⚠️ %s failed", label)
+	sendFailure := func(label, detail, errMsg string) {
+		text := fmt.Sprintf("-# ⎿ ⚠️ %s failed (background upload)", label)
 		if detail != "" {
 			text = fmt.Sprintf("%s: `%s`", text, detail)
 		}
 		text = fmt.Sprintf("%s\n-# ⎿ `%s`", text, errMsg)
 		if _, err := client.Send(ctx, channelID, replyTo, text); err != nil {
-			slog.Warn("github.com/pardnchiu/go-bot/discord Bot.Send (notify)",
+			slog.Error("github.com/pardnchiu/go-bot/discord Bot.Send (notify)",
 				slog.String("label", label),
 				slog.String("error", err.Error()))
 		}
@@ -34,11 +34,12 @@ func sendAttachments(ctx context.Context, client *go_bot_discord.Bot, channelID,
 		end := min(start+10, len(paths))
 		batch := paths[start:end]
 		if _, err := client.SendFiles(ctx, channelID, replyTo, batch); err != nil {
-			slog.Warn("github.com/pardnchiu/go-bot/discord Bot.SendFiles",
+			slog.Error("github.com/pardnchiu/go-bot/discord Bot.SendFiles",
 				slog.String("channel", channelName),
 				slog.Int("count", len(batch)),
+				slog.String("paths", strings.Join(batch, ", ")),
 				slog.String("error", err.Error()))
-			notifyFailure("SendFiles", strings.Join(batch, ", "), err.Error())
+			sendFailure("SendFiles", strings.Join(batch, ", "), err.Error())
 		}
 	}
 }

--- a/internal/runtime/discord/run.go
+++ b/internal/runtime/discord/run.go
@@ -249,6 +249,9 @@ func run(ctx context.Context, b *Bot, in go_bot_discord.Input) error {
 	if doneEvent.Usage != nil {
 		footer = fmt.Sprintf("%s | in:%s out:%s", footer, utils.FormatUsage(doneEvent.Usage.Input), utils.FormatUsage(doneEvent.Usage.Output))
 	}
+	if len(attachmentPaths) > 0 || len(voiceTexts) > 0 {
+		footer = "🔗 " + footer
+	}
 	replyText = fmt.Sprintf("%s\n-# ⎿ %s", replyText, footer)
 	if len(execErrors) > 0 {
 		replyText = fmt.Sprintf("%s\n-# ⎿ ⚠️ %s", replyText, strings.Join(execErrors, ", "))
@@ -279,43 +282,37 @@ func run(ctx context.Context, b *Bot, in go_bot_discord.Input) error {
 	}
 
 	if len(voiceTexts) > 0 {
-		sendFailure := func(label, detail, errMsg string) {
-			text := fmt.Sprintf("-# ⎿ ⚠️ %s failed", label)
-			if detail != "" {
-				text = fmt.Sprintf("%s: `%s`", text, detail)
-			}
-			text = fmt.Sprintf("%s\n-# ⎿ `%s`", text, errMsg)
-			if _, err := b.client.Send(ctx, in.ChannelID, replyToID, text); err != nil {
-				slog.Warn("github.com/pardnchiu/go-bot/discord Bot.client.Send (notify)",
-					slog.String("label", label),
-					slog.String("error", err.Error()))
-			}
-		}
-		if err := b.client.SendStatus(ctx, in.ChannelID, replyToID, "sending…",
-			go_bot_discord.WithStatusEmoji("⚡")); err != nil {
-			slog.Warn("github.com/pardnchiu/go-bot/discord Bot.client.SendStatus",
-				slog.String("channel", channelName(in)),
-				slog.String("error", err.Error()))
-		}
-		apiKey := strings.TrimSpace(keychain.Get("GEMINI_API_KEY"))
-		if apiKey == "" {
-			slog.Warn("keychain.Get GEMINI_API_KEY missing",
-				slog.String("channel", channelName(in)))
-			sendFailure("SendVoice", "", "GEMINI_API_KEY missing")
-		} else {
-			for _, text := range voiceTexts {
-				if _, err := b.client.SendVoice(ctx, in.ChannelID, replyToID, text, apiKey); err != nil {
-					slog.Warn("github.com/pardnchiu/go-bot/discord Bot.client.SendVoice",
+		bgCtx := context.WithoutCancel(ctx)
+		channel := channelName(in)
+		channelID := in.ChannelID
+		reply := replyToID
+		client := b.client
+		texts := voiceTexts
+		go func() {
+			sendFailure := func(errMsg string) {
+				text := fmt.Sprintf("-# ⎿ ⚠️ SendVoice failed (background)\n-# ⎿ `%s`", errMsg)
+				if _, err := client.Send(bgCtx, channelID, reply, text); err != nil {
+					slog.Error("github.com/pardnchiu/go-bot/discord Bot.client.Send (notify)",
+						slog.String("channel", channel),
 						slog.String("error", err.Error()))
-					sendFailure("SendVoice", "", err.Error())
 				}
 			}
-		}
-		if err := b.client.FinishStatus(ctx, in.ChannelID); err != nil {
-			slog.Warn("github.com/pardnchiu/go-bot/discord Bot.client.FinishStatus",
-				slog.String("channel", channelName(in)),
-				slog.String("error", err.Error()))
-		}
+			apiKey := strings.TrimSpace(keychain.Get("GEMINI_API_KEY"))
+			if apiKey == "" {
+				slog.Error("keychain.Get GEMINI_API_KEY missing",
+					slog.String("channel", channel))
+				sendFailure("GEMINI_API_KEY missing")
+				return
+			}
+			for _, text := range texts {
+				if _, err := client.SendVoice(bgCtx, channelID, reply, text, apiKey); err != nil {
+					slog.Error("github.com/pardnchiu/go-bot/discord Bot.client.SendVoice",
+						slog.String("channel", channel),
+						slog.String("error", err.Error()))
+					sendFailure(err.Error())
+				}
+			}
+		}()
 	}
 
 	return nil

--- a/internal/runtime/discord/run.go
+++ b/internal/runtime/discord/run.go
@@ -269,31 +269,34 @@ func run(ctx context.Context, b *Bot, in go_bot_discord.Input) error {
 	if replyMsg != nil {
 		replyToID = replyMsg.ID
 	}
-	sendFailure := func(label, detail, errMsg string) {
-		text := fmt.Sprintf("-# ⎿ ⚠️ %s failed", label)
-		if detail != "" {
-			text = fmt.Sprintf("%s: `%s`", text, detail)
-		}
-		text = fmt.Sprintf("%s\n-# ⎿ `%s`", text, errMsg)
-		if _, err := b.client.Send(ctx, in.ChannelID, replyToID, text); err != nil {
-			slog.Warn("github.com/pardnchiu/go-bot/discord Bot.client.Send (notify)",
-				slog.String("label", label),
-				slog.String("error", err.Error()))
-		}
-	}
-
-	if err := b.client.SendStatus(ctx, in.ChannelID, replyToID, "sending…",
-		go_bot_discord.WithStatusEmoji("⚡")); err != nil {
-		slog.Warn("github.com/pardnchiu/go-bot/discord Bot.client.SendStatus",
-			slog.String("channel", channelName(in)),
-			slog.String("error", err.Error()))
-	}
 
 	if len(attachmentPaths) > 0 {
-		sendAttachments(ctx, b.client, in.ChannelID, channelName(in), replyToID, attachmentPaths)
+		bgCtx := context.WithoutCancel(ctx)
+		channel := channelName(in)
+		client := b.client
+		paths := attachmentPaths
+		go sendAttachments(bgCtx, client, in.ChannelID, channel, replyToID, paths)
 	}
 
 	if len(voiceTexts) > 0 {
+		sendFailure := func(label, detail, errMsg string) {
+			text := fmt.Sprintf("-# ⎿ ⚠️ %s failed", label)
+			if detail != "" {
+				text = fmt.Sprintf("%s: `%s`", text, detail)
+			}
+			text = fmt.Sprintf("%s\n-# ⎿ `%s`", text, errMsg)
+			if _, err := b.client.Send(ctx, in.ChannelID, replyToID, text); err != nil {
+				slog.Warn("github.com/pardnchiu/go-bot/discord Bot.client.Send (notify)",
+					slog.String("label", label),
+					slog.String("error", err.Error()))
+			}
+		}
+		if err := b.client.SendStatus(ctx, in.ChannelID, replyToID, "sending…",
+			go_bot_discord.WithStatusEmoji("⚡")); err != nil {
+			slog.Warn("github.com/pardnchiu/go-bot/discord Bot.client.SendStatus",
+				slog.String("channel", channelName(in)),
+				slog.String("error", err.Error()))
+		}
 		apiKey := strings.TrimSpace(keychain.Get("GEMINI_API_KEY"))
 		if apiKey == "" {
 			slog.Warn("keychain.Get GEMINI_API_KEY missing",
@@ -308,12 +311,11 @@ func run(ctx context.Context, b *Bot, in go_bot_discord.Input) error {
 				}
 			}
 		}
-	}
-
-	if err := b.client.FinishStatus(ctx, in.ChannelID); err != nil {
-		slog.Warn("github.com/pardnchiu/go-bot/discord Bot.client.FinishStatus",
-			slog.String("channel", channelName(in)),
-			slog.String("error", err.Error()))
+		if err := b.client.FinishStatus(ctx, in.ChannelID); err != nil {
+			slog.Warn("github.com/pardnchiu/go-bot/discord Bot.client.FinishStatus",
+				slog.String("channel", channelName(in)),
+				slog.String("error", err.Error()))
+		}
 	}
 
 	return nil

--- a/internal/runtime/telegram/attachments.go
+++ b/internal/runtime/telegram/attachments.go
@@ -18,14 +18,14 @@ import (
 
 const attachmentSendTimeout = 10 * time.Minute
 
-func sendAttachments(ctx context.Context, chatID int64, chatName string, replyToID int, photoPaths, docPaths []string) {
+func sendAttachments(ctx context.Context, chatID int64, chatName string, photoPaths, docPaths []string) {
 	if len(photoPaths) == 0 && len(docPaths) == 0 {
 		return
 	}
 
 	token := strings.TrimSpace(keychain.Get(Key))
 	if token == "" {
-		slog.Warn("github.com/pardnchiu/go-pkg/filesystem/keychain Get",
+		slog.Error("github.com/pardnchiu/go-pkg/filesystem/keychain Get",
 			slog.String("chat", chatName),
 			slog.String("key", Key))
 		return
@@ -34,7 +34,7 @@ func sendAttachments(ctx context.Context, chatID int64, chatName string, replyTo
 	client, err := go_bot_telegram.New(token,
 		go_bot_telegram.WithHTTPClient(&http.Client{Timeout: attachmentSendTimeout}))
 	if err != nil {
-		slog.Warn("github.com/pardnchiu/go-bot/telegram New",
+		slog.Error("github.com/pardnchiu/go-bot/telegram New",
 			slog.String("chat", chatName),
 			slog.String("error", err.Error()))
 		return
@@ -45,9 +45,9 @@ func sendAttachments(ctx context.Context, chatID int64, chatName string, replyTo
 		if detail != "" {
 			body = fmt.Sprintf("<code>%s</code>: %s", html.EscapeString(detail), body)
 		}
-		text := fmt.Sprintf("⚠️ %s failed\n%s", label, body)
-		if _, err := client.Send(ctx, chatID, replyToID, text, go_bot_telegram.WithSendType(go_bot_telegram.TypeHTML)); err != nil {
-			slog.Warn("github.com/pardnchiu/go-bot/telegram Bot.Send (notify)",
+		text := fmt.Sprintf("⚠️ %s failed (background upload)\n%s", label, body)
+		if _, err := client.Send(ctx, chatID, 0, text, go_bot_telegram.WithSendType(go_bot_telegram.TypeHTML)); err != nil {
+			slog.Error("github.com/pardnchiu/go-bot/telegram Bot.Send (notify)",
 				slog.String("label", label),
 				slog.String("error", err.Error()))
 		}
@@ -57,16 +57,17 @@ func sendAttachments(ctx context.Context, chatID int64, chatName string, replyTo
 		end := start + 10
 		end = min(end, len(photoPaths))
 		if _, err := client.SendPhoto(ctx, chatID, photoPaths[start:end]); err != nil {
-			slog.Warn("github.com/pardnchiu/go-bot/telegram Bot.SendPhoto",
+			slog.Error("github.com/pardnchiu/go-bot/telegram Bot.SendPhoto",
 				slog.String("chat", chatName),
 				slog.Int("count", end-start),
+				slog.String("paths", strings.Join(photoPaths[start:end], ", ")),
 				slog.String("error", err.Error()))
 			notifyFailure("SendPhoto", strings.Join(photoPaths[start:end], ", "), err.Error())
 		}
 	}
 	for _, path := range docPaths {
 		if _, err := client.SendFile(ctx, chatID, go_bot_telegram.TypeDocument, path); err != nil {
-			slog.Warn("github.com/pardnchiu/go-bot/telegram Bot.SendFile",
+			slog.Error("github.com/pardnchiu/go-bot/telegram Bot.SendFile",
 				slog.String("chat", chatName),
 				slog.String("path", path),
 				slog.String("error", err.Error()))

--- a/internal/runtime/telegram/push.go
+++ b/internal/runtime/telegram/push.go
@@ -72,7 +72,7 @@ func PushTelegramResult(ctx context.Context, payload exec.PushPayload) {
 		}
 	}
 
-	sendAttachments(ctx, chatID, chatName, 0, photoPaths, docPaths)
+	sendAttachments(ctx, chatID, chatName, photoPaths, docPaths)
 }
 
 func buildPushFooter(model string, usage *agentTypes.Usage) string {

--- a/internal/runtime/telegram/run.go
+++ b/internal/runtime/telegram/run.go
@@ -270,6 +270,9 @@ func run(ctx context.Context, b *Bot, in go_bot_telegram.Input) error {
 	if doneEvent.Usage != nil {
 		footer = fmt.Sprintf("%s | in:%s out:%s", footer, utils.FormatUsage(doneEvent.Usage.Input), utils.FormatUsage(doneEvent.Usage.Output))
 	}
+	if len(photoPaths) > 0 || len(docPaths) > 0 || len(voiceTexts) > 0 {
+		footer = "🔗 " + footer
+	}
 	replyText = fmt.Sprintf("%s\n\n<blockquote expandable>%s</blockquote>", replyText, footer)
 	if len(execErrors) > 0 {
 		replyText = fmt.Sprintf("%s\n\n<blockquote expandable>⚠️ %s</blockquote>", replyText, strings.Join(execErrors, ", "))
@@ -278,7 +281,7 @@ func run(ctx context.Context, b *Bot, in go_bot_telegram.Input) error {
 	if in.MessageID != 0 {
 		replyText = "​\n" + replyText
 	}
-	replyMsg, sendErr := b.client.Send(ctx, in.ChatID, in.MessageID, replyText, go_bot_telegram.WithSendType(go_bot_telegram.TypeHTML))
+	_, sendErr := b.client.Send(ctx, in.ChatID, in.MessageID, replyText, go_bot_telegram.WithSendType(go_bot_telegram.TypeHTML))
 	if sendErr != nil {
 		slog.Warn("github.com/pardnchiu/go-bot/telegram Bot.client.Send",
 			slog.String("error", sendErr.Error()))
@@ -288,63 +291,43 @@ func run(ctx context.Context, b *Bot, in go_bot_telegram.Input) error {
 		return nil
 	}
 
-	replyToID := 0
-	if replyMsg != nil {
-		replyToID = replyMsg.ID
-	}
-
 	if len(photoPaths) > 0 || len(docPaths) > 0 {
 		bgCtx := context.WithoutCancel(ctx)
 		chat := chatName(in)
-		go sendAttachments(bgCtx, in.ChatID, chat, replyToID, photoPaths, docPaths)
+		go sendAttachments(bgCtx, in.ChatID, chat, photoPaths, docPaths)
 	}
 
 	if len(voiceTexts) > 0 {
-		sendStatus := func(text string) {
-			wrapped := fmt.Sprintf("<blockquote expandable>%s</blockquote>", html.EscapeString(text))
-			if err := b.client.SendStatus(ctx, in.ChatID, replyToID, wrapped,
-				go_bot_telegram.WithStatusEmoji("⚡"),
-				go_bot_telegram.WithStatusSendType(go_bot_telegram.TypeHTML),
-			); err != nil {
-				slog.Warn("github.com/pardnchiu/go-bot/telegram Bot.client.SendStatus",
-					slog.String("text", text),
-					slog.String("chat", chatName(in)),
-					slog.Int("replyTo", replyToID),
-					slog.String("error", err.Error()))
-			}
-		}
-		sendFailure := func(label, detail, errMsg string) {
-			body := fmt.Sprintf("<code>%s</code>", html.EscapeString(errMsg))
-			if detail != "" {
-				body = fmt.Sprintf("<code>%s</code>: %s", html.EscapeString(detail), body)
-			}
-			text := fmt.Sprintf("⚠️ %s failed\n%s", label, body)
-			if _, err := b.client.Send(ctx, in.ChatID, replyToID, text, go_bot_telegram.WithSendType(go_bot_telegram.TypeHTML)); err != nil {
-				slog.Warn("github.com/pardnchiu/go-bot/telegram Bot.client.Send (notify)",
-					slog.String("label", label),
-					slog.String("error", err.Error()))
-			}
-		}
-		sendStatus("sending…")
-		apiKey := strings.TrimSpace(keychain.Get("GEMINI_API_KEY"))
-		if apiKey == "" {
-			slog.Warn("keychain.Get GEMINI_API_KEY missing",
-				slog.String("chat", chatName(in)))
-			sendFailure("SendVoice", "", "GEMINI_API_KEY missing")
-		} else {
-			for _, text := range voiceTexts {
-				if _, err := b.client.SendVoice(ctx, in.ChatID, text, apiKey); err != nil {
-					slog.Warn("github.com/pardnchiu/go-bot/telegram Bot.client.SendVoice",
+		bgCtx := context.WithoutCancel(ctx)
+		chat := chatName(in)
+		chatID := in.ChatID
+		client := b.client
+		texts := voiceTexts
+		go func() {
+			notifyFailure := func(errMsg string) {
+				text := fmt.Sprintf("⚠️ SendVoice failed (background)\n<code>%s</code>", html.EscapeString(errMsg))
+				if _, err := client.Send(bgCtx, chatID, 0, text, go_bot_telegram.WithSendType(go_bot_telegram.TypeHTML)); err != nil {
+					slog.Error("github.com/pardnchiu/go-bot/telegram Bot.client.Send (notify)",
+						slog.String("chat", chat),
 						slog.String("error", err.Error()))
-					sendFailure("SendVoice", "", err.Error())
 				}
 			}
-		}
-		if err := b.client.FinishStatus(ctx, in.ChatID); err != nil {
-			slog.Warn("github.com/pardnchiu/go-bot/telegram Bot.client.FinishStatus",
-				slog.String("chat", chatName(in)),
-				slog.String("error", err.Error()))
-		}
+			apiKey := strings.TrimSpace(keychain.Get("GEMINI_API_KEY"))
+			if apiKey == "" {
+				slog.Error("keychain.Get GEMINI_API_KEY missing",
+					slog.String("chat", chat))
+				notifyFailure("GEMINI_API_KEY missing")
+				return
+			}
+			for _, text := range texts {
+				if _, err := client.SendVoice(bgCtx, chatID, text, apiKey); err != nil {
+					slog.Error("github.com/pardnchiu/go-bot/telegram Bot.client.SendVoice",
+						slog.String("chat", chat),
+						slog.String("error", err.Error()))
+					notifyFailure(err.Error())
+				}
+			}
+		}()
 	}
 
 	return nil

--- a/internal/runtime/telegram/run.go
+++ b/internal/runtime/telegram/run.go
@@ -292,38 +292,40 @@ func run(ctx context.Context, b *Bot, in go_bot_telegram.Input) error {
 	if replyMsg != nil {
 		replyToID = replyMsg.ID
 	}
-	sendStatus := func(text string) {
-		wrapped := fmt.Sprintf("<blockquote expandable>%s</blockquote>", html.EscapeString(text))
-		if err := b.client.SendStatus(ctx, in.ChatID, replyToID, wrapped,
-			go_bot_telegram.WithStatusEmoji("⚡"),
-			go_bot_telegram.WithStatusSendType(go_bot_telegram.TypeHTML),
-		); err != nil {
-			slog.Warn("github.com/pardnchiu/go-bot/telegram Bot.client.SendStatus",
-				slog.String("text", text),
-				slog.String("chat", chatName(in)),
-				slog.Int("replyTo", replyToID),
-				slog.String("error", err.Error()))
-		}
-	}
-	sendFailure := func(label, detail, errMsg string) {
-		body := fmt.Sprintf("<code>%s</code>", html.EscapeString(errMsg))
-		if detail != "" {
-			body = fmt.Sprintf("<code>%s</code>: %s", html.EscapeString(detail), body)
-		}
-		text := fmt.Sprintf("⚠️ %s failed\n%s", label, body)
-		if _, err := b.client.Send(ctx, in.ChatID, replyToID, text, go_bot_telegram.WithSendType(go_bot_telegram.TypeHTML)); err != nil {
-			slog.Warn("github.com/pardnchiu/go-bot/telegram Bot.client.Send (notify)",
-				slog.String("label", label),
-				slog.String("error", err.Error()))
-		}
-	}
-	sendStatus("sending…")
 
 	if len(photoPaths) > 0 || len(docPaths) > 0 {
-		sendAttachments(ctx, in.ChatID, chatName(in), replyToID, photoPaths, docPaths)
+		bgCtx := context.WithoutCancel(ctx)
+		chat := chatName(in)
+		go sendAttachments(bgCtx, in.ChatID, chat, replyToID, photoPaths, docPaths)
 	}
 
 	if len(voiceTexts) > 0 {
+		sendStatus := func(text string) {
+			wrapped := fmt.Sprintf("<blockquote expandable>%s</blockquote>", html.EscapeString(text))
+			if err := b.client.SendStatus(ctx, in.ChatID, replyToID, wrapped,
+				go_bot_telegram.WithStatusEmoji("⚡"),
+				go_bot_telegram.WithStatusSendType(go_bot_telegram.TypeHTML),
+			); err != nil {
+				slog.Warn("github.com/pardnchiu/go-bot/telegram Bot.client.SendStatus",
+					slog.String("text", text),
+					slog.String("chat", chatName(in)),
+					slog.Int("replyTo", replyToID),
+					slog.String("error", err.Error()))
+			}
+		}
+		sendFailure := func(label, detail, errMsg string) {
+			body := fmt.Sprintf("<code>%s</code>", html.EscapeString(errMsg))
+			if detail != "" {
+				body = fmt.Sprintf("<code>%s</code>: %s", html.EscapeString(detail), body)
+			}
+			text := fmt.Sprintf("⚠️ %s failed\n%s", label, body)
+			if _, err := b.client.Send(ctx, in.ChatID, replyToID, text, go_bot_telegram.WithSendType(go_bot_telegram.TypeHTML)); err != nil {
+				slog.Warn("github.com/pardnchiu/go-bot/telegram Bot.client.Send (notify)",
+					slog.String("label", label),
+					slog.String("error", err.Error()))
+			}
+		}
+		sendStatus("sending…")
 		apiKey := strings.TrimSpace(keychain.Get("GEMINI_API_KEY"))
 		if apiKey == "" {
 			slog.Warn("keychain.Get GEMINI_API_KEY missing",
@@ -338,12 +340,11 @@ func run(ctx context.Context, b *Bot, in go_bot_telegram.Input) error {
 				}
 			}
 		}
-	}
-
-	if err := b.client.FinishStatus(ctx, in.ChatID); err != nil {
-		slog.Warn("github.com/pardnchiu/go-bot/telegram Bot.client.FinishStatus",
-			slog.String("chat", chatName(in)),
-			slog.String("error", err.Error()))
+		if err := b.client.FinishStatus(ctx, in.ChatID); err != nil {
+			slog.Warn("github.com/pardnchiu/go-bot/telegram Bot.client.FinishStatus",
+				slog.String("chat", chatName(in)),
+				slog.String("error", err.Error()))
+		}
 	}
 
 	return nil

--- a/internal/utils/fileMarker.go
+++ b/internal/utils/fileMarker.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"os"
 	"regexp"
 	"strings"
 )
@@ -12,13 +13,14 @@ var (
 
 func ExtractFileMarkers(text string) (cleanText string, paths []string) {
 	seen := map[string]bool{}
+	var raw []string
 	collect := func(path string) {
 		path = strings.TrimSpace(path)
 		if path == "" || seen[path] {
 			return
 		}
 		seen[path] = true
-		paths = append(paths, path)
+		raw = append(raw, path)
 	}
 
 	for _, m := range fileMarkerRegex.FindAllStringSubmatch(text, -1) {
@@ -30,6 +32,14 @@ func ExtractFileMarkers(text string) (cleanText string, paths []string) {
 		collect(m[1])
 	}
 	text = fileLineRegex.ReplaceAllString(text, "")
+
+	for _, p := range raw {
+		info, err := os.Stat(p)
+		if err != nil || info.IsDir() {
+			continue
+		}
+		paths = append(paths, p)
+	}
 
 	cleanText = strings.TrimSpace(text)
 	return

--- a/static/scripts/install.sh
+++ b/static/scripts/install.sh
@@ -16,6 +16,7 @@ SUDO=""
 
 SRC_DIR=""
 GO_TMP_DIR=""
+INSTALLED_TAG=""
 cleanup() {
   if [ -n "$SRC_DIR" ] && [ -d "$SRC_DIR" ]; then
     rm -rf "$SRC_DIR"
@@ -106,8 +107,7 @@ confirm_overwrite_agen() {
   log "agen already installed at: $existing"
 
   if [ ! -e /dev/tty ] || [ ! -r /dev/tty ]; then
-    log "Non-interactive shell; launching existing agen"
-    launch_agen
+    log "Non-interactive shell; keeping existing agen"
     exit 0
   fi
 
@@ -117,8 +117,7 @@ confirm_overwrite_agen() {
   case "$ans" in
     y|Y|yes|YES|Yes) ok "Proceeding with reinstall" ;;
     *)
-      ok "Keeping existing agen; launching"
-      launch_agen
+      ok "Keeping existing agen"
       exit 0
       ;;
   esac
@@ -216,6 +215,7 @@ clone_repo() {
   SRC_DIR="$(mktemp -d "${TMPDIR:-/tmp}/agenvoy-install.XXXXXX")"
   log "Cloning agenvoy@${tag} -> ${SRC_DIR}"
   git clone --depth 1 --branch "$tag" "$REPO_URL" "$SRC_DIR"
+  INSTALLED_TAG="$tag"
   ok "Cloned $tag"
 }
 
@@ -252,12 +252,41 @@ stop_daemon() {
   agen stop || true
 }
 
-launch_agen() {
-  if [ -e /dev/tty ] && [ -r /dev/tty ] && [ -w /dev/tty ]; then
-    log "Launching agen..."
-    exec </dev/tty >/dev/tty 2>/dev/tty agen
-  fi
-  warn "Non-interactive shell detected; run 'agen' manually to start."
+print_done() {
+  local tag="${1:-installed}"
+  local lines=(
+    "Agenvoy ${tag} installed"
+    ""
+    "Next: run 'agen' to attach the new build"
+  )
+
+  local max=0 line len
+  for line in "${lines[@]}"; do
+    len=${#line}
+    [ "$len" -gt "$max" ] && max=$len
+  done
+
+  local pad_each=2
+  local inner=$((max + pad_each * 2))
+
+  local border="" rpad=""
+  local i=0
+  while [ $i -lt $inner ]; do
+    border="${border}─"
+    i=$((i + 1))
+  done
+
+  printf '\n%s╭%s╮%s\n' "$C_GRN" "$border" "$C_RST"
+  for line in "${lines[@]}"; do
+    rpad=""
+    i=0
+    while [ $i -lt $((max - ${#line})) ]; do
+      rpad="${rpad} "
+      i=$((i + 1))
+    done
+    printf '%s│%s  %s%s  %s│%s\n' "$C_GRN" "$C_RST" "$line" "$rpad" "$C_GRN" "$C_RST"
+  done
+  printf '%s╰%s╯%s\n\n' "$C_GRN" "$border" "$C_RST"
 }
 
 main() {
@@ -281,7 +310,7 @@ main() {
   build_and_install
   seed_mcp_config
   stop_daemon
-  launch_agen
+  print_done "$INSTALLED_TAG"
 }
 
 main "$@"


### PR DESCRIPTION
Detaches media delivery from the reply lifecycle so both runtimes return the agent's text immediately while file and voice uploads run in the background. Path-validates extracted markers before send and routes upload errors through a structured failure channel so silent loss is no longer possible.
