### PR TITLE
Add agent fallback handling and denied-path tracking for file tools

### DIFF
--- a/internal/agents/exec/selectAgent.go
+++ b/internal/agents/exec/selectAgent.go
@@ -49,7 +49,7 @@ func GetAgent() []agentTypes.AgentEntry {
 	return cfg.Models
 }
 
-func SelectAgentNames(ctx context.Context, bot agentTypes.Agent, registry agentTypes.AgentRegistry, userInput string, hasSkill bool, sessionID string) ([]string, map[string]bool, error) {
+func SelectAgentNames(ctx context.Context, bot agentTypes.Agent, registry agentTypes.AgentRegistry, userInput string, hasSkill bool, sessionID string) ([]string, map[string]bool) {
 	dead := map[string]bool{}
 
 	if sessionID != "" {
@@ -59,13 +59,17 @@ func SelectAgentNames(ctx context.Context, bot agentTypes.Agent, registry agentT
 		}
 		if s.Model != "" && s.Model != sessionManager.StatusModel {
 			if _, ok := registry.Registry[s.Model]; ok {
-				return []string{s.Model}, dead, nil
+				return []string{s.Model}, dead
 			}
 		}
 	}
 
 	if len(registry.Entries) == 0 {
-		return nil, dead, nil
+		return nil, dead
+	}
+
+	if len(registry.Entries) == 1 {
+		return []string{registry.Entries[0].Name}, dead
 	}
 
 	registryOrder := make([]string, 0, len(registry.Entries))
@@ -98,14 +102,16 @@ func SelectAgentNames(ctx context.Context, bot agentTypes.Agent, registry agentT
 				if sendErr == nil {
 					break
 				}
-				slog.Warn("dispatcher routing failed",
+				slog.Warn("dispatcher routing attempt failed",
 					slog.String("name", bot.Name()),
 					slog.String("error", sendErr.Error()))
 			}
 			if sendErr != nil {
-				return nil, dead, fmt.Errorf("dispatcher routing exhausted after %d attempts (%v each): %w", DispatcherMaxRetry, DispatcherCallTimeout, sendErr)
-			}
-			if resp != nil && len(resp.Choices) > 0 {
+				dead[bot.Name()] = true
+				slog.Warn("dispatcher routing exhausted, falling back to registry order",
+					slog.String("name", bot.Name()),
+					slog.String("error", sendErr.Error()))
+			} else if resp != nil && len(resp.Choices) > 0 {
 				if content, ok := resp.Choices[0].Message.Content.(string); ok {
 					raw := strings.Trim(strings.TrimSpace(content), "\"'` \n")
 					if raw != "" && raw != "NONE" {
@@ -133,11 +139,11 @@ func SelectAgentNames(ctx context.Context, bot agentTypes.Agent, registry agentT
 		picked = append(picked, n)
 		seen[n] = true
 	}
-	return picked, dead, nil
+	return picked, dead
 }
 
 func SelectAgent(ctx context.Context, bot agentTypes.Agent, registry agentTypes.AgentRegistry, userInput string, hasSkill bool, sessionID string) agentTypes.Agent {
-	names, dead, _ := SelectAgentNames(ctx, bot, registry, userInput, hasSkill, sessionID)
+	names, dead := SelectAgentNames(ctx, bot, registry, userInput, hasSkill, sessionID)
 	for _, n := range names {
 		if dead[n] {
 			continue
@@ -160,10 +166,7 @@ func ProbeAgent(ctx context.Context, a agentTypes.Agent, timeout time.Duration) 
 }
 
 func ResolveAgent(ctx context.Context, bot agentTypes.Agent, registry agentTypes.AgentRegistry, userInput string, hasSkill bool, sessionID string) (agentTypes.Agent, []agentTypes.Agent, error) {
-	names, dead, err := SelectAgentNames(ctx, bot, registry, userInput, hasSkill, sessionID)
-	if err != nil {
-		return nil, nil, err
-	}
+	names, dead := SelectAgentNames(ctx, bot, registry, userInput, hasSkill, sessionID)
 	if len(names) == 0 {
 		return nil, nil, fmt.Errorf("no agents available")
 	}

--- a/internal/tools/file/denied/denied.go
+++ b/internal/tools/file/denied/denied.go
@@ -1,0 +1,58 @@
+package denied
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+type pathSet struct {
+	mu    sync.Mutex
+	paths map[string]struct{}
+}
+
+var cache sync.Map
+
+func get(sessionID string) *pathSet {
+	if v, ok := cache.Load(sessionID); ok {
+		return v.(*pathSet)
+	}
+	ps := &pathSet{paths: map[string]struct{}{}}
+	actual, _ := cache.LoadOrStore(sessionID, ps)
+	return actual.(*pathSet)
+}
+
+func Register(sessionID, absPath string) {
+	absPath = filepath.Clean(absPath)
+	if absPath == "" || absPath == "/" {
+		return
+	}
+	ps := get(sessionID)
+	ps.mu.Lock()
+	defer ps.mu.Unlock()
+	ps.paths[absPath] = struct{}{}
+}
+
+func Hit(sessionID, absPath string) (string, bool) {
+	absPath = filepath.Clean(absPath)
+	ps := get(sessionID)
+	ps.mu.Lock()
+	defer ps.mu.Unlock()
+	sep := string(filepath.Separator)
+	for p := range ps.paths {
+		if absPath == p || strings.HasPrefix(absPath, p+sep) {
+			return p, true
+		}
+	}
+	return "", false
+}
+
+func IsPermission(err error) bool {
+	if err == nil {
+		return false
+	}
+	return os.IsPermission(err) || errors.Is(err, fs.ErrPermission)
+}

--- a/internal/tools/file/globFiles.go
+++ b/internal/tools/file/globFiles.go
@@ -8,6 +8,7 @@ import (
 
 	go_pkg_filesystem "github.com/pardnchiu/go-pkg/filesystem"
 
+	"github.com/pardnchiu/agenvoy/internal/tools/file/denied"
 	toolRegister "github.com/pardnchiu/agenvoy/internal/tools/register"
 	toolTypes "github.com/pardnchiu/agenvoy/internal/tools/types"
 	go_pkg_filesystem_reader "github.com/pardnchiu/go-pkg/filesystem/reader"
@@ -53,6 +54,10 @@ Locate specific file types (e.g. '**/*.go' for Go files).`,
 				return "", fmt.Errorf("go_pkg_filesystem.AbsPath: %w", err)
 			}
 
+			if parent, ok := denied.Hit(e.SessionID, absPath); ok {
+				return "", fmt.Errorf("permission denied: %s is under previously rejected %s; not retried", absPath, parent)
+			}
+
 			pattern := strings.TrimSpace(params.Pattern)
 			if pattern == "" {
 				return "", fmt.Errorf("pattern is required")
@@ -60,6 +65,10 @@ Locate specific file types (e.g. '**/*.go' for Go files).`,
 
 			matches, err := go_pkg_filesystem_reader.GlobFiles(absPath, pattern)
 			if err != nil {
+				if denied.IsPermission(err) {
+					denied.Register(e.SessionID, absPath)
+					return "", fmt.Errorf("permission denied: %s (recorded; further reads under this path will be skipped)", absPath)
+				}
 				return "", fmt.Errorf("go_pkg_filesystem_reader.GlobFiles: %w", err)
 			}
 			data, err := json.Marshal(matches)

--- a/internal/tools/file/listFiles.go
+++ b/internal/tools/file/listFiles.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 
 	go_pkg_filesystem "github.com/pardnchiu/go-pkg/filesystem"
 
+	"github.com/pardnchiu/agenvoy/internal/tools/file/denied"
 	toolRegister "github.com/pardnchiu/agenvoy/internal/tools/register"
 	toolTypes "github.com/pardnchiu/agenvoy/internal/tools/types"
 	go_pkg_filesystem_reader "github.com/pardnchiu/go-pkg/filesystem/reader"
@@ -15,9 +17,9 @@ import (
 
 func registListFiles() {
 	toolRegister.Regist(toolRegister.Def{
-		Name:       "list_files",
-		AlwaysAllow:   true,
-		Concurrent: true,
+		Name:        "list_files",
+		AlwaysAllow: true,
+		Concurrent:  true,
 		Description: `
 List directory entries.
 Inspect immediate children; recursive=true walks subtree files.`,
@@ -49,6 +51,20 @@ Inspect immediate children; recursive=true walks subtree files.`,
 			absPath, err := go_pkg_filesystem.AbsPath(e.WorkDir, dir, go_pkg_filesystem.AbsPathOption{HomeOnly: true})
 			if err != nil {
 				return "", fmt.Errorf("go_pkg_filesystem.AbsPath: %w", err)
+			}
+
+			if parent, ok := denied.Hit(e.SessionID, absPath); ok {
+				return "", fmt.Errorf("permission denied: %s is under previously rejected %s; not retried", absPath, parent)
+			}
+
+			if f, openErr := os.Open(absPath); openErr != nil {
+				if denied.IsPermission(openErr) {
+					denied.Register(e.SessionID, absPath)
+					return "", fmt.Errorf("permission denied: %s (recorded; further reads under this path will be skipped)", absPath)
+				}
+				return "", fmt.Errorf("os.Open: %w", openErr)
+			} else {
+				f.Close()
 			}
 
 			var files []go_pkg_filesystem_reader.File

--- a/internal/tools/file/patchFile.go
+++ b/internal/tools/file/patchFile.go
@@ -10,6 +10,7 @@ import (
 	go_pkg_filesystem "github.com/pardnchiu/go-pkg/filesystem"
 
 	"github.com/pardnchiu/agenvoy/internal/filesystem"
+	"github.com/pardnchiu/agenvoy/internal/tools/file/denied"
 	toolRegister "github.com/pardnchiu/agenvoy/internal/tools/register"
 	toolTypes "github.com/pardnchiu/agenvoy/internal/tools/types"
 )
@@ -82,8 +83,16 @@ Accepts absolute paths and '~' (e.g. '/abs/path/foo.go', '~/notes.md').`,
 				return "", fmt.Errorf("no edit needed")
 			}
 
+			if parent, ok := denied.Hit(e.SessionID, absPath); ok {
+				return "", fmt.Errorf("permission denied: %s is under previously rejected %s; not retried", absPath, parent)
+			}
+
 			info, err := os.Stat(absPath)
 			if err != nil {
+				if denied.IsPermission(err) {
+					denied.Register(e.SessionID, absPath)
+					return "", fmt.Errorf("permission denied: %s (recorded; further edits under this path will be skipped)", absPath)
+				}
 				return "", fmt.Errorf("os.Stat: %w", err)
 			}
 			if info.Size() > maxReadSize {
@@ -92,6 +101,10 @@ Accepts absolute paths and '~' (e.g. '/abs/path/foo.go', '~/notes.md').`,
 
 			fileContent, err := go_pkg_filesystem.ReadText(absPath)
 			if err != nil {
+				if denied.IsPermission(err) {
+					denied.Register(e.SessionID, absPath)
+					return "", fmt.Errorf("permission denied: %s (recorded; further edits under this path will be skipped)", absPath)
+				}
 				return "", fmt.Errorf("go_pkg_filesystem.ReadText: %w", err)
 			}
 
@@ -111,6 +124,10 @@ Accepts absolute paths and '~' (e.g. '/abs/path/foo.go', '~/notes.md').`,
 			}
 
 			if err := go_pkg_filesystem.WriteFile(absPath, updated, 0644); err != nil {
+				if denied.IsPermission(err) {
+					denied.Register(e.SessionID, absPath)
+					return "", fmt.Errorf("permission denied: %s (recorded; further edits under this path will be skipped)", absPath)
+				}
 				return "", fmt.Errorf("go_pkg_filesystem.WriteFile: %w", err)
 			}
 

--- a/internal/tools/file/readFile.go
+++ b/internal/tools/file/readFile.go
@@ -8,6 +8,7 @@ import (
 	go_pkg_filesystem "github.com/pardnchiu/go-pkg/filesystem"
 
 	"github.com/pardnchiu/agenvoy/internal/filesystem"
+	"github.com/pardnchiu/agenvoy/internal/tools/file/denied"
 	toolRegister "github.com/pardnchiu/agenvoy/internal/tools/register"
 	toolTypes "github.com/pardnchiu/agenvoy/internal/tools/types"
 )
@@ -70,12 +71,21 @@ Inspect source, config, notes, slides, documents, tabular data, or screenshots.`
 				return "", fmt.Errorf("path is required")
 			}
 
+			if parent, ok := denied.Hit(e.SessionID, absPath); ok {
+				return "", fmt.Errorf("permission denied: %s is under previously rejected %s; not retried", absPath, parent)
+			}
+
 			offset := max(params.Offset, 1)
 			limit := max(params.Limit, 0)
 			if limit == 0 {
 				limit = defaultReadLimit
 			}
-			return filesystem.ReadFile(ctx, absPath, offset, limit)
+			out, err := filesystem.ReadFile(ctx, absPath, offset, limit)
+			if err != nil && denied.IsPermission(err) {
+				denied.Register(e.SessionID, absPath)
+				return "", fmt.Errorf("permission denied: %s (recorded; further reads under this path will be skipped)", absPath)
+			}
+			return out, err
 		},
 	})
 }

--- a/internal/tools/file/searchFiles.go
+++ b/internal/tools/file/searchFiles.go
@@ -9,6 +9,7 @@ import (
 
 	go_pkg_filesystem "github.com/pardnchiu/go-pkg/filesystem"
 
+	"github.com/pardnchiu/agenvoy/internal/tools/file/denied"
 	toolRegister "github.com/pardnchiu/agenvoy/internal/tools/register"
 	toolTypes "github.com/pardnchiu/agenvoy/internal/tools/types"
 	go_pkg_filesystem_reader "github.com/pardnchiu/go-pkg/filesystem/reader"
@@ -61,6 +62,10 @@ Scope with file_pattern glob (e.g. '**/*.go', 'configs/**').`,
 				return "", fmt.Errorf("go_pkg_filesystem.AbsPath: %w", err)
 			}
 
+			if parent, ok := denied.Hit(e.SessionID, absPath); ok {
+				return "", fmt.Errorf("permission denied: %s is under previously rejected %s; not retried", absPath, parent)
+			}
+
 			pattern := strings.TrimSpace(params.Pattern)
 			if pattern == "" {
 				return "", fmt.Errorf("pattern is required")
@@ -76,6 +81,10 @@ Scope with file_pattern glob (e.g. '**/*.go', 'configs/**').`,
 					IgnoreWalkError: true,
 				})
 			if err != nil {
+				if denied.IsPermission(err) {
+					denied.Register(e.SessionID, absPath)
+					return "", fmt.Errorf("permission denied: %s (recorded; further reads under this path will be skipped)", absPath)
+				}
 				return "", fmt.Errorf("go_pkg_filesystem_reader.SearchFiles: %w", err)
 			}
 

--- a/internal/tools/file/writeFile.go
+++ b/internal/tools/file/writeFile.go
@@ -10,6 +10,7 @@ import (
 	go_pkg_filesystem "github.com/pardnchiu/go-pkg/filesystem"
 
 	"github.com/pardnchiu/agenvoy/internal/filesystem"
+	"github.com/pardnchiu/agenvoy/internal/tools/file/denied"
 	toolRegister "github.com/pardnchiu/agenvoy/internal/tools/register"
 	toolTypes "github.com/pardnchiu/agenvoy/internal/tools/types"
 )
@@ -66,9 +67,17 @@ Accepts absolute paths and '~' (e.g. '/abs/path/foo.go', '~/notes.md').`,
 				return "", fmt.Errorf("content is required")
 			}
 
+			if parent, ok := denied.Hit(e.SessionID, absPath); ok {
+				return "", fmt.Errorf("permission denied: %s is under previously rejected %s; not retried", absPath, parent)
+			}
+
 			info, err := os.Stat(absPath)
 			isNew := os.IsNotExist(err)
 			if err != nil && !isNew {
+				if denied.IsPermission(err) {
+					denied.Register(e.SessionID, absPath)
+					return "", fmt.Errorf("permission denied: %s (recorded; further writes under this path will be skipped)", absPath)
+				}
 				return "", fmt.Errorf("os.Stat: %w", err)
 			}
 			if !isNew && info.Size() > maxReadSize {
@@ -76,6 +85,10 @@ Accepts absolute paths and '~' (e.g. '/abs/path/foo.go', '~/notes.md').`,
 			}
 
 			if err := go_pkg_filesystem.WriteFile(absPath, content, 0644); err != nil {
+				if denied.IsPermission(err) {
+					denied.Register(e.SessionID, absPath)
+					return "", fmt.Errorf("permission denied: %s (recorded; further writes under this path will be skipped)", absPath)
+				}
 				return "", fmt.Errorf("go_pkg_filesystem.WriteFile: %w", err)
 			}
 


### PR DESCRIPTION
Agent resolution recovers the multi-agent failover path: when dispatcher routing exhausts its retries it now marks the dispatcher dead and falls through to the registry order instead of returning an outright error, so other registered agents still get tried. Skips dispatcher entirely when only one agent is registered. File tools remember per-session permission-denied roots and short-circuit subsequent calls into the same subtree.
