### PR TITLE
Enhance logging and timeout features across tools

### DIFF
--- a/internal/agents/exec/execute.go
+++ b/internal/agents/exec/execute.go
@@ -317,6 +317,10 @@ func Execute(ctx context.Context, data ExecData, session *agentTypes.AgentSessio
 				default:
 					userMsg = fmt.Sprintf("upstream %s failed %d times in a row: %s", modelName, sendFailCount, err.Error())
 				}
+				slog.Error("data.Agent.Send exhausted",
+					slog.String("session", session.ID),
+					slog.String("error", err.Error()),
+					slog.Int("attempts", sendFailCount))
 				sendText(events, userMsg)
 				events <- agentTypes.Event{
 					Type:     agentTypes.EventDone,

--- a/internal/agents/exec/execute.go
+++ b/internal/agents/exec/execute.go
@@ -261,9 +261,11 @@ func Execute(ctx context.Context, data ExecData, session *agentTypes.AgentSessio
 			}
 			if isContextLengthError(err) {
 				trimmedToolCalls = trimmedToolCalls || trimOnContextExceeded(&session.OldHistories, &session.ToolHistories)
-				slog.Warn("data.Agent.Send context length exceeded, trimming oldest exchange")
+				slog.Warn("data.Agent.Send context length exceeded, trimming oldest exchange",
+					slog.String("session", session.ID))
 			} else {
 				slog.Warn("data.Agent.Send",
+					slog.String("session", session.ID),
 					slog.String("error", err.Error()),
 					slog.Int("sameSigCount", sendFailCount))
 			}
@@ -327,6 +329,7 @@ func Execute(ctx context.Context, data ExecData, session *agentTypes.AgentSessio
 
 			if err := saveNewHistory(choice, session); err != nil {
 				slog.Warn("writeHistory",
+					slog.String("session", session.ID),
 					slog.String("error", err.Error()))
 			}
 
@@ -342,6 +345,7 @@ func Execute(ctx context.Context, data ExecData, session *agentTypes.AgentSessio
 
 		if err := filesystem.UpdateUsage(data.Agent.Name(), usage.Input, usage.Output, usage.CacheCreate, usage.CacheRead); err != nil {
 			slog.Warn("usageManager.Update",
+				slog.String("session", session.ID),
 				slog.String("error", err.Error()))
 		}
 		events <- agentTypes.Event{Type: agentTypes.EventDone, Model: data.Agent.Name(), Usage: &usage, Duration: time.Since(executeStart)}
@@ -369,6 +373,7 @@ func Execute(ctx context.Context, data ExecData, session *agentTypes.AgentSessio
 			sendText(events, StripModelResponse(text))
 			if err := filesystem.UpdateUsage(data.Agent.Name(), usage.Input, usage.Output, usage.CacheCreate, usage.CacheRead); err != nil {
 				slog.Warn("usageManager.Update",
+					slog.String("session", session.ID),
 					slog.String("error", err.Error()))
 			}
 			events <- agentTypes.Event{Type: agentTypes.EventDone, Model: data.Agent.Name(), Usage: &usage, Duration: time.Since(executeStart)}
@@ -379,6 +384,7 @@ func Execute(ctx context.Context, data ExecData, session *agentTypes.AgentSessio
 	sendText(events, "no usable data, retry later, or using other tools.")
 	if err := filesystem.UpdateUsage(data.Agent.Name(), usage.Input, usage.Output, usage.CacheCreate, usage.CacheRead); err != nil {
 		slog.Warn("usageManager.Update",
+			slog.String("session", session.ID),
 			slog.String("error", err.Error()))
 	}
 	events <- agentTypes.Event{Type: agentTypes.EventDone, Model: data.Agent.Name(), Usage: &usage, Duration: time.Since(executeStart)}
@@ -541,6 +547,7 @@ func writeSessionHistEntry(sessionID string, msg agentTypes.Message) {
 	if setErr := db.SetVector(context.Background(), key, value, torii.SetDefault, nil); setErr != nil {
 		if setErr = db.Set(key, value, torii.SetDefault, nil); setErr != nil {
 			slog.Warn("store.DB.Set",
+				slog.String("session", sessionID),
 				slog.String("error", setErr.Error()))
 		}
 	}

--- a/internal/agents/exec/execute.go
+++ b/internal/agents/exec/execute.go
@@ -6,6 +6,7 @@ import (
 	_ "embed"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"regexp"
@@ -22,8 +23,8 @@ import (
 	"github.com/pardnchiu/agenvoy/internal/agents/external"
 	agentTypes "github.com/pardnchiu/agenvoy/internal/agents/types"
 	"github.com/pardnchiu/agenvoy/internal/filesystem"
-	"github.com/pardnchiu/agenvoy/internal/runtime/torii"
 	"github.com/pardnchiu/agenvoy/internal/runtime"
+	"github.com/pardnchiu/agenvoy/internal/runtime/torii"
 	sessionManager "github.com/pardnchiu/agenvoy/internal/session"
 	"github.com/pardnchiu/agenvoy/internal/tools"
 	toolSearcher "github.com/pardnchiu/agenvoy/internal/tools/searcher"
@@ -65,6 +66,30 @@ var MaxToolIterations = positiveEnvInt("MAX_TOOL_ITERATIONS", 16)
 var MaxSkillIterations = positiveEnvInt("MAX_SKILL_ITERATIONS", 128)
 var MaxEmptyResponses = positiveEnvInt("MAX_EMPTY_RESPONSES", 8)
 var MaxRetry = positiveEnvInt("MAX_SAME_PAYLOAD_RETRY", 3)
+var AgentSendTimeout = time.Duration(positiveEnvInt("AGENT_SEND_TIMEOUT_SECONDS", 600)) * time.Second
+
+func isSendTimeoutError(err error, sendCtxErr error) bool {
+	if errors.Is(sendCtxErr, context.DeadlineExceeded) {
+		return true
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	s := err.Error()
+	switch {
+	case strings.Contains(s, "Client.Timeout"):
+		return true
+	case strings.Contains(s, "context deadline exceeded"):
+		return true
+	case strings.Contains(s, "timeout awaiting response headers"):
+		return true
+	case strings.Contains(s, "TLS handshake timeout"):
+		return true
+	case strings.Contains(s, "i/o timeout"):
+		return true
+	}
+	return false
+}
 
 func positiveEnvInt(key string, def int) int {
 	if n := go_pkg_utils.GetWithDefaultInt(key, def); n > 0 {
@@ -247,17 +272,28 @@ func Execute(ctx context.Context, data ExecData, session *agentTypes.AgentSessio
 			return ctx.Err()
 		}
 		assembled := assembleMessages(session.SystemPrompts, session.OldHistories, session.SummaryMessage, session.UserInput, session.ToolHistories)
-		resp, err := data.Agent.Send(ctx, assembled, exec.Tools)
+		sendStart := time.Now()
+		sendCtx, cancelSend := context.WithTimeout(ctx, AgentSendTimeout)
+		resp, err := data.Agent.Send(sendCtx, assembled, exec.Tools)
+		sendElapsed := time.Since(sendStart).Round(time.Second)
+		sendCtxErr := sendCtx.Err()
+		cancelSend()
 		if err != nil {
 			if ctx.Err() != nil {
 				return ctx.Err()
 			}
-			sig := hashPayload(assembled, exec.Tools)
-			if sig == lastSendSig {
+			isTimeout := isSendTimeoutError(err, sendCtxErr)
+			if isTimeout {
 				sendFailCount++
+				lastSendSig = ""
 			} else {
-				sendFailCount = 1
-				lastSendSig = sig
+				sig := hashPayload(assembled, exec.Tools)
+				if sig == lastSendSig {
+					sendFailCount++
+				} else {
+					sendFailCount = 1
+					lastSendSig = sig
+				}
 			}
 			if isContextLengthError(err) {
 				trimmedToolCalls = trimmedToolCalls || trimOnContextExceeded(&session.OldHistories, &session.ToolHistories)
@@ -267,10 +303,35 @@ func Execute(ctx context.Context, data ExecData, session *agentTypes.AgentSessio
 				slog.Warn("data.Agent.Send",
 					slog.String("session", session.ID),
 					slog.String("error", err.Error()),
+					slog.Bool("timeout", isTimeout),
 					slog.Int("sameSigCount", sendFailCount))
 			}
+			modelName := data.Agent.Name()
 			if sendFailCount >= MaxRetry {
-				return fmt.Errorf("data.Agent.Send failed %d times with identical payload: %w", sendFailCount, err)
+				var userMsg string
+				switch {
+				case isTimeout:
+					userMsg = fmt.Sprintf("upstream %s timed out %d times in a row (last attempt bailed at %s). Try again later or switch model.", modelName, sendFailCount, sendElapsed)
+				case isContextLengthError(err):
+					userMsg = fmt.Sprintf("upstream %s context exceeded after %d trim attempts. Start a new session or switch to a larger-context model.", modelName, sendFailCount)
+				default:
+					userMsg = fmt.Sprintf("upstream %s failed %d times in a row: %s", modelName, sendFailCount, err.Error())
+				}
+				sendText(events, userMsg)
+				events <- agentTypes.Event{
+					Type:     agentTypes.EventDone,
+					Model:    modelName,
+					Usage:    &usage,
+					Duration: time.Since(executeStart),
+				}
+				return fmt.Errorf("data.Agent.Send failed %d times: %w", sendFailCount, err)
+			}
+			if isTimeout {
+				events <- agentTypes.Event{
+					Type:     agentTypes.EventExecError,
+					ToolName: modelName,
+					Text:     fmt.Sprintf("upstream timeout after %s, retrying %d/%d", sendElapsed, sendFailCount, MaxRetry),
+				}
 			}
 			continue
 		}

--- a/internal/agents/exec/toolCall.go
+++ b/internal/agents/exec/toolCall.go
@@ -111,6 +111,7 @@ func toolCall(ctx context.Context, exec *toolTypes.Executor, choice agentTypes.O
 					if reply.Approve && reply.Remember {
 						if err = allowTool.Append(exec.WorkDir, toolName, toolArg); err != nil {
 							slog.Warn("appendAllowListRule",
+								slog.String("session", sessionData.ID),
 								slog.String("error", err.Error()))
 						}
 					}

--- a/internal/agents/provider/claude/new.go
+++ b/internal/agents/provider/claude/new.go
@@ -5,9 +5,10 @@ import (
 	"net/http"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/pardnchiu/go-pkg/filesystem/keychain"
+
+	"github.com/pardnchiu/agenvoy/internal/agents/provider"
 )
 
 type Agent struct {
@@ -38,7 +39,7 @@ func New(model ...string) (*Agent, error) {
 	}
 
 	return &Agent{
-		httpClient: &http.Client{Timeout: 2 * time.Minute},
+		httpClient: provider.NewHTTPClient(),
 		model:      usedModel,
 		apiKey:     apiKey,
 		workDir:    workDir,

--- a/internal/agents/provider/compat/new.go
+++ b/internal/agents/provider/compat/new.go
@@ -60,7 +60,7 @@ func New(model ...string) (*Agent, error) {
 	}
 
 	return &Agent{
-		httpClient: &http.Client{Timeout: 2 * time.Minute},
+		httpClient: &http.Client{Timeout: 5 * time.Minute},
 		model:      usedModel,
 		baseURL:    baseURL,
 		apiKey:     apiKey,

--- a/internal/agents/provider/copilot/login.go
+++ b/internal/agents/provider/copilot/login.go
@@ -72,7 +72,7 @@ func (c *Agent) Login(ctx context.Context) (*Token, error) {
 	deadline := time.Now().Add(time.Duration(code.ExpiresIn) * time.Second)
 
 	var token *Token
-	client := &http.Client{} // * use the same http client for reuse connection
+	client := &http.Client{Timeout: 30 * time.Second}
 	for time.Now().Before(deadline) {
 		select {
 		case <-ctx.Done():

--- a/internal/agents/provider/copilot/new.go
+++ b/internal/agents/provider/copilot/new.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	"github.com/pardnchiu/go-pkg/filesystem/keychain"
+
+	"github.com/pardnchiu/agenvoy/internal/agents/provider"
 )
 
 type Token struct {
@@ -50,7 +52,7 @@ func New(model ...string) (*Agent, error) {
 	// }
 
 	agent := &Agent{
-		httpClient: &http.Client{Timeout: 2 * time.Minute},
+		httpClient: provider.NewHTTPClient(),
 		model:      usedModel,
 		workDir:    workDir,
 	}
@@ -87,7 +89,7 @@ func Authenticate(ctx context.Context) error {
 		return fmt.Errorf("os.Getwd: %w", err)
 	}
 	a := &Agent{
-		httpClient: &http.Client{Timeout: 2 * time.Minute},
+		httpClient: provider.NewHTTPClient(),
 		workDir:    workDir,
 	}
 	token, err := a.Login(ctx)

--- a/internal/agents/provider/gemini/new.go
+++ b/internal/agents/provider/gemini/new.go
@@ -5,9 +5,10 @@ import (
 	"net/http"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/pardnchiu/go-pkg/filesystem/keychain"
+
+	"github.com/pardnchiu/agenvoy/internal/agents/provider"
 )
 
 type Agent struct {
@@ -35,7 +36,7 @@ func New(model ...string) (*Agent, error) {
 	workDir, _ := os.Getwd()
 
 	return &Agent{
-		httpClient: &http.Client{Timeout: 2 * time.Minute},
+		httpClient: provider.NewHTTPClient(),
 		model:      usedModel,
 		apiKey:     apiKey,
 		workDir:    workDir,

--- a/internal/agents/provider/gemini/stt/register.go
+++ b/internal/agents/provider/gemini/stt/register.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/pardnchiu/go-pkg/filesystem/keychain"
 
@@ -21,6 +22,7 @@ func Register() {
 		Name:        "transcribe_media",
 		AlwaysAllow: true,
 		Concurrent:  true,
+		Timeout:     5 * time.Minute,
 		Description: `[system-default]
 Transcribe a local audio or video file to text via Gemini.
 Supports ogg / mp3 / wav / m4a / flac / aac / mp4 / mov / webm / mpeg / 3gp.`,

--- a/internal/agents/provider/gemini/youtube/register.go
+++ b/internal/agents/provider/gemini/youtube/register.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/pardnchiu/go-pkg/filesystem/keychain"
 
@@ -21,6 +22,7 @@ func Register() {
 		Name:        "fetch_youtube_transcript",
 		AlwaysAllow: true,
 		Concurrent:  true,
+		Timeout:     5 * time.Minute,
 		Description: `[system-default]
 Transcribe YouTube video with timestamps.
 Video to text for analysis, summarization, quote extraction.`,

--- a/internal/agents/provider/nvidia/new.go
+++ b/internal/agents/provider/nvidia/new.go
@@ -5,9 +5,10 @@ import (
 	"net/http"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/pardnchiu/go-pkg/filesystem/keychain"
+
+	"github.com/pardnchiu/agenvoy/internal/agents/provider"
 )
 
 type Agent struct {
@@ -35,7 +36,7 @@ func New(model ...string) (*Agent, error) {
 	workDir, _ := os.Getwd()
 
 	return &Agent{
-		httpClient: &http.Client{Timeout: 2 * time.Minute},
+		httpClient: provider.NewHTTPClient(),
 		model:      usedModel,
 		apiKey:     apiKey,
 		workDir:    workDir,

--- a/internal/agents/provider/openai/new.go
+++ b/internal/agents/provider/openai/new.go
@@ -5,9 +5,10 @@ import (
 	"net/http"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/pardnchiu/go-pkg/filesystem/keychain"
+
+	"github.com/pardnchiu/agenvoy/internal/agents/provider"
 )
 
 type Agent struct {
@@ -35,7 +36,7 @@ func New(model ...string) (*Agent, error) {
 	workDir, _ := os.Getwd()
 
 	return &Agent{
-		httpClient: &http.Client{Timeout: 2 * time.Minute},
+		httpClient: provider.NewHTTPClient(),
 		model:      usedModel,
 		apiKey:     apiKey,
 		workDir:    workDir,

--- a/internal/agents/provider/openaiCodex/image2/register.go
+++ b/internal/agents/provider/openaiCodex/image2/register.go
@@ -1,6 +1,8 @@
 package image2
 
 import (
+	"time"
+
 	openaicodex "github.com/pardnchiu/agenvoy/internal/agents/provider/openaiCodex"
 	toolRegister "github.com/pardnchiu/agenvoy/internal/tools/register"
 )
@@ -12,6 +14,7 @@ func Register() {
 
 	toolRegister.Regist(toolRegister.Def{
 		Name:        "generate_image",
+		Timeout:     5 * time.Minute,
 		Description: "Generate an image via gpt-image-2 on the codex@ subscription quota. Use when the user asks to create / draw / render an image. Confirm size and quality via ask_user first (no defaults; high ≈ 5× quota). Output path appears on the last line as `FILE: <path>`.",
 		Parameters: map[string]any{
 			"type": "object",

--- a/internal/agents/provider/openaiCodex/new.go
+++ b/internal/agents/provider/openaiCodex/new.go
@@ -14,6 +14,19 @@ import (
 
 const prefix = "codex@"
 
+func newHTTPClient() *http.Client {
+	base, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		base = &http.Transport{}
+	}
+	transport := base.Clone()
+	transport.ResponseHeaderTimeout = 15 * time.Second
+	return &http.Client{
+		Timeout:   10 * time.Minute,
+		Transport: transport,
+	}
+}
+
 type Agent struct {
 	httpClient *http.Client
 	model      string
@@ -34,7 +47,7 @@ func New(model ...string) (*Agent, error) {
 	}
 
 	a := &Agent{
-		httpClient: &http.Client{Timeout: 10 * time.Minute},
+		httpClient: newHTTPClient(),
 		model:      usedModel,
 		workDir:    workDir,
 	}
@@ -67,7 +80,7 @@ func Authenticate(ctx context.Context) error {
 		return fmt.Errorf("os.Getwd: %w", err)
 	}
 	a := &Agent{
-		httpClient: &http.Client{Timeout: 10 * time.Minute},
+		httpClient: newHTTPClient(),
 		workDir:    workDir,
 	}
 	token, err := a.Login(ctx)

--- a/internal/agents/provider/provider.go
+++ b/internal/agents/provider/provider.go
@@ -3,6 +3,8 @@ package provider
 import (
 	_ "embed"
 	"encoding/json"
+	"net/http"
+	"time"
 
 	"github.com/pardnchiu/agenvoy/configs"
 )
@@ -87,4 +89,17 @@ func Models(provider string) map[string]ModelItem {
 
 func SupportTemperature(providerName, model string) bool {
 	return !Get(providerName, model).NoTemperature
+}
+
+func NewHTTPClient() *http.Client {
+	base, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		base = &http.Transport{}
+	}
+	transport := base.Clone()
+	transport.ResponseHeaderTimeout = 15 * time.Second
+	return &http.Client{
+		Timeout:   5 * time.Minute,
+		Transport: transport,
+	}
 }

--- a/internal/filesystem/toolError.go
+++ b/internal/filesystem/toolError.go
@@ -22,6 +22,7 @@ func GetError(sessionID, hash string) string {
 	result, err := go_pkg_filesystem.ReadText(path)
 	if err != nil {
 		slog.Warn("github.com/pardnchiu/go-pkg/filesystem ReadText",
+			slog.String("session", sessionID),
 			slog.String("path", path),
 			slog.String("error", err.Error()))
 		return ""
@@ -42,6 +43,7 @@ func SaveError(sessionID, toolName, args, errMsg string) string {
 	dir := ErrorDir(sessionID)
 	if err := go_pkg_filesystem.CheckDir(dir, true); err != nil {
 		slog.Warn("github.com/pardnchiu/go-pkg/filesystem CheckDir",
+			slog.String("session", sessionID),
 			slog.String("dir", dir),
 			slog.String("error", err.Error()))
 		return hash
@@ -49,6 +51,7 @@ func SaveError(sessionID, toolName, args, errMsg string) string {
 	path := ErrorPath(sessionID, hash)
 	if err := go_pkg_filesystem.WriteJSON(path, record, false); err != nil {
 		slog.Warn("github.com/pardnchiu/go-pkg/filesystem WriteJSON",
+			slog.String("session", sessionID),
 			slog.String("path", path),
 			slog.String("error", err.Error()))
 	}

--- a/internal/routes/handler/page.go
+++ b/internal/routes/handler/page.go
@@ -98,6 +98,7 @@ func PageListener() gin.HandlerFunc {
 					if go_pkg_filesystem_reader.IsDir(ev.Name) {
 						if err := watcher.Add(ev.Name); err != nil {
 							slog.Warn("page watcher add subdir",
+								slog.String("session", sessionID),
 								slog.String("path", ev.Name),
 								slog.String("error", err.Error()))
 						}

--- a/internal/runtime/cli/config.go
+++ b/internal/runtime/cli/config.go
@@ -64,6 +64,7 @@ func Config(name string) {
 	fmt.Printf("Editing %s\n", botPath)
 	if err := cmd.Run(); err != nil {
 		slog.Error("cmd.Run",
+			slog.String("session", sessionID),
 			slog.String("error", err.Error()))
 		os.Exit(1)
 	}

--- a/internal/runtime/discord/push.go
+++ b/internal/runtime/discord/push.go
@@ -27,7 +27,7 @@ func PushDiscordResult(ctx context.Context, payload exec.PushPayload) {
 	channelID, err := sessionManager.GetChannelID(id)
 	if err != nil {
 		slog.Warn("github.com/pardnchiu/agenvoy/internal/session GetChannelID",
-			slog.String("session_id", id),
+			slog.String("session", id),
 			slog.String("error", err.Error()))
 		return
 	}
@@ -38,13 +38,14 @@ func PushDiscordResult(ctx context.Context, payload exec.PushPayload) {
 	token := strings.TrimSpace(keychain.Get(Key))
 	if token == "" {
 		slog.Warn("github.com/pardnchiu/go-pkg/filesystem/keychain Get",
-			slog.String("session_id", id),
+			slog.String("session", id),
 			slog.String("key", Key))
 		return
 	}
 	client, err := go_bot_discord.New(token)
 	if err != nil {
 		slog.Warn("github.com/pardnchiu/go-bot/discord New",
+			slog.String("session", id),
 			slog.String("error", err.Error()))
 		return
 	}
@@ -61,6 +62,7 @@ func PushDiscordResult(ctx context.Context, payload exec.PushPayload) {
 		for _, part := range chunk(message) {
 			if _, err := client.Send(ctx, channelID, "", part); err != nil {
 				slog.Warn("github.com/pardnchiu/go-bot/discord Bot.Send",
+					slog.String("session", id),
 					slog.String("channel", chanName),
 					slog.String("error", err.Error()))
 				break

--- a/internal/runtime/discord/run.go
+++ b/internal/runtime/discord/run.go
@@ -187,6 +187,7 @@ func run(ctx context.Context, b *Bot, in go_bot_discord.Input) error {
 	markStatus := func(text string) {
 		if err := b.client.SendStatus(ctx, in.ChannelID, in.MessageID, text); err != nil {
 			slog.Warn("github.com/pardnchiu/go-bot/discord Bot.client.SendStatus",
+				slog.String("session", sess.ID),
 				slog.String("text", text),
 				slog.String("channel", channelName(in)),
 				slog.String("error", err.Error()))
@@ -205,6 +206,7 @@ func run(ctx context.Context, b *Bot, in go_bot_discord.Input) error {
 		}
 		if execErr != nil {
 			slog.Warn("exec",
+				slog.String("session", sess.ID),
 				slog.String("error", execErr.Error()))
 		}
 		close(events)
@@ -219,6 +221,7 @@ func run(ctx context.Context, b *Bot, in go_bot_discord.Input) error {
 
 	if err := b.client.FinishStatus(ctx, in.ChannelID); err != nil {
 		slog.Warn("github.com/pardnchiu/go-bot/discord Bot.client.FinishStatus",
+			slog.String("session", sess.ID),
 			slog.String("channel", channelName(in)),
 			slog.String("error", err.Error()))
 	}
@@ -259,6 +262,7 @@ func run(ctx context.Context, b *Bot, in go_bot_discord.Input) error {
 		msg, sendErr := b.client.Send(ctx, in.ChannelID, replyTo, part)
 		if sendErr != nil {
 			slog.Warn("github.com/pardnchiu/go-bot/discord Bot.client.Send",
+				slog.String("session", sess.ID),
 				slog.String("channel", channelName(in)),
 				slog.String("error", sendErr.Error()))
 			break
@@ -291,11 +295,13 @@ func run(ctx context.Context, b *Bot, in go_bot_discord.Input) error {
 		reply := replyToID
 		client := b.client
 		texts := voiceTexts
+		sessID := sess.ID
 		go func() {
 			sendFailure := func(errMsg string) {
 				text := fmt.Sprintf("-# ⎿ ⚠️ SendVoice failed (background)\n-# ⎿ `%s`", errMsg)
 				if _, err := client.Send(bgCtx, channelID, reply, text); err != nil {
 					slog.Error("github.com/pardnchiu/go-bot/discord Bot.client.Send (notify)",
+						slog.String("session", sessID),
 						slog.String("channel", channel),
 						slog.String("error", err.Error()))
 				}
@@ -303,6 +309,7 @@ func run(ctx context.Context, b *Bot, in go_bot_discord.Input) error {
 			apiKey := strings.TrimSpace(keychain.Get("GEMINI_API_KEY"))
 			if apiKey == "" {
 				slog.Error("keychain.Get GEMINI_API_KEY missing",
+					slog.String("session", sessID),
 					slog.String("channel", channel))
 				sendFailure("GEMINI_API_KEY missing")
 				return
@@ -310,6 +317,7 @@ func run(ctx context.Context, b *Bot, in go_bot_discord.Input) error {
 			for _, text := range texts {
 				if _, err := client.SendVoice(bgCtx, channelID, reply, text, apiKey); err != nil {
 					slog.Error("github.com/pardnchiu/go-bot/discord Bot.client.SendVoice",
+						slog.String("session", sessID),
 						slog.String("channel", channel),
 						slog.String("error", err.Error()))
 					sendFailure(err.Error())

--- a/internal/runtime/scheduler.go
+++ b/internal/runtime/scheduler.go
@@ -145,6 +145,7 @@ func reload() error {
 			go func(e TaskEntry) {
 				if _, err := RemoveTaskByTimeSkill(e.At, e.Skill); err != nil {
 					slog.Warn("RemoveTaskByTimeSkill",
+						slog.String("session", e.SessionID),
 						slog.String("error", err.Error()))
 				}
 			}(entry)
@@ -160,12 +161,14 @@ func reload() error {
 			st.mu.Unlock()
 			if _, err := RemoveTaskByTimeSkill(entryCopy.At, entryCopy.Skill); err != nil {
 				slog.Warn("RemoveTaskByTimeSkill",
+					slog.String("session", entryCopy.SessionID),
 					slog.String("error", err.Error()))
 				return
 			}
 			hasMore, err := HasTaskForSkill(entryCopy.Skill)
 			if err != nil {
 				slog.Warn("HasTaskForSkill",
+					slog.String("session", entryCopy.SessionID),
 					slog.String("error", err.Error()))
 				return
 			}
@@ -174,6 +177,7 @@ func reload() error {
 			}
 			if err := filesystem.TrashScheduleSkill(context.Background(), entryCopy.Skill); err != nil {
 				slog.Warn("filesystem.TrashScheduleSkill",
+					slog.String("session", entryCopy.SessionID),
 					slog.String("error", err.Error()))
 			}
 		})
@@ -190,6 +194,7 @@ func reload() error {
 		})
 		if err != nil {
 			slog.Warn("cron.Add",
+				slog.String("session", entry.SessionID),
 				slog.String("error", err.Error()))
 			continue
 		}
@@ -207,6 +212,7 @@ func fire(sessionID, skillName string) {
 	ctx := context.Background()
 	if _, err := (*fn)(ctx, sessionID, skillName); err != nil {
 		slog.Warn("scheduler.fire: runner error",
+			slog.String("session", sessionID),
 			slog.String("error", err.Error()))
 	}
 }

--- a/internal/runtime/telegram/push.go
+++ b/internal/runtime/telegram/push.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"html"
 	"log/slog"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -19,9 +20,15 @@ import (
 	"github.com/pardnchiu/agenvoy/internal/utils"
 )
 
+var brTagRegex = regexp.MustCompile(`(?i)<br\s*/?>`)
+
+func sanitizeHTML(s string) string {
+	return brTagRegex.ReplaceAllString(s, "\n")
+}
+
 func PushTelegramResult(ctx context.Context, payload exec.PushPayload) {
 	id := strings.TrimSpace(payload.SessionID)
-	text := strings.TrimSpace(payload.Text)
+	text := sanitizeHTML(strings.TrimSpace(payload.Text))
 	if id == "" || text == "" || !strings.HasPrefix(id, "tg-") {
 		return
 	}

--- a/internal/runtime/telegram/push.go
+++ b/internal/runtime/telegram/push.go
@@ -36,7 +36,7 @@ func PushTelegramResult(ctx context.Context, payload exec.PushPayload) {
 	chatIDStr, err := sessionManager.GetChatID(id)
 	if err != nil {
 		slog.Warn("github.com/pardnchiu/agenvoy/internal/session GetChatID",
-			slog.String("session_id", id),
+			slog.String("session", id),
 			slog.String("error", err.Error()))
 		return
 	}
@@ -46,6 +46,7 @@ func PushTelegramResult(ctx context.Context, payload exec.PushPayload) {
 	chatID, err := strconv.ParseInt(chatIDStr, 10, 64)
 	if err != nil {
 		slog.Warn("strconv.ParseInt",
+			slog.String("session", id),
 			slog.String("chat_id", chatIDStr),
 			slog.String("error", err.Error()))
 		return
@@ -54,13 +55,14 @@ func PushTelegramResult(ctx context.Context, payload exec.PushPayload) {
 	token := strings.TrimSpace(keychain.Get(Key))
 	if token == "" {
 		slog.Warn("github.com/pardnchiu/go-pkg/filesystem/keychain Get",
-			slog.String("session_id", id),
+			slog.String("session", id),
 			slog.String("key", Key))
 		return
 	}
 	client, err := go_bot_telegram.New(token)
 	if err != nil {
 		slog.Warn("github.com/pardnchiu/go-bot/telegram New",
+			slog.String("session", id),
 			slog.String("error", err.Error()))
 		return
 	}
@@ -76,6 +78,7 @@ func PushTelegramResult(ctx context.Context, payload exec.PushPayload) {
 		for _, chunk := range chunk(message) {
 			if _, err := client.Send(ctx, chatID, 0, chunk, go_bot_telegram.WithSendType(go_bot_telegram.TypeHTML)); err != nil {
 				slog.Warn("github.com/pardnchiu/go-bot/telegram Bot.Send",
+					slog.String("session", id),
 					slog.String("chat", chatName),
 					slog.String("error", err.Error()))
 				break

--- a/internal/runtime/telegram/run.go
+++ b/internal/runtime/telegram/run.go
@@ -244,6 +244,7 @@ func run(ctx context.Context, b *Bot, in go_bot_telegram.Input) error {
 	}
 
 	replyText = strings.TrimSpace(tsPrefixRegex.ReplaceAllString(replyText, ""))
+	replyText = sanitizeHTML(replyText)
 	if replyText == "" {
 		return fmt.Errorf("no reply")
 	}

--- a/internal/runtime/telegram/run.go
+++ b/internal/runtime/telegram/run.go
@@ -225,6 +225,7 @@ func run(ctx context.Context, b *Bot, in go_bot_telegram.Input) error {
 		}
 		if execErr != nil {
 			slog.Warn("exec",
+				slog.String("session", sess.ID),
 				slog.String("error", execErr.Error()))
 		}
 		close(events)
@@ -239,6 +240,7 @@ func run(ctx context.Context, b *Bot, in go_bot_telegram.Input) error {
 
 	if err := b.client.FinishStatus(ctx, in.ChatID); err != nil {
 		slog.Warn("github.com/pardnchiu/go-bot/telegram Bot.client.FinishStatus",
+			slog.String("session", sess.ID),
 			slog.String("chat", chatName(in)),
 			slog.String("error", err.Error()))
 	}
@@ -282,6 +284,7 @@ func run(ctx context.Context, b *Bot, in go_bot_telegram.Input) error {
 		_, sendErr := b.client.Send(ctx, in.ChatID, replyTo, chunk, go_bot_telegram.WithSendType(go_bot_telegram.TypeHTML))
 		if sendErr != nil {
 			slog.Warn("github.com/pardnchiu/go-bot/telegram Bot.client.Send",
+				slog.String("session", sess.ID),
 				slog.String("error", sendErr.Error()))
 			break
 		}
@@ -304,11 +307,13 @@ func run(ctx context.Context, b *Bot, in go_bot_telegram.Input) error {
 		chatID := in.ChatID
 		client := b.client
 		texts := voiceTexts
+		sessID := sess.ID
 		go func() {
 			notifyFailure := func(errMsg string) {
 				text := fmt.Sprintf("⚠️ SendVoice failed (background)\n<code>%s</code>", html.EscapeString(errMsg))
 				if _, err := client.Send(bgCtx, chatID, 0, text, go_bot_telegram.WithSendType(go_bot_telegram.TypeHTML)); err != nil {
 					slog.Error("github.com/pardnchiu/go-bot/telegram Bot.client.Send (notify)",
+						slog.String("session", sessID),
 						slog.String("chat", chat),
 						slog.String("error", err.Error()))
 				}
@@ -316,6 +321,7 @@ func run(ctx context.Context, b *Bot, in go_bot_telegram.Input) error {
 			apiKey := strings.TrimSpace(keychain.Get("GEMINI_API_KEY"))
 			if apiKey == "" {
 				slog.Error("keychain.Get GEMINI_API_KEY missing",
+					slog.String("session", sessID),
 					slog.String("chat", chat))
 				notifyFailure("GEMINI_API_KEY missing")
 				return
@@ -323,6 +329,7 @@ func run(ctx context.Context, b *Bot, in go_bot_telegram.Input) error {
 			for _, text := range texts {
 				if _, err := client.SendVoice(bgCtx, chatID, text, apiKey); err != nil {
 					slog.Error("github.com/pardnchiu/go-bot/telegram Bot.client.SendVoice",
+						slog.String("session", sessID),
 						slog.String("chat", chat),
 						slog.String("error", err.Error()))
 					notifyFailure(err.Error())

--- a/internal/runtime/tui/handlerLogMode.go
+++ b/internal/runtime/tui/handlerLogMode.go
@@ -68,6 +68,7 @@ func newActionTailer(ctx context.Context, sid string) {
 	w, err := fsnotify.NewWatcher()
 	if err != nil {
 		slog.Warn("tail watcher",
+			slog.String("session", sid),
 			slog.String("error", err.Error()))
 		return
 	}
@@ -75,6 +76,7 @@ func newActionTailer(ctx context.Context, sid string) {
 
 	if err := w.Add(dir); err != nil {
 		slog.Warn("tail watch dir",
+			slog.String("session", sid),
 			slog.String("error", err.Error()))
 		return
 	}
@@ -112,6 +114,7 @@ func newActionTailer(ctx context.Context, sid string) {
 				return
 			}
 			slog.Warn("tail watcher error",
+				slog.String("session", sid),
 				slog.String("error", err.Error()))
 		case <-pollTicker.C:
 			lastSize = drainNew(path, lastSize)

--- a/internal/runtime/tui/slog.go
+++ b/internal/runtime/tui/slog.go
@@ -142,11 +142,8 @@ func installSlogTUI(ctx context.Context) func() {
 var subMgrParentCtx = context.Background()
 
 func subscribeSessionLog(sessionID string) {
-	if strings.HasPrefix(sessionID, "cli-") {
-		subMgr.Switch(subMgrParentCtx, "")
-		return
-	}
-	subMgr.Switch(subMgrParentCtx, sessionID)
+	_ = sessionID
+	subMgr.Switch(subMgrParentCtx, "")
 }
 
 func (m *sessionSubMgr) Switch(parent context.Context, sessionID string) {

--- a/internal/session/bot.go
+++ b/internal/session/bot.go
@@ -31,6 +31,7 @@ func SaveBot(sessionID, name string, force bool) {
 	dir := filepath.Join(filesystem.SessionsDir, sessionID)
 	if err := go_pkg_filesystem.CheckDir(dir, true); err != nil {
 		slog.Warn("go_pkg_filesystem.CheckDir",
+			slog.String("session", sessionID),
 			slog.String("error", err.Error()))
 		return
 	}
@@ -43,6 +44,7 @@ func SaveBot(sessionID, name string, force bool) {
 	content := fmt.Sprintf("---\nname: %s\n---\n%s", name, configs.DefaultSessionPrompt)
 	if err := go_pkg_filesystem.WriteFile(path, content, 0644); err != nil {
 		slog.Warn("go_pkg_filesystem.WriteFile",
+			slog.String("session", sessionID),
 			slog.String("error", err.Error()))
 	}
 }

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -30,6 +30,7 @@ func SaveToToolCall(sessionID, content string) {
 		toolActionsPath := filepath.Join(toolCallsDir, filename)
 		if err := go_pkg_filesystem.WriteFile(toolActionsPath, content, 0644); err != nil {
 			slog.Warn("WriteFile",
+				slog.String("session", sessionID),
 				slog.String("error", err.Error()))
 		}
 	}
@@ -202,6 +203,7 @@ func Clean() {
 		if now.Sub(latestModTime(sessionDir)) > time.Hour {
 			if err := os.RemoveAll(sessionDir); err != nil {
 				slog.Warn("Clean",
+					slog.String("session", entry.Name()),
 					slog.String("dir", entry.Name()),
 					slog.String("error", err.Error()))
 			}

--- a/internal/session/status.go
+++ b/internal/session/status.go
@@ -190,6 +190,7 @@ func writeStatus(sessionID string, s Status) {
 	path := filepath.Join(dir, "status.json")
 	if err := go_pkg_filesystem.WriteJSON(path, s, true); err != nil {
 		slog.Warn("go_pkg_filesystem.WriteJSON",
+			slog.String("session", sessionID),
 			slog.String("error", err.Error()))
 	}
 }

--- a/internal/session/summary.go
+++ b/internal/session/summary.go
@@ -39,6 +39,7 @@ func SaveSummaryMeta(sessionID string, lastTime string) {
 	meta := SummaryMeta{LastMessageTime: lastTime}
 	if err := go_pkg_filesystem.WriteJSON(SummaryMetaPath(sessionID), meta, false); err != nil {
 		slog.Warn("WriteJSON summary meta",
+			slog.String("session", sessionID),
 			slog.String("error", err.Error()))
 	}
 }
@@ -53,6 +54,7 @@ func GetSummary(sessionID string) ([]byte, map[string]any) {
 	var summary map[string]any
 	if err := json.Unmarshal(bytes, &summary); err != nil {
 		slog.Warn("json.Unmarshal",
+			slog.String("session", sessionID),
 			slog.String("error", err.Error()))
 		return bytes, nil
 	}
@@ -143,6 +145,7 @@ func IsNeedSummary() []string {
 func SaveSummary(sessionID string, data any) {
 	if err := go_pkg_filesystem.WriteJSON(SummaryPath(sessionID), data, false); err != nil {
 		slog.Warn("WriteJSON",
+			slog.String("session", sessionID),
 			slog.String("error", err.Error()))
 	}
 }

--- a/internal/toolAdapter/api/execute.go
+++ b/internal/toolAdapter/api/execute.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"strings"
 	"sync"
@@ -41,7 +42,7 @@ func (t *Translator) Execute(ctx context.Context, name string, params map[string
 		return "", err
 	}
 
-	result, err := t.send(doc, params)
+	result, err := t.send(ctx, key, doc, params)
 	if err != nil {
 		return "", fmt.Errorf("t.send: %w", err)
 	}
@@ -107,7 +108,7 @@ func (t *Translator) checkRequireds(doc *APIDocumentData, params map[string]any)
 	return nil
 }
 
-func (t *Translator) send(doc *APIDocumentData, params map[string]any) (string, error) {
+func (t *Translator) send(ctx context.Context, key string, doc *APIDocumentData, params map[string]any) (string, error) {
 	var (
 		req *http.Request
 		err error
@@ -134,13 +135,17 @@ func (t *Translator) send(doc *APIDocumentData, params map[string]any) (string, 
 		}
 	}
 
-	timeout := doc.Endpoint.Timeout
-	if timeout <= 0 {
-		timeout = 30
+	timeoutSec := doc.Endpoint.Timeout
+	if timeoutSec <= 0 {
+		timeoutSec = 60
 	}
-	t.client.Timeout = time.Duration(timeout) * time.Second
+	timeout := time.Duration(timeoutSec) * time.Second
 
-	resp, err := t.client.Do(req)
+	reqCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	req = req.WithContext(reqCtx)
+
+	resp, err := t.doWithProgress(reqCtx, "api_"+key, req, timeoutSec)
 	if err != nil {
 		return "", fmt.Errorf("client.Do: %w", err)
 	}
@@ -199,4 +204,34 @@ func (t *Translator) insetAuth(req *http.Request, auth *APIDocumentAuthData) err
 	}
 
 	return nil
+}
+
+type httpResult struct {
+	resp *http.Response
+	err  error
+}
+
+func (t *Translator) doWithProgress(ctx context.Context, name string, req *http.Request, timeoutSec int) (*http.Response, error) {
+	done := make(chan httpResult, 1)
+	go func() {
+		resp, err := t.client.Do(req)
+		done <- httpResult{resp, err}
+	}()
+
+	start := time.Now()
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case r := <-done:
+			return r.resp, r.err
+		case <-ticker.C:
+			slog.Warn("running",
+				slog.String("name", name),
+				slog.String("elapsed", fmt.Sprintf("%ds/%ds", int(time.Since(start).Seconds()), timeoutSec)))
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
 }

--- a/internal/toolAdapter/api/send.go
+++ b/internal/toolAdapter/api/send.go
@@ -40,7 +40,7 @@ func Send(api, method string, headers map[string]string, body map[string]any, co
 	}
 
 	if timeout <= 0 {
-		timeout = 30
+		timeout = 60
 	} else if timeout > 300 {
 		timeout = 300
 	}

--- a/internal/toolAdapter/script/ececute.go
+++ b/internal/toolAdapter/script/ececute.go
@@ -13,6 +13,8 @@ import (
 	go_pkg_sandbox "github.com/pardnchiu/go-pkg/sandbox"
 )
 
+const defaultScriptTimeoutSec = 300
+
 func (t *Translator) Execute(ctx context.Context, name string, args json.RawMessage, workDir string) (string, error) {
 	key := strings.TrimPrefix(name, "script_")
 	data, ok := t.scripts[key]
@@ -30,8 +32,13 @@ func (t *Translator) Execute(ctx context.Context, name string, args json.RawMess
 		input = "{}"
 	}
 
-	// * max 5min with every 30s check
-	execCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	timeoutSec := data.Doc.Timeout
+	if timeoutSec <= 0 {
+		timeoutSec = defaultScriptTimeoutSec
+	}
+	timeout := time.Duration(timeoutSec) * time.Second
+
+	execCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	cmd, err := go_pkg_sandbox.Wrap(execCtx, runtime, []string{data.scriptPath}, workDir, nil)
@@ -65,7 +72,7 @@ func (t *Translator) Execute(ctx context.Context, name string, args json.RawMess
 					return "", fmt.Errorf("script error: %s", strings.TrimSpace(stderr.String()))
 				}
 				if execCtx.Err() == context.DeadlineExceeded {
-					return "", fmt.Errorf("execution timeout: 5m")
+					return "", fmt.Errorf("execution timeout: %s", timeout)
 				}
 				return "", fmt.Errorf("exec: %w", err)
 			}
@@ -74,7 +81,7 @@ func (t *Translator) Execute(ctx context.Context, name string, args json.RawMess
 		case <-ticker.C:
 			slog.Warn("running",
 				slog.String("name", key),
-				slog.String("elapsed", fmt.Sprintf("%ds/300s", int(time.Since(start).Seconds()))))
+				slog.String("elapsed", fmt.Sprintf("%ds/%ds", int(time.Since(start).Seconds()), timeoutSec)))
 		}
 	}
 }

--- a/internal/toolAdapter/script/translator.go
+++ b/internal/toolAdapter/script/translator.go
@@ -26,6 +26,7 @@ type ScriptDoc struct {
 	Name        string          `json:"name"`
 	Description string          `json:"description"`
 	AlwaysAllow bool            `json:"always_allow,omitempty"`
+	Timeout     int             `json:"timeout,omitempty"`
 	Parameters  json.RawMessage `json:"parameters,omitempty"`
 }
 

--- a/internal/tools/agent/external/crossReviewWithExternalAgents.go
+++ b/internal/tools/agent/external/crossReviewWithExternalAgents.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/pardnchiu/agenvoy/internal/agents/external"
 	toolRegister "github.com/pardnchiu/agenvoy/internal/tools/register"
@@ -15,6 +16,7 @@ func registCrossReviewWithExternalAgents() {
 	toolRegister.Regist(toolRegister.Def{
 		Name:        "cross_review_with_external_agents",
 		AlwaysAllow: true,
+		Timeout:     15 * time.Minute,
 		Description: "Fan out a deliverable to all installed external CLIs (codex / copilot / claude / gemini) in parallel for cross-review. Use for multi-model sanity check on non-trivial results.",
 		Parameters: map[string]any{
 			"type": "object",

--- a/internal/tools/agent/external/invokeExternalAgent.go
+++ b/internal/tools/agent/external/invokeExternalAgent.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/pardnchiu/agenvoy/internal/agents/external"
 	toolRegister "github.com/pardnchiu/agenvoy/internal/tools/register"
@@ -16,6 +17,7 @@ func registInvokeExternalAgent() {
 	toolRegister.Regist(toolRegister.Def{
 		Name:        "invoke_external_agent",
 		AlwaysAllow: true,
+		Timeout:     10 * time.Minute,
 		Description: "Invoke one external CLI agent (codex / copilot / claude / gemini) and return its response. Use when the user names an agent or wants a non-Anthropic perspective.",
 		Parameters: map[string]any{
 			"type": "object",

--- a/internal/tools/agent/plan/generatePlan.go
+++ b/internal/tools/agent/plan/generatePlan.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/pardnchiu/agenvoy/internal/agents"
 	"github.com/pardnchiu/agenvoy/internal/agents/exec"
@@ -58,6 +59,7 @@ func registGeneratePlan() {
 		Name:        "generate_plan",
 		AlwaysAllow: true,
 		Concurrent:  false,
+		Timeout:     5 * time.Minute,
 		Description: "Generate a detailed step-by-step execution plan from a requirement description. Use BEFORE starting a multi-step task where the user describes WHAT to achieve but not HOW — pass the requirement, receive a structured plan (需求總結 / 前置條件 / 步驟+驗收 / 整體驗收 / 風險表 / 回退方案), then execute it. This tool only generates the plan text; it never executes or gathers data.",
 		Parameters: map[string]any{
 			"type": "object",

--- a/internal/tools/agent/subagent/invokeSubagent.go
+++ b/internal/tools/agent/subagent/invokeSubagent.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/pardnchiu/agenvoy/internal/agents/exec"
 	sessionManager "github.com/pardnchiu/agenvoy/internal/session"
@@ -26,6 +27,7 @@ func registInvokeSubagent() {
 		Name:        "invoke_subagent",
 		AlwaysAllow: true,
 		Concurrent:  true,
+		Timeout:     time.Duration(exec.SubagentTimeoutMin) * time.Minute,
 		Description: "Spawn an internal subagent in its own session and return its reply. Use to delegate a self-contained subtask. Pass `name` / `session_id` for multi-turn persona threading.",
 		Parameters: map[string]any{
 			"type": "object",

--- a/internal/tools/agent/subagent/invokeSubagent.go
+++ b/internal/tools/agent/subagent/invokeSubagent.go
@@ -97,7 +97,8 @@ func registInvokeSubagent() {
 
 			model := strings.TrimSpace(params.Model)
 			if model != "" && !slices.Contains(models, model) {
-				slog.Warn("invalid model, fallback to auto-select")
+				slog.Warn("invalid model, fallback to auto-select",
+					slog.String("session", sessionID))
 				model = ""
 			}
 

--- a/internal/tools/external/googleRSS/register.go
+++ b/internal/tools/external/googleRSS/register.go
@@ -72,7 +72,8 @@ func Register() {
 			// avoid small agent like 4.1 be stupid to call with not support value
 			timeRange := strings.TrimSpace(params.TimeRange)
 			if timeRange != "" && !slices.Contains(timeRanges, timeRange) {
-				slog.Warn("invalid time_range, fallback to '7d'")
+				slog.Warn("invalid time_range, fallback to '7d'",
+					slog.String("session", e.SessionID))
 				timeRange = "7d"
 			}
 
@@ -80,7 +81,8 @@ func Register() {
 			ceid := strings.TrimSpace(params.CEID)
 			parts := strings.SplitN(ceid, ":", 2)
 			if params.CEID == "" || len(parts) != 2 {
-				slog.Warn("invalid CEID, fallback to 'TW:zh-Hant'")
+				slog.Warn("invalid CEID, fallback to 'TW:zh-Hant'",
+					slog.String("session", e.SessionID))
 				params.CEID = "TW:zh-Hant"
 				geo, lang = "TW", "zh-Hant"
 			} else {

--- a/internal/tools/listLog/register.go
+++ b/internal/tools/listLog/register.go
@@ -1,0 +1,140 @@
+package listLog
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/pardnchiu/agenvoy/internal/filesystem"
+	toolRegister "github.com/pardnchiu/agenvoy/internal/tools/register"
+	toolTypes "github.com/pardnchiu/agenvoy/internal/tools/types"
+)
+
+const tailWindowBytes = int64(1 * 1024 * 1024)
+
+func Register() {
+	toolRegister.Regist(toolRegister.Def{
+		Name:        "list_log",
+		AlwaysAllow: true,
+		Concurrent:  true,
+		Description: "Tail recent daemon log lines for debugging. Use when the user reports unexplained failures (message not delivered, tool errored, daemon-side warning) or when you need to confirm what the daemon actually observed. When the user says 'check errors / recent failures / 看錯誤 / 排錯', default to level='WARN' — most fail-soft conditions (HTTP 4xx, parse errors, send failures, retries) are recorded at WARN; level='ERROR' alone almost always misses the real cause.",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"lines": map[string]any{
+					"type":        "integer",
+					"description": "Trailing line count to return after filtering. Default 50, max 500. Larger windows cost more tokens; start small and re-call with a tighter filter if the answer is not in view.",
+					"default":     50,
+					"minimum":     1,
+					"maximum":     500,
+				},
+				"filter": map[string]any{
+					"type":        "string",
+					"description": "Case-insensitive substring filter applied per line before tailing. Blank returns every line. Pair with a specific identifier (tool name, session id prefix like 'tg-', error keyword) to drop unrelated noise.",
+					"default":     "",
+				},
+				"level": map[string]any{
+					"type":        "string",
+					"description": "Severity threshold. Blank or INFO returns every line; WARN returns WARN+ERROR (recommended default when user is investigating failures — most issues land at WARN); ERROR returns ERROR only (use sparingly, will hide WARN-level send/parse/HTTP errors). Matches both stdlib log format ('YYYY/MM/DD HH:MM:SS LEVEL ...') and slog format ('level=LEVEL').",
+					"default":     "",
+					"enum":        []string{"", "INFO", "WARN", "ERROR"},
+				},
+			},
+		},
+		Handler: handler,
+	})
+}
+
+func handler(_ context.Context, _ *toolTypes.Executor, args json.RawMessage) (string, error) {
+	var params struct {
+		Lines  int    `json:"lines"`
+		Filter string `json:"filter"`
+		Level  string `json:"level"`
+	}
+	if err := json.Unmarshal(args, &params); err != nil {
+		return "", fmt.Errorf("json.Unmarshal: %w", err)
+	}
+	if params.Lines <= 0 {
+		params.Lines = 50
+	}
+	params.Lines = min(params.Lines, 500)
+
+	path := filepath.Join(filesystem.AgenvoyDir, "daemon.log")
+	f, err := os.Open(path)
+	if err != nil {
+		return "", fmt.Errorf("os.Open: %w", err)
+	}
+	defer f.Close()
+
+	st, err := f.Stat()
+	if err != nil {
+		return "", fmt.Errorf("Stat: %w", err)
+	}
+	size := st.Size()
+
+	offset := int64(0)
+	readSize := size
+	if size > tailWindowBytes {
+		offset = size - tailWindowBytes
+		readSize = tailWindowBytes
+	}
+
+	buf := make([]byte, readSize)
+	if readSize > 0 {
+		if _, err := f.ReadAt(buf, offset); err != nil {
+			return "", fmt.Errorf("ReadAt: %w", err)
+		}
+	}
+
+	text := string(buf)
+	if offset > 0 {
+		if i := strings.IndexByte(text, '\n'); i >= 0 {
+			text = text[i+1:]
+		} else {
+			text = ""
+		}
+	}
+
+	filter := strings.ToLower(strings.TrimSpace(params.Filter))
+	level := strings.ToUpper(strings.TrimSpace(params.Level))
+
+	lines := strings.Split(text, "\n")
+	collected := make([]string, 0, params.Lines)
+	for i := len(lines) - 1; i >= 0 && len(collected) < params.Lines; i-- {
+		line := lines[i]
+		if line == "" {
+			continue
+		}
+		if filter != "" && !strings.Contains(strings.ToLower(line), filter) {
+			continue
+		}
+		if !matchLevel(line, level) {
+			continue
+		}
+		collected = append(collected, line)
+	}
+
+	for i, j := 0, len(collected)-1; i < j; i, j = i+1, j-1 {
+		collected[i], collected[j] = collected[j], collected[i]
+	}
+
+	if len(collected) == 0 {
+		return "(no matching lines)", nil
+	}
+	return strings.Join(collected, "\n"), nil
+}
+
+func matchLevel(line, level string) bool {
+	switch level {
+	case "", "INFO":
+		return true
+	case "WARN":
+		return strings.Contains(line, "WARN") || strings.Contains(line, "ERROR")
+	case "ERROR":
+		return strings.Contains(line, "ERROR")
+	}
+	return true
+}

--- a/internal/tools/listLog/register.go
+++ b/internal/tools/listLog/register.go
@@ -33,7 +33,12 @@ func Register() {
 				},
 				"filter": map[string]any{
 					"type":        "string",
-					"description": "Case-insensitive substring filter applied per line before tailing. Blank returns every line. Pair with a specific identifier (tool name, session id prefix like 'tg-', error keyword) to drop unrelated noise.",
+					"description": "Case-insensitive substring filter applied per line before tailing. Blank returns every line. Pair with a specific identifier (tool name, error keyword) to drop unrelated noise.",
+					"default":     "",
+				},
+				"session": map[string]any{
+					"type":        "string",
+					"description": "Restrict to lines tagged with this session id (matches `session=<id>` in slog attrs; case-sensitive). Accepts a full id or a prefix like `tg-` / `dc-` / `cli-` to scope to one channel. Blank disables session filtering. Lines without a session attr never match a non-blank value.",
 					"default":     "",
 				},
 				"level": map[string]any{
@@ -50,9 +55,10 @@ func Register() {
 
 func handler(_ context.Context, _ *toolTypes.Executor, args json.RawMessage) (string, error) {
 	var params struct {
-		Lines  int    `json:"lines"`
-		Filter string `json:"filter"`
-		Level  string `json:"level"`
+		Lines   int    `json:"lines"`
+		Filter  string `json:"filter"`
+		Session string `json:"session"`
+		Level   string `json:"level"`
 	}
 	if err := json.Unmarshal(args, &params); err != nil {
 		return "", fmt.Errorf("json.Unmarshal: %w", err)
@@ -100,12 +106,16 @@ func handler(_ context.Context, _ *toolTypes.Executor, args json.RawMessage) (st
 
 	filter := strings.ToLower(strings.TrimSpace(params.Filter))
 	level := strings.ToUpper(strings.TrimSpace(params.Level))
+	sessionNeedle := strings.TrimSpace(params.Session)
 
 	lines := strings.Split(text, "\n")
 	collected := make([]string, 0, params.Lines)
 	for i := len(lines) - 1; i >= 0 && len(collected) < params.Lines; i-- {
 		line := lines[i]
 		if line == "" {
+			continue
+		}
+		if sessionNeedle != "" && !strings.Contains(line, "session="+sessionNeedle) {
 			continue
 		}
 		if filter != "" && !strings.Contains(strings.ToLower(line), filter) {

--- a/internal/tools/register.go
+++ b/internal/tools/register.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pardnchiu/agenvoy/internal/tools/errorMemory"
 	"github.com/pardnchiu/agenvoy/internal/tools/external"
 	"github.com/pardnchiu/agenvoy/internal/tools/file"
+	"github.com/pardnchiu/agenvoy/internal/tools/listLog"
 	toolRegister "github.com/pardnchiu/agenvoy/internal/tools/register"
 	toolScheduler "github.com/pardnchiu/agenvoy/internal/tools/scheduler"
 	toolSearcher "github.com/pardnchiu/agenvoy/internal/tools/searcher"
@@ -27,6 +28,7 @@ func init() {
 	fetchPage.Register()
 	file.Register()
 	errorMemory.Register()
+	listLog.Register()
 	toolScheduler.Register()
 	toolSearcher.Register()
 

--- a/internal/tools/register/register.go
+++ b/internal/tools/register/register.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
 
 	toolTypes "github.com/pardnchiu/agenvoy/internal/tools/types"
 )
@@ -14,14 +15,17 @@ type Handler func(ctx context.Context, e *toolTypes.Executor, args json.RawMessa
 
 type GroupHandler func(ctx context.Context, e *toolTypes.Executor, name string, args json.RawMessage) (string, error)
 
+const DefaultToolTimeout = time.Minute
+
 type Def struct {
 	Name        string
 	Description string
 	Parameters  map[string]any
 	Handler     Handler
-	AlwaysAllow    bool
+	AlwaysAllow bool
 	AlwaysLoad  bool
 	Concurrent  bool
+	Timeout     time.Duration
 }
 
 var handlerMap = map[string]Handler{}
@@ -30,6 +34,7 @@ var defList []toolTypes.Tool
 var readOnlySet = map[string]bool{}
 var alwaysLoadSet = map[string]bool{}
 var concurrentSet = map[string]bool{}
+var timeoutMap = map[string]time.Duration{}
 
 func Regist(d Def) {
 	d.Name = strings.TrimSpace(d.Name)
@@ -63,6 +68,16 @@ func Regist(d Def) {
 	if d.Concurrent {
 		concurrentSet[d.Name] = true
 	}
+	if d.Timeout > 0 {
+		timeoutMap[d.Name] = d.Timeout
+	}
+}
+
+func GetTimeout(name string) time.Duration {
+	if t, ok := timeoutMap[name]; ok {
+		return t
+	}
+	return DefaultToolTimeout
 }
 
 func IsAlwaysLoad(name string) bool {
@@ -94,14 +109,26 @@ func JSON() []byte {
 }
 
 func Dispatch(ctx context.Context, e *toolTypes.Executor, name string, args json.RawMessage) (string, error) {
+	timeout := GetTimeout(name)
+	tctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
 	handler, ok := handlerMap[name]
 	if ok {
-		return handler(ctx, e, args)
+		result, err := handler(tctx, e, args)
+		if tctx.Err() == context.DeadlineExceeded {
+			return result, fmt.Errorf("tool %q timed out after %s", name, timeout)
+		}
+		return result, err
 	}
 
 	for prefix, handler := range groupHandlerMap {
 		if strings.HasPrefix(name, prefix) {
-			return handler(ctx, e, name, args)
+			result, err := handler(tctx, e, name, args)
+			if tctx.Err() == context.DeadlineExceeded {
+				return result, fmt.Errorf("tool %q timed out after %s", name, timeout)
+			}
+			return result, err
 		}
 	}
 


### PR DESCRIPTION
Splits provider HTTP timeouts into header- and body-level limits so stuck upstreams bail quickly instead of silently looping until the full body deadline. Surfaces retry status and exhausted failures back to the user, and mirrors that visibility into long-running tools via periodic progress logs. Adds a daemon log tail tool, tags warnings with their originating session, and makes script execution caps configurable per tool.
