### PR TITLE
Enhance agent fallback and OAuth error handling with credential checks

### DIFF
--- a/configs/prompts/agent_selector.md
+++ b/configs/prompts/agent_selector.md
@@ -1,7 +1,7 @@
 You are an AGENT Selector.
 Given a user request and a list of available agents (JSON array, each with `name` and `description`), select the most suitable agent.
 
-**Critical: output must exactly match one of the `name` values in the available list. Never invent a name. No explanation. No additional text. No markdown. No prefix or suffix. Output exactly one bare name string.**
+**Critical: output a comma-separated list of `name` values in preference order (best first). Each name must exactly match one entry in the available list. Never invent names. No explanation. No additional text. No markdown. No quotes. No prefix or suffix. Example: `codex@gpt-5.4,claude@sonnet-4.6,copilot@gpt-4.1`. If only one candidate fits, output just that single name.**
 
 ## Naming Conventions
 
@@ -59,11 +59,11 @@ Chain order is pure priority — leftmost is most preferred, rightmost is least 
 
 ### P2: Fallback
 
-None of the above matched → return the first `name` in the available list.
+None of the above matched → return all `name` values in the available list, in their given order (still comma-separated).
 
 ## Hard Constraints
 
-- Output is a bare agent name only — no quotes, no markdown, no JSON, no commentary, no "I selected" preamble.
+- Output is a bare comma-separated list of agent names only — no quotes, no markdown, no JSON, no commentary, no "I selected" preamble.
 - Never invent agent names. If no node matches the available list, fall to P2.
 - When two nodes have equal applicability and both have available variants, the leftmost in the chain wins.
 - The Version Axis applies after node selection — first pick the node, then within that node pick the newest version.

--- a/internal/agents/exec/execute.go
+++ b/internal/agents/exec/execute.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	go_pkg_keychain "github.com/pardnchiu/go-pkg/filesystem/keychain"
 	go_pkg_filesystem_reader "github.com/pardnchiu/go-pkg/filesystem/reader"
 	go_pkg_utils "github.com/pardnchiu/go-pkg/utils"
 
@@ -242,6 +243,22 @@ func Execute(ctx context.Context, data ExecData, session *agentTypes.AgentSessio
 	if !go_pkg_filesystem_reader.Exists(filesystem.KuradbEndpointPath) {
 		data.ExcludeTools = append(data.ExcludeTools,
 			"rag_list_db", "rag_search_keyword", "rag_search_semantic")
+	}
+	if go_pkg_keychain.Get("agenvoy.codex.token") == "" {
+		data.ExcludeTools = append(data.ExcludeTools, "generate_image")
+	}
+	if go_pkg_keychain.Get("GEMINI_API_KEY") == "" {
+		data.ExcludeTools = append(data.ExcludeTools,
+			"fetch_youtube_transcript", "transcribe_media")
+	}
+	cfg, _ := sessionManager.Load()
+	if cfg == nil || !cfg.TelegramEnabled || go_pkg_keychain.Get("TELEGRAM_TOKEN") == "" {
+		data.ExcludeTools = append(data.ExcludeTools,
+			"telegram_format", "list_telegram_chat", "send_to_telegram_chat")
+	}
+	if cfg == nil || !cfg.DiscordEnabled || go_pkg_keychain.Get("DISCORD_TOKEN") == "" {
+		data.ExcludeTools = append(data.ExcludeTools,
+			"discord_format", "list_discord_channel", "send_to_discord_channel")
 	}
 
 	if len(data.ExcludeTools) > 0 {

--- a/internal/agents/exec/execute.go
+++ b/internal/agents/exec/execute.go
@@ -112,6 +112,7 @@ func hashPayload(parts ...any) string {
 
 type ExecData struct {
 	Agent             agentTypes.Agent
+	FallbackAgents    []agentTypes.Agent
 	WorkDir           string
 	Skill             *filesystem.Skill
 	SkillScanner      *runtime.SkillScanner
@@ -331,10 +332,46 @@ func Execute(ctx context.Context, data ExecData, session *agentTypes.AgentSessio
 			}
 			modelName := data.Agent.Name()
 			if sendFailCount >= MaxRetry {
+				var nextAgent agentTypes.Agent
+				var nextName string
+				if !isContextLengthError(err) {
+					for len(data.FallbackAgents) > 0 {
+						cand := data.FallbackAgents[0]
+						data.FallbackAgents = data.FallbackAgents[1:]
+						if cand == nil {
+							continue
+						}
+						if !ProbeAgent(ctx, cand, ProbeTimeout) {
+							slog.Warn("fallback probe failed",
+								slog.String("session", session.ID),
+								slog.String("name", cand.Name()))
+							continue
+						}
+						nextAgent = cand
+						nextName = cand.Name()
+						break
+					}
+				}
+				if nextAgent != nil {
+					slog.Warn("data.Agent.Send exhausted, switching model",
+						slog.String("session", session.ID),
+						slog.String("from", modelName),
+						slog.String("to", nextName),
+						slog.Int("attempts", sendFailCount))
+					events <- agentTypes.Event{
+						Type:  agentTypes.EventAgentResult,
+						Text:  nextName,
+						Model: nextName,
+					}
+					data.Agent = nextAgent
+					sendFailCount = 0
+					lastSendSig = ""
+					continue
+				}
 				var userMsg string
 				switch {
 				case isTimeout:
-					userMsg = fmt.Sprintf("upstream %s timed out %d times in a row (last attempt bailed at %s). Try again later or switch model.", modelName, sendFailCount, sendElapsed)
+					userMsg = fmt.Sprintf("upstream %s timed out %d times in a row (last attempt bailed at %s). No fallback model available.", modelName, sendFailCount, sendElapsed)
 				case isContextLengthError(err):
 					userMsg = fmt.Sprintf("upstream %s context exceeded after %d trim attempts. Start a new session or switch to a larger-context model.", modelName, sendFailCount)
 				default:

--- a/internal/agents/exec/run.go
+++ b/internal/agents/exec/run.go
@@ -68,6 +68,9 @@ func Run(ctx context.Context, bot agentTypes.Agent, registry agentTypes.AgentReg
 		}
 	} else {
 		agent = SelectAgent(ctx, bot, registry, trimInput, matchedSkill != nil, sessionOverride)
+		if agent == nil {
+			return fmt.Errorf("no agent available; run `agen model add` to authenticate at least one provider")
+		}
 		agentResult = agentTypes.Event{
 			Type: agentTypes.EventAgentResult,
 			Text: strings.TrimSpace(agent.Name()),

--- a/internal/agents/exec/run.go
+++ b/internal/agents/exec/run.go
@@ -60,6 +60,7 @@ func Run(ctx context.Context, bot agentTypes.Agent, registry agentTypes.AgentReg
 	}
 
 	var agent agentTypes.Agent
+	var fallbacks []agentTypes.Agent
 	var agentResult agentTypes.Event
 	if externalAgent != "" {
 		agentResult = agentTypes.Event{
@@ -67,10 +68,12 @@ func Run(ctx context.Context, bot agentTypes.Agent, registry agentTypes.AgentReg
 			Text: "external:" + externalAgent,
 		}
 	} else {
-		agent = SelectAgent(ctx, bot, registry, trimInput, matchedSkill != nil, sessionOverride)
-		if agent == nil {
-			return fmt.Errorf("no agent available; run `agen model add` to authenticate at least one provider")
+		primary, rest, err := ResolveAgent(ctx, bot, registry, trimInput, matchedSkill != nil, sessionOverride)
+		if err != nil {
+			return fmt.Errorf("ResolveAgent: %w", err)
 		}
+		agent = primary
+		fallbacks = rest
 		agentResult = agentTypes.Event{
 			Type: agentTypes.EventAgentResult,
 			Text: strings.TrimSpace(agent.Name()),
@@ -79,15 +82,16 @@ func Run(ctx context.Context, bot agentTypes.Agent, registry agentTypes.AgentReg
 	events <- agentResult
 
 	execData := ExecData{
-		Agent:       agent,
-		WorkDir:     workDir,
-		Skill:       matchedSkill,
-		Content:     trimInput,
-		SessionID:   sessionOverride,
-		ImageInputs: imageInputs,
-		FileInputs:  fileInputs,
-		AllowAll:    allowAll,
-		WebMode:     webMode,
+		Agent:          agent,
+		FallbackAgents: fallbacks,
+		WorkDir:        workDir,
+		Skill:          matchedSkill,
+		Content:        trimInput,
+		SessionID:      sessionOverride,
+		ImageInputs:    imageInputs,
+		FileInputs:     fileInputs,
+		AllowAll:       allowAll,
+		WebMode:        webMode,
 	}
 	session, err := GetSession(execData)
 	if err != nil {

--- a/internal/agents/exec/selectAgent.go
+++ b/internal/agents/exec/selectAgent.go
@@ -5,7 +5,9 @@ import (
 	_ "embed"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"strings"
+	"time"
 
 	go_pkg_filesystem "github.com/pardnchiu/go-pkg/filesystem"
 
@@ -14,6 +16,11 @@ import (
 	agentTypes "github.com/pardnchiu/agenvoy/internal/agents/types"
 	"github.com/pardnchiu/agenvoy/internal/filesystem"
 	sessionManager "github.com/pardnchiu/agenvoy/internal/session"
+)
+
+const (
+	ProbeTimeout          = 5 * time.Second
+	DispatcherCallTimeout = 10 * time.Second
 )
 
 type AgentConfig struct {
@@ -41,8 +48,8 @@ func GetAgent() []agentTypes.AgentEntry {
 	return cfg.Models
 }
 
-func SelectAgent(ctx context.Context, bot agentTypes.Agent, registry agentTypes.AgentRegistry, userInput string, hasSkill bool, sessionID string) agentTypes.Agent {
-	trimInput := strings.TrimSpace(userInput)
+func SelectAgentNames(ctx context.Context, bot agentTypes.Agent, registry agentTypes.AgentRegistry, userInput string, hasSkill bool, sessionID string) ([]string, map[string]bool) {
+	dead := map[string]bool{}
 
 	if sessionID != "" {
 		s := sessionManager.ReadStatus(sessionID)
@@ -50,61 +57,131 @@ func SelectAgent(ctx context.Context, bot agentTypes.Agent, registry agentTypes.
 			provider.SetReasoningLevel(s.Reasoning)
 		}
 		if s.Model != "" && s.Model != sessionManager.StatusModel {
-			if a, ok := registry.Registry[s.Model]; ok {
-				return a
+			if _, ok := registry.Registry[s.Model]; ok {
+				return []string{s.Model}, dead
 			}
 		}
 	}
 
-	if len(registry.Entries) == 0 || bot == nil {
-		return registry.Fallback
+	if len(registry.Entries) == 0 {
+		return nil, dead
 	}
 
-	agentMap := make(map[string]struct{}, len(registry.Entries))
-	for _, a := range registry.Entries {
-		agentMap[a.Name] = struct{}{}
+	registryOrder := make([]string, 0, len(registry.Entries))
+	known := make(map[string]struct{}, len(registry.Entries))
+	for _, e := range registry.Entries {
+		registryOrder = append(registryOrder, e.Name)
+		known[e.Name] = struct{}{}
 	}
 
-	agentJson, err := json.Marshal(registry.Entries)
-	if err != nil {
-		return registry.Fallback
-	}
+	picked := []string{}
+	seen := map[string]bool{}
 
-	userContent := strings.TrimSpace(trimInput)
-	if hasSkill {
-		userContent = "[Run Skill] " + userContent
-	}
-
-	messages := []agentTypes.Message{
-		{
-			Role:    "system",
-			Content: strings.TrimSpace(configs.AgentSelector),
-		},
-		{
-			Role:    "user",
-			Content: fmt.Sprintf("Available agents:\n%s\nUser request: %s", string(agentJson), userContent),
-		},
-	}
-
-	resp, err := bot.Send(ctx, messages, nil)
-	if err != nil || len(resp.Choices) == 0 {
-		return registry.Fallback
-	}
-
-	answer := ""
-	if content, ok := resp.Choices[0].Message.Content.(string); ok {
-		answer = strings.Trim(strings.TrimSpace(content), "\"'` \n")
-	}
-
-	if answer == "NONE" || answer == "" {
-		return registry.Fallback
-	}
-
-	if _, ok := agentMap[answer]; ok {
-		if a, ok := registry.Registry[answer]; ok {
-			return a
+	if bot != nil {
+		agentJson, err := json.Marshal(registry.Entries)
+		if err == nil {
+			userContent := strings.TrimSpace(userInput)
+			if hasSkill {
+				userContent = "[Run Skill] " + userContent
+			}
+			messages := []agentTypes.Message{
+				{Role: "system", Content: strings.TrimSpace(configs.AgentSelector)},
+				{Role: "user", Content: fmt.Sprintf("Available agents:\n%s\nUser request: %s", string(agentJson), userContent)},
+			}
+			routingCtx, cancel := context.WithTimeout(ctx, DispatcherCallTimeout)
+			resp, sendErr := bot.Send(routingCtx, messages, nil)
+			cancel()
+			if sendErr == nil && len(resp.Choices) > 0 {
+				if content, ok := resp.Choices[0].Message.Content.(string); ok {
+					raw := strings.Trim(strings.TrimSpace(content), "\"'` \n")
+					if raw != "" && raw != "NONE" {
+						for n := range strings.SplitSeq(raw, ",") {
+							n = strings.Trim(strings.TrimSpace(n), "\"'`")
+							if n == "" || seen[n] {
+								continue
+							}
+							if _, ok := known[n]; !ok {
+								continue
+							}
+							picked = append(picked, n)
+							seen[n] = true
+						}
+					}
+				}
+			} else if sendErr != nil {
+				dead[bot.Name()] = true
+				slog.Warn("dispatcher routing failed, falling back to registry order",
+					slog.String("name", bot.Name()),
+					slog.String("error", sendErr.Error()))
+			}
 		}
 	}
 
+	for _, n := range registryOrder {
+		if seen[n] || dead[n] {
+			continue
+		}
+		picked = append(picked, n)
+		seen[n] = true
+	}
+	return picked, dead
+}
+
+func SelectAgent(ctx context.Context, bot agentTypes.Agent, registry agentTypes.AgentRegistry, userInput string, hasSkill bool, sessionID string) agentTypes.Agent {
+	names, dead := SelectAgentNames(ctx, bot, registry, userInput, hasSkill, sessionID)
+	for _, n := range names {
+		if dead[n] {
+			continue
+		}
+		if a, ok := registry.Registry[n]; ok && a != nil {
+			return a
+		}
+	}
 	return registry.Fallback
+}
+
+func ProbeAgent(ctx context.Context, a agentTypes.Agent, timeout time.Duration) bool {
+	if a == nil {
+		return false
+	}
+	probeCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	_, err := a.Send(probeCtx, []agentTypes.Message{{Role: "user", Content: "."}}, nil)
+	return err == nil
+}
+
+func ResolveAgent(ctx context.Context, bot agentTypes.Agent, registry agentTypes.AgentRegistry, userInput string, hasSkill bool, sessionID string) (agentTypes.Agent, []agentTypes.Agent, error) {
+	names, dead := SelectAgentNames(ctx, bot, registry, userInput, hasSkill, sessionID)
+	if len(names) == 0 {
+		return nil, nil, fmt.Errorf("no agents available")
+	}
+	candidates := make([]agentTypes.Agent, 0, len(names))
+	for _, n := range names {
+		if dead[n] {
+			continue
+		}
+		if a, ok := registry.Registry[n]; ok && a != nil {
+			candidates = append(candidates, a)
+		}
+	}
+	if len(candidates) == 0 {
+		return nil, nil, fmt.Errorf("no resolvable agents from %d names (dead: %d)", len(names), len(dead))
+	}
+	for i, a := range candidates {
+		if ProbeAgent(ctx, a, ProbeTimeout) {
+			rest := make([]agentTypes.Agent, 0, len(candidates)-i-1)
+			for _, b := range candidates[i+1:] {
+				if dead[b.Name()] {
+					continue
+				}
+				rest = append(rest, b)
+			}
+			return a, rest, nil
+		}
+		dead[a.Name()] = true
+		slog.Warn("agent probe failed",
+			slog.String("name", a.Name()),
+			slog.Duration("timeout", ProbeTimeout))
+	}
+	return nil, nil, fmt.Errorf("all %d candidates failed probe", len(candidates))
 }

--- a/internal/agents/exec/selectAgent.go
+++ b/internal/agents/exec/selectAgent.go
@@ -56,7 +56,7 @@ func SelectAgent(ctx context.Context, bot agentTypes.Agent, registry agentTypes.
 		}
 	}
 
-	if len(registry.Entries) == 0 {
+	if len(registry.Entries) == 0 || bot == nil {
 		return registry.Fallback
 	}
 

--- a/internal/agents/provider/gemini/stt/register.go
+++ b/internal/agents/provider/gemini/stt/register.go
@@ -7,16 +7,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pardnchiu/go-pkg/filesystem/keychain"
-
 	toolRegister "github.com/pardnchiu/agenvoy/internal/tools/register"
 	toolTypes "github.com/pardnchiu/agenvoy/internal/tools/types"
 )
 
 func Register() {
-	if strings.TrimSpace(keychain.Get("GEMINI_API_KEY")) == "" {
-		return
-	}
 
 	toolRegister.Regist(toolRegister.Def{
 		Name:        "transcribe_media",

--- a/internal/agents/provider/gemini/youtube/register.go
+++ b/internal/agents/provider/gemini/youtube/register.go
@@ -7,16 +7,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pardnchiu/go-pkg/filesystem/keychain"
-
 	toolRegister "github.com/pardnchiu/agenvoy/internal/tools/register"
 	toolTypes "github.com/pardnchiu/agenvoy/internal/tools/types"
 )
 
 func Register() {
-	if strings.TrimSpace(keychain.Get("GEMINI_API_KEY")) == "" {
-		return
-	}
 
 	toolRegister.Regist(toolRegister.Def{
 		Name:        "fetch_youtube_transcript",

--- a/internal/agents/provider/openaiCodex/image2/register.go
+++ b/internal/agents/provider/openaiCodex/image2/register.go
@@ -3,14 +3,10 @@ package image2
 import (
 	"time"
 
-	openaicodex "github.com/pardnchiu/agenvoy/internal/agents/provider/openaiCodex"
 	toolRegister "github.com/pardnchiu/agenvoy/internal/tools/register"
 )
 
 func Register() {
-	if !openaicodex.HasToken() {
-		return
-	}
 
 	toolRegister.Regist(toolRegister.Def{
 		Name:        "generate_image",

--- a/internal/agents/provider/openaiCodex/login.go
+++ b/internal/agents/provider/openaiCodex/login.go
@@ -86,8 +86,8 @@ func (a *Agent) exchangeCode(ctx context.Context, code, verifier, redirect strin
 	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
 		return nil, fmt.Errorf("json.Decode: %w", err)
 	}
-	if raw.Error != "" {
-		return nil, fmt.Errorf("token error %s: %s", raw.Error, raw.ErrorDesc)
+	if raw.Error != nil {
+		return nil, fmt.Errorf("token error %v: %v", raw.Error, raw.ErrorDesc)
 	}
 
 	expiry := time.Now().Add(time.Duration(raw.ExpiresIn) * time.Second)

--- a/internal/agents/provider/openaiCodex/refresh.go
+++ b/internal/agents/provider/openaiCodex/refresh.go
@@ -47,8 +47,8 @@ func (a *Agent) refreshToken(ctx context.Context) error {
 	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
 		return fmt.Errorf("json.Decode: %w", err)
 	}
-	if raw.Error != "" {
-		return fmt.Errorf("refresh error %s: %s", raw.Error, raw.ErrorDesc)
+	if raw.Error != nil {
+		return fmt.Errorf("refresh error %v: %v", raw.Error, raw.ErrorDesc)
 	}
 
 	expiry := time.Now().Add(time.Duration(raw.ExpiresIn) * time.Second)

--- a/internal/agents/provider/openaiCodex/type.go
+++ b/internal/agents/provider/openaiCodex/type.go
@@ -29,6 +29,8 @@ type oauthTokenResponse struct {
 	IDToken      string `json:"id_token"`
 	ExpiresIn    int    `json:"expires_in"`
 	TokenType    string `json:"token_type"`
-	Error        string `json:"error,omitempty"`
-	ErrorDesc    string `json:"error_description,omitempty"`
+	// * Error / ErrorDesc are `any` because OpenAI's token endpoint switched
+	// * `error` from string to object (e.g. {"code":"...","message":"..."}).
+	Error     any `json:"error,omitempty"`
+	ErrorDesc any `json:"error_description,omitempty"`
 }

--- a/internal/routes/handler/chatCompletions/run.go
+++ b/internal/routes/handler/chatCompletions/run.go
@@ -46,6 +46,7 @@ func run(ctx context.Context, req Request, sessionID, userContent string, events
 	events <- agentTypes.Event{Type: agentTypes.EventAgentSelect}
 
 	var agent agentTypes.Agent
+	var fallbacks []agentTypes.Agent
 	var agentResult agentTypes.Event
 	registry := agents.Registry()
 	if externalAgent != "" {
@@ -53,7 +54,13 @@ func run(ctx context.Context, req Request, sessionID, userContent string, events
 	} else {
 		switch {
 		case req.Model == "" || req.Model == "auto":
-			agent = exec.SelectAgent(ctx, agents.Dispatcher(), registry, trimContent, matchedSkill != nil, sessionID)
+			primary, rest, err := exec.ResolveAgent(ctx, agents.Dispatcher(), registry, trimContent, matchedSkill != nil, sessionID)
+			if err != nil {
+				events <- agentTypes.Event{Type: agentTypes.EventError, Err: err}
+				return
+			}
+			agent = primary
+			fallbacks = rest
 
 		default:
 			a, ok := registry.Registry[req.Model]
@@ -73,12 +80,13 @@ func run(ctx context.Context, req Request, sessionID, userContent string, events
 		workDir, _ = os.UserHomeDir()
 	}
 	data := exec.ExecData{
-		Agent:     agent,
-		WorkDir:   workDir,
-		Skill:     matchedSkill,
-		Content:   trimContent,
-		SessionID: sessionID,
-		AllowAll:  true,
+		Agent:          agent,
+		FallbackAgents: fallbacks,
+		WorkDir:        workDir,
+		Skill:          matchedSkill,
+		Content:        trimContent,
+		SessionID:      sessionID,
+		AllowAll:       true,
 	}
 
 	sessionManager.SaveBot(sessionID, sessionID, false)

--- a/internal/routes/handler/send.go
+++ b/internal/routes/handler/send.go
@@ -89,6 +89,7 @@ func Send() gin.HandlerFunc {
 
 			wrapped <- agentTypes.Event{Type: agentTypes.EventAgentSelect}
 			var agent agentTypes.Agent
+			var fallbacks []agentTypes.Agent
 			var agentResult agentTypes.Event
 			if externalAgent != "" {
 				agentResult = agentTypes.Event{Type: agentTypes.EventAgentResult, Text: "external:" + externalAgent}
@@ -100,7 +101,13 @@ func Send() gin.HandlerFunc {
 					}
 				}
 				if agent == nil {
-					agent = exec.SelectAgent(ctx, agents.Dispatcher(), registry, trimContent, false, sessionID)
+					primary, rest, err := exec.ResolveAgent(ctx, agents.Dispatcher(), registry, trimContent, false, sessionID)
+					if err != nil {
+						wrapped <- agentTypes.Event{Type: agentTypes.EventError, Err: err}
+						return
+					}
+					agent = primary
+					fallbacks = rest
 				}
 				agentResult = agentTypes.Event{Type: agentTypes.EventAgentResult, Text: agent.Name()}
 			}
@@ -112,6 +119,7 @@ func Send() gin.HandlerFunc {
 			workDir, _ := os.UserHomeDir()
 			data := exec.ExecData{
 				Agent:             agent,
+				FallbackAgents:    fallbacks,
 				WorkDir:           workDir,
 				Skill:             matchedSkill,
 				Content:           trimContent,

--- a/internal/runtime/discord/run.go
+++ b/internal/runtime/discord/run.go
@@ -166,16 +166,23 @@ func run(ctx context.Context, b *Bot, in go_bot_discord.Input) error {
 	}
 
 	var agent agentTypes.Agent
+	var fallbacks []agentTypes.Agent
 	if externalAgent == "" {
-		agent = exec.SelectAgent(ctx, agents.Dispatcher(), agents.Registry(), content, matchedSkill != nil, "")
+		primary, rest, err := exec.ResolveAgent(ctx, agents.Dispatcher(), agents.Registry(), content, matchedSkill != nil, "")
+		if err != nil {
+			return fmt.Errorf("ResolveAgent: %w", err)
+		}
+		agent = primary
+		fallbacks = rest
 	}
 
 	execData := exec.ExecData{
-		Agent:    agent,
-		WorkDir:  workDir,
-		Skill:    matchedSkill,
-		Content:  content,
-		AllowAll: false,
+		Agent:          agent,
+		FallbackAgents: fallbacks,
+		WorkDir:        workDir,
+		Skill:          matchedSkill,
+		Content:        content,
+		AllowAll:       false,
 	}
 
 	sess, err := getSession(in, content, execData)

--- a/internal/runtime/discord/tool/register.go
+++ b/internal/runtime/discord/tool/register.go
@@ -1,22 +1,6 @@
 package tool
 
-import (
-	"strings"
-
-	"github.com/pardnchiu/go-pkg/filesystem/keychain"
-
-	"github.com/pardnchiu/agenvoy/internal/runtime/discord"
-	"github.com/pardnchiu/agenvoy/internal/session"
-)
-
 func Register() {
-	cfg, err := session.Load()
-	if err != nil || cfg == nil || !cfg.DiscordEnabled {
-		return
-	}
-	if strings.TrimSpace(keychain.Get(discord.Key)) == "" {
-		return
-	}
 	registDiscordFormat()
 	registListDiscordChannel()
 	registSendToDiscordChannel()

--- a/internal/runtime/telegram/run.go
+++ b/internal/runtime/telegram/run.go
@@ -196,16 +196,23 @@ func run(ctx context.Context, b *Bot, in go_bot_telegram.Input) error {
 	}
 
 	var agent agentTypes.Agent
+	var fallbacks []agentTypes.Agent
 	if externalAgent == "" {
-		agent = exec.SelectAgent(ctx, agents.Dispatcher(), agents.Registry(), content, matchedSkill != nil, "")
+		primary, rest, err := exec.ResolveAgent(ctx, agents.Dispatcher(), agents.Registry(), content, matchedSkill != nil, "")
+		if err != nil {
+			return fmt.Errorf("ResolveAgent: %w", err)
+		}
+		agent = primary
+		fallbacks = rest
 	}
 
 	execData := exec.ExecData{
-		Agent:    agent,
-		WorkDir:  workDir,
-		Skill:    matchedSkill,
-		Content:  content,
-		AllowAll: false,
+		Agent:          agent,
+		FallbackAgents: fallbacks,
+		WorkDir:        workDir,
+		Skill:          matchedSkill,
+		Content:        content,
+		AllowAll:       false,
 	}
 
 	sess, err := getSession(in.ChatID, in.Username, content, execData, sessionOverride, sessionMissing)

--- a/internal/runtime/telegram/tool/register.go
+++ b/internal/runtime/telegram/tool/register.go
@@ -1,22 +1,6 @@
 package tool
 
-import (
-	"strings"
-
-	"github.com/pardnchiu/go-pkg/filesystem/keychain"
-
-	"github.com/pardnchiu/agenvoy/internal/runtime/telegram"
-	"github.com/pardnchiu/agenvoy/internal/session"
-)
-
 func Register() {
-	cfg, err := session.Load()
-	if err != nil || cfg == nil || !cfg.TelegramEnabled {
-		return
-	}
-	if strings.TrimSpace(keychain.Get(telegram.Key)) == "" {
-		return
-	}
 	registTelegramFormat()
 	registListTelegramChat()
 	registSendToTelegramChat()

--- a/internal/runtime/tui/cmdSelector.go
+++ b/internal/runtime/tui/cmdSelector.go
@@ -132,7 +132,7 @@ func getCmdSelectorItems(query, sessionID string) []CmdSelectorItem {
 			if scanner.Skills != nil {
 				if sk := scanner.Skills.ByName[name]; sk != nil {
 					source = skillSource(sk.AbsPath)
-					description = sk.Description
+					description = strings.Join(strings.Fields(sk.Description), " ")
 				}
 			}
 			desc := description

--- a/internal/runtime/tui/tui.go
+++ b/internal/runtime/tui/tui.go
@@ -37,7 +37,7 @@ type WorkDir struct {
 }
 
 func Run(ctx context.Context) error {
-	prog := tea.NewProgram(newModel(ctx), tea.WithContext(ctx))
+	prog := tea.NewProgram(newModel(ctx), tea.WithContext(ctx), tea.WithoutSignalHandler())
 	program.Store(prog)
 	defer program.Store(nil)
 

--- a/internal/runtime/tui/update.go
+++ b/internal/runtime/tui/update.go
@@ -45,10 +45,7 @@ func (t TUI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyMsg:
 		switch msg.Type {
 		case tea.KeyCtrlC:
-			return t, tea.Sequence(
-				tea.Println(hintStyle.Render("⎯ exit")+"\n"),
-				tea.Quit,
-			)
+			return t, nil
 
 		case tea.KeyEsc:
 			if t.selector != nil {


### PR DESCRIPTION
Agent selection switches from a single-name pick to a prioritized chain so the runtime cascades to the next candidate when a provider call fails mid-turn. Optional provider tools always register at startup and are hidden per-turn based on credential presence, keeping the toolset coherent as keys come and go. Closes a nil-agent crash path and a Codex OAuth error decode bug.
