### PR TITLE
Add plan routing and agent selection for generation

### DIFF
--- a/configs/prompts/agent_selector.md
+++ b/configs/prompts/agent_selector.md
@@ -29,6 +29,10 @@ Request contains "use <name>", "用 <名稱>", "指定 <名稱>", "select <name>
 Request begins with `[summary]` prefix → pure JSON output task, no dense system prompt.
 → Apply summary chain (see below) directly.
 
+### P0.6: Planning task routing
+Request begins with `[plan]` prefix → text-only execution plan generation, no tool calls (toolDefs=nil).
+→ Apply the "Dense routing / multi-step planning / task decomposition / subagent dispatch / complexity evaluation" chain directly: `claude-opus > codex-pro > codex > claude-sonnet > openai-pro > openai > gemini-pro > codex-mini > openai-mini > claude-haiku > gemini-flash > codex-nano > openai-nano > gemini-flash-lite`.
+
 ### P1: Task-type chain matching
 
 Identify which task scenario the request belongs to, then apply the corresponding preference chain. Scan from left to right; return the first `name` in the available list that matches a node. Within a node, prefer the highest-version variant.

--- a/internal/tools/agent/plan/generatePlan.go
+++ b/internal/tools/agent/plan/generatePlan.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/pardnchiu/agenvoy/internal/agents"
+	"github.com/pardnchiu/agenvoy/internal/agents/exec"
 	agentTypes "github.com/pardnchiu/agenvoy/internal/agents/types"
 	toolRegister "github.com/pardnchiu/agenvoy/internal/tools/register"
 	toolTypes "github.com/pardnchiu/agenvoy/internal/tools/types"
@@ -73,7 +74,7 @@ func registGeneratePlan() {
 			},
 			"required": []string{"requirement"},
 		},
-		Handler: func(ctx context.Context, _ *toolTypes.Executor, args json.RawMessage) (string, error) {
+		Handler: func(ctx context.Context, e *toolTypes.Executor, args json.RawMessage) (string, error) {
 			var params struct {
 				Requirement string `json:"requirement"`
 				Context     string `json:"context,omitempty"`
@@ -88,8 +89,18 @@ func registGeneratePlan() {
 			}
 
 			dispatcher := agents.Dispatcher()
-			if dispatcher == nil {
-				return "", fmt.Errorf("dispatcher unavailable")
+			registry := agents.Registry()
+			if dispatcher == nil || len(registry.Registry) == 0 {
+				return "", fmt.Errorf("planner host not initialized")
+			}
+
+			sessionID := ""
+			if e != nil {
+				sessionID = e.SessionID
+			}
+			agent := exec.SelectAgent(ctx, dispatcher, registry, "[plan] "+requirement, false, sessionID)
+			if agent == nil {
+				return "", fmt.Errorf("no agent available")
 			}
 
 			var userBuilder strings.Builder
@@ -105,9 +116,9 @@ func registGeneratePlan() {
 				{Role: "user", Content: userBuilder.String()},
 			}
 
-			resp, err := dispatcher.Send(ctx, messages, nil)
+			resp, err := agent.Send(ctx, messages, nil)
 			if err != nil {
-				return "", fmt.Errorf("dispatcher.Send: %w", err)
+				return "", fmt.Errorf("agent.Send: %w", err)
 			}
 			if resp == nil || len(resp.Choices) == 0 {
 				return "", fmt.Errorf("planner returned no choices")


### PR DESCRIPTION
Routes plan generation through the agent selector so a high-reasoning model writes the plan instead of the routing model. Introduces a dedicated routing prefix that pins the selector to the dense-reasoning preference chain.
