### PR TITLE
Enhance command validation, session flow, and provider documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ _tui_archived
 _scheduler
 _script_tools
 _discord
+scripts/

--- a/README.md
+++ b/README.md
@@ -111,7 +111,9 @@ Compared against the two closest peers — personal AI agent frameworks with dae
 | GitHub Copilot | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ |
 | Nvidia NIM | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ |
 | OpenAI-compat | ✅ | ✅ Ollama/LM Studio | ✅ OpenRouter 200+ | ❌ | ❌ | ❌ |
-| DeepSeek / Mistral / xAI | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ |
+| DeepSeek | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ |
+| xAI (Grok) | ✅ API key | ✅ | ✅ OAuth + API key | ❌ | ❌ | ❌ |
+| Mistral | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ |
 | Dispatcher routing | ✅ dedicated dispatcher model | ❌ | ❌ | ❌ | ❌ | ❌ |
 
 ---

--- a/cmd/app/addProvider.go
+++ b/cmd/app/addProvider.go
@@ -48,6 +48,8 @@ var providers = []Provider{
 	{Prefix: "codex@"},
 	{Prefix: "claude@"},
 	{Prefix: "gemini@"},
+	{Prefix: "grok@"},
+	{Prefix: "deepseek@"},
 	{Prefix: "nvidia@"},
 	{Prefix: "compat"},
 }
@@ -517,7 +519,7 @@ func checkBrokenModels() []brokenModel {
 	}
 	out := make([]brokenModel, 0)
 	for _, m := range cfg.Models {
-		head := strings.SplitN(m.Name, "@", 2)[0]
+		head, _, _ := strings.Cut(m.Name, "@")
 		prov, _, _ := strings.Cut(head, "[")
 		var reason string
 		switch prov {
@@ -529,7 +531,7 @@ func checkBrokenModels() []brokenModel {
 			if !openaicodex.HasToken() {
 				reason = "codex token missing"
 			}
-		case "openai", "claude", "gemini", "nvidia":
+		case "openai", "claude", "gemini", "nvidia", "grok", "deepseek":
 			envKey := strings.ToUpper(prov) + "_API_KEY"
 			if keychain.Get(envKey) == "" {
 				reason = envKey + " missing"
@@ -617,7 +619,7 @@ func reLogin(b brokenModel) error {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 		defer cancel()
 		return openaicodex.Authenticate(ctx)
-	case "openai", "claude", "gemini", "nvidia":
+	case "openai", "claude", "gemini", "nvidia", "grok", "deepseek":
 		envKey := strings.ToUpper(b.Provider) + "_API_KEY"
 		fmt.Printf("%s API Key: ", strings.ToUpper(b.Provider[:1])+b.Provider[1:])
 		keyBytes, err := term.ReadPassword(int(os.Stdin.Fd()))

--- a/cmd/app/buildAgentRegistry.go
+++ b/cmd/app/buildAgentRegistry.go
@@ -8,7 +8,9 @@ import (
 	"github.com/pardnchiu/agenvoy/internal/agents/provider/claude"
 	"github.com/pardnchiu/agenvoy/internal/agents/provider/compat"
 	"github.com/pardnchiu/agenvoy/internal/agents/provider/copilot"
+	"github.com/pardnchiu/agenvoy/internal/agents/provider/deepseek"
 	"github.com/pardnchiu/agenvoy/internal/agents/provider/gemini"
+	"github.com/pardnchiu/agenvoy/internal/agents/provider/grok"
 	"github.com/pardnchiu/agenvoy/internal/agents/provider/nvidia"
 	"github.com/pardnchiu/agenvoy/internal/agents/provider/openai"
 	openaicodex "github.com/pardnchiu/agenvoy/internal/agents/provider/openaiCodex"
@@ -18,13 +20,15 @@ import (
 
 func buildAgentRegistry() agentTypes.AgentRegistry {
 	newFn := map[string]func(string) (agentTypes.Agent, error){
-		"copilot": func(m string) (agentTypes.Agent, error) { return copilot.New(m) },
-		"openai":  func(m string) (agentTypes.Agent, error) { return openai.New(m) },
-		"codex":   func(m string) (agentTypes.Agent, error) { return openaicodex.New(m) },
-		"compat":  func(m string) (agentTypes.Agent, error) { return compat.New(m) },
-		"claude":  func(m string) (agentTypes.Agent, error) { return claude.New(m) },
-		"gemini":  func(m string) (agentTypes.Agent, error) { return gemini.New(m) },
-		"nvidia":  func(m string) (agentTypes.Agent, error) { return nvidia.New(m) },
+		"claude":   func(m string) (agentTypes.Agent, error) { return claude.New(m) },
+		"openai":   func(m string) (agentTypes.Agent, error) { return openai.New(m) },
+		"codex":    func(m string) (agentTypes.Agent, error) { return openaicodex.New(m) },
+		"gemini":   func(m string) (agentTypes.Agent, error) { return gemini.New(m) },
+		"grok":     func(m string) (agentTypes.Agent, error) { return grok.New(m) },
+		"copilot":  func(m string) (agentTypes.Agent, error) { return copilot.New(m) },
+		"nvidia":   func(m string) (agentTypes.Agent, error) { return nvidia.New(m) },
+		"deepseek": func(m string) (agentTypes.Agent, error) { return deepseek.New(m) },
+		"compat":   func(m string) (agentTypes.Agent, error) { return compat.New(m) },
 	}
 
 	agentEntries := exec.GetAgent()
@@ -33,7 +37,7 @@ func buildAgentRegistry() agentTypes.AgentRegistry {
 		Entries:  make([]agentTypes.AgentEntry, 0, len(agentEntries)),
 	}
 	for _, e := range agentEntries {
-		providerFull := strings.SplitN(e.Name, "@", 2)[0]
+		providerFull, _, _ := strings.Cut(e.Name, "@")
 		prov, _, _ := strings.Cut(providerFull, "[")
 		fn, ok := newFn[prov]
 		if !ok {

--- a/configs/configs.go
+++ b/configs/configs.go
@@ -61,20 +61,26 @@ var WhiteList []byte
 //go:embed jsons/providors/claude.json
 var ClaudeModels []byte
 
-//go:embed jsons/providors/copilot.json
-var CopilotModels []byte
-
-//go:embed jsons/providors/gemini.json
-var GeminiModels []byte
-
-//go:embed jsons/providors/nvidia.json
-var NvidiaModels []byte
+//go:embed jsons/providors/openai.json
+var OpenaiModels []byte
 
 //go:embed jsons/providors/codex.json
 var CodexModels []byte
 
-//go:embed jsons/providors/openai.json
-var OpenaiModels []byte
+//go:embed jsons/providors/gemini.json
+var GeminiModels []byte
+
+//go:embed jsons/providors/grok.json
+var GrokModels []byte
+
+//go:embed jsons/providors/copilot.json
+var CopilotModels []byte
+
+//go:embed jsons/providors/nvidia.json
+var NvidiaModels []byte
+
+//go:embed jsons/providors/deepseek.json
+var DeepseekModels []byte
 
 //go:embed webmode.html
 var WebmodeHTML string

--- a/configs/jsons/providors/deepseek.json
+++ b/configs/jsons/providors/deepseek.json
@@ -1,0 +1,9 @@
+{
+  "deepseek-chat": {
+    "description": "General-purpose chat with tool use"
+  },
+  "deepseek-reasoner": {
+    "description": "Reasoning model with chain-of-thought output",
+    "no_temperature": true
+  }
+}

--- a/configs/jsons/providors/grok.json
+++ b/configs/jsons/providors/grok.json
@@ -1,0 +1,21 @@
+{
+  "grok-4": {
+    "description": "Flagship reasoning model with strong agentic capability"
+  },
+  "grok-4-fast-reasoning": {
+    "description": "Lower-latency reasoning model"
+  },
+  "grok-4-fast-non-reasoning": {
+    "description": "Lower-latency general model without reasoning"
+  },
+  "grok-code-fast-1": {
+    "description": "Code generation tuned for speed"
+  },
+  "grok-3": {
+    "description": "General-purpose model"
+  },
+  "grok-3-mini": {
+    "description": "Lightweight reasoning with configurable effort",
+    "reasoning_effort": true
+  }
+}

--- a/configs/prompts/summary_context.md
+++ b/configs/prompts/summary_context.md
@@ -1,14 +1,25 @@
 # Prior Conversation Context
 
-The following is a background summary of prior discussion in this session, provided **for your reference only** so you understand what has been discussed, decided, or is still pending.
+The JSON below is the rolling summary of prior discussion in this session — your long-term memory anchor. It captures key decisions, past discussion topics with their direction, and the topic currently being discussed.
 
-**Strict rules:**
-- This is context, not a task. Do NOT generate, echo, or reproduce a summary in your reply.
-- Never output a `<summary>...</summary>` block, `[summary]...[/summary]` block, or any JSON summary structure.
-- Never quote, paraphrase, or restate the JSON below unless the user explicitly asks for it.
-- Summary maintenance runs separately on a schedule — it is never your job in this turn.
+**`key_decisions` is binding** — these are the **locked-in, concluded** outcomes from prior turns (what was finally agreed `要：` or finally rejected `不要：`). Treat them as authoritative session-level commitments: do not re-litigate, re-propose, or quietly contradict them in this turn unless the user explicitly reopens the decision. When relevant to the current task, **honor `key_decisions` first**, then layer in other context.
 
-**Prior summary (reference only):**
+**When to surface this summary content (MUST include in reply):**
+
+- User asks about memory / state / history / what has been discussed: "目前記憶", "你記得什麼", "what do you remember", "檢視記憶", "我們聊過什麼", "之前討論過哪些", "what did we cover", "今天聊了什麼", "概要", "重點" → **must** quote or paraphrase `key_decisions` **first** (these are the settled outcomes), then `past_discussions` and `current_discussion`, then optionally augment with `search_conversation_history` / `search_error_memory` / `rag_list_db` for specifics.
+- User asks "what decisions were made" / "agreed on" / "要做 / 不要做" / "決定了什麼" → cite `key_decisions` directly and verbatim in spirit; flag clearly if the list is empty.
+- User asks about a specific past topic that appears in `past_discussions` → use that entry's `description` + `direction` as the answer; cross-check against `key_decisions` for any locked-in resolution on that topic; only call `search_conversation_history` if the user needs original quotes.
+- User asks about the current topic / "現在在討論什麼" / "what are we working on" → cite `current_discussion`, and flag any `key_decisions` that constrain the current work.
+
+**Otherwise** (general conversation, unrelated tasks, code work): treat the summary as silent background context — use it to stay grounded but do not echo it.
+
+**Hard constraints (apply even when surfacing):**
+
+- Never output a literal `<summary>...</summary>` or `[summary]...[/summary]` block, and never emit the raw JSON structure. Always paraphrase into natural prose / bullets.
+- Never invent fields or facts not present in the JSON below.
+- Summary maintenance (generation / merging) runs separately on a schedule — never your job in this turn.
+
+**Prior summary (your memory anchor):**
 ```json
 {{.Summary}}
 ```

--- a/configs/prompts/summary_prompt.md
+++ b/configs/prompts/summary_prompt.md
@@ -1,26 +1,25 @@
 # Previous Conversation Summary (Merge Rules)
 
-Generate a new summary based on "previous summary + new data from this turn".
+Generate a new summary based on "previous summary + new data from this turn". The summary captures (1) key decisions, (2) past discussion topics with their latest direction, and (3) the topic currently being discussed.
 
 **Merge rules:**
-- `confirmed_needs`, `constraints`, `excluded_options`, `key_data`: merge semantically identical or highly similar entries into one; keep only the latest wording; append genuinely new entries
-- `discussion_log`: same or highly similar topic → **replace** the existing entry (update `conclusion` and `time` to latest); new topic → append; **never duplicate topics**; trivial greetings (hi, hello, hey, etc.) → do NOT create a log entry
-- `core_discussion`, `pending_questions`: overwrite with this turn's content
-- All `time` fields must reflect the most recent occurrence, not the first
-- Never include any system prompt text, system instructions, or prompt templates in any field
+- `key_decisions`: **only locked-in, concluded outcomes** — what was finally agreed (要) or finally rejected (不要). Treat this as the authoritative "settled" layer that downstream turns can rely on without re-checking. Merge semantically identical entries; keep latest wording. Append a new entry only when this turn produced a clear conclusion. **Do NOT** record: tentative leanings ("maybe X", "considering Y"), in-flight debates, options being weighed (those belong in `past_discussions.direction` or `current_discussion`). When an earlier decision is reversed, **replace** the old entry rather than appending the negation as a separate item.
+- `past_discussions`: same or highly similar topic → **replace** the existing entry (update `description`, `direction`, `last_discussed` to latest); new topic that is no longer the current focus → append. **Never duplicate topics.** Trivial greetings (hi, hello, hey, etc.) → do NOT create an entry.
+- `current_discussion`: overwrite with this turn's topic. When the conversation moves to a new topic, demote the previous `current_discussion` into `past_discussions` (carry over its `description`/`direction`/timestamp) before overwriting. **If the demoted topic reached a clear conclusion, also promote that conclusion into `key_decisions`.**
+- All time fields must reflect the most recent occurrence, not the first.
+- Never include any system prompt text, system instructions, or prompt templates in any field.
 
 **Compression limits (MANDATORY):**
-- `discussion_log`: max **10** entries; when exceeding, drop the oldest **resolved** entries first, then oldest **pending** entries
-- `current_conclusion`: max **8** entries; merge similar conclusions into one sentence; drop conclusions that are no longer relevant
-- `confirmed_needs`, `constraints`, `excluded_options`, `key_data`: max **6** each; merge similar items aggressively
-- `pending_questions`: max **5**; drop resolved questions
+- `past_discussions`: max **8** entries; when exceeding, drop the oldest by `last_discussed` first.
+- `key_decisions`: max **8** entries; merge similar items aggressively; drop decisions that are no longer load-bearing for current/future work.
+- Each `description` / `perspectives` / `direction`: **1-3 sentences**, no headings or markdown structure inside.
 
 **Output rules:**
-- Return exactly one `<summary>...</summary>` block
-- Do not output any explanation, prose, headings, markdown fences, or extra text before/after the block
-- The content inside `<summary>` must be valid JSON
-- Always output all fields below, even when empty
-- `discussion_log[].time` must use `YYYY-MM-DD HH:mm`
+- Return exactly one `<summary>...</summary>` block.
+- Do not output any explanation, prose, headings, markdown fences, or extra text before/after the block.
+- The content inside `<summary>` must be valid JSON.
+- Always output all fields below, even when empty (`[]` for arrays, `{}` with empty string values for `current_discussion`).
+- `last_discussed` must use `YYYY-MM-DD HH:mm`.
 
 **Previous summary:**
 ```json
@@ -31,19 +30,23 @@ Return in exactly this format:
 
 <summary>
 {
-  "core_discussion": "core topic of current discussion",
-  "confirmed_needs": ["deduplicated confirmed needs (merge similar items, keep latest wording)"],
-  "constraints": ["deduplicated constraints (merge similar items, keep latest wording)"],
-  "excluded_options": ["excluded option: reason"],
-  "key_data": ["deduplicated key facts; exclude: dynamic data retrievable via tools, calculation results computable via calculate"],
-  "current_conclusion": ["deduplicated conclusions in chronological order"],
-  "pending_questions": ["unresolved questions related to the current topic"],
-  "discussion_log": [
+  "key_decisions": [
+    "要：concluded want / final agreed approach / locked-in requirement",
+    "不要：concluded avoid / final rejected approach / locked-in constraint"
+  ],
+  "past_discussions": [
     {
-      "topic": "topic summary",
-      "time": "YYYY-MM-DD HH:mm (latest occurrence)",
-      "conclusion": "resolved / pending / dropped"
+      "topic": "short topic name",
+      "description": "1-3 sentence summary of what was discussed",
+      "direction": "latest conclusion if resolved; current direction if unresolved",
+      "last_discussed": "YYYY-MM-DD HH:mm"
     }
-  ]
+  ],
+  "current_discussion": {
+    "topic": "current topic name",
+    "description": "1-3 sentence summary of what is being discussed now",
+    "perspectives": "both sides' views / arguments / trade-offs being weighed",
+    "direction": "latest conclusion if resolved this turn; current direction otherwise"
+  }
 }
 </summary>

--- a/configs/prompts/system_prompt.md
+++ b/configs/prompts/system_prompt.md
@@ -109,7 +109,10 @@ RAG = primary source (user's curated reference corpus). External = secondary sup
 - News (read/summarize): skip summary/search_conversation_history (unless cached data is within 10 minutes) → fetch_google_rss; if the requested window returns no result, retry in order `1h → 24h → 7d`; if still empty or tool fails, fallback to `search_web`; then `fetch_page` (see §5)
 - `search_conversation_history` keyword: extract the most essential noun from the question (e.g. "邱敬幃是誰" → keyword="邱敬幃")
 
-**Conversation history queries**: user asks "之前說過什麼", "上次提到的內容", "歷史紀錄", "查詢歷史", "查歷史", "歷史查詢", "之前討論過", "之前提過", etc. → **must call `search_conversation_history`**; never assert "no record" based solely on summary JSON or self-memory.
+**Conversation history queries** — branch on intent:
+
+- **Theme recall** (no specific entity / asking for overview): "聊過什麼", "討論過哪些主題", "今天聊了什麼", "概要", "重點", "之前談過哪些議題", "what did we cover", "summarize our conversation" → **answer from summary JSON first** — summary is the authoritative source for theme-level recall. Only fall back to `search_conversation_history` if summary is empty / clearly stale, or the user explicitly requests raw quotes.
+- **Specific instance lookup** (contains a concrete entity / keyword to search for): "之前提到的 X 怎麼說", "上次討論 X 的細節", "history of X", "之前說過 X 嗎" → **must call `search_conversation_history`** with X as keyword; never claim "no record" based solely on summary JSON or self-memory.
 
 **Math/calculation notes:**
 - If the input value is variable data, fetch it first via tool, then pass into `calculate`

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,8 @@ require (
 	github.com/pardnchiu/go-scheduler v1.2.0
 )
 
+require mvdan.cc/sh/v3 v3.13.1 // indirect
+
 require (
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -274,3 +274,5 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+mvdan.cc/sh/v3 v3.13.1 h1:DP3TfgZhDkT7lerUdnp6PTGKyxxzz6T+cOlY/xEvfWk=
+mvdan.cc/sh/v3 v3.13.1/go.mod h1:lXJ8SexMvEVcHCoDvAGLZgFJ9Wsm2sulmoNEXGhYZD0=

--- a/internal/agents/exec/reset.go
+++ b/internal/agents/exec/reset.go
@@ -1,0 +1,52 @@
+package exec
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pardnchiu/agenvoy/internal/agents"
+	"github.com/pardnchiu/agenvoy/internal/agents/summary"
+	sessionManager "github.com/pardnchiu/agenvoy/internal/session"
+)
+
+func ForceSummary(ctx context.Context, sessionID string) (int, error) {
+	if sessionID == "" {
+		return 0, fmt.Errorf("session id is required")
+	}
+
+	histories, _ := sessionManager.GetHistory(sessionID)
+	summaryHistories := summary.Get(histories)
+	if len(summaryHistories) == 0 {
+		return 0, nil
+	}
+
+	agent := SelectAgent(ctx, agents.Dispatcher(), agents.Registry(), "[summary] force refresh", false, sessionID)
+	if agent == nil {
+		return 0, fmt.Errorf("no agent available for summary refresh")
+	}
+	if err := summary.Generate(ctx, agent, sessionID, summaryHistories); err != nil {
+		return 0, fmt.Errorf("summary refresh failed: %w", err)
+	}
+	return len(summaryHistories), nil
+}
+
+func ResetSessionWithSummary(ctx context.Context, sessionID string) (int, error) {
+	if sessionID == "" {
+		return 0, fmt.Errorf("session id is required")
+	}
+
+	histories, _ := sessionManager.GetHistory(sessionID)
+	summaryHistories := summary.Get(histories)
+
+	if len(summaryHistories) > 0 {
+		agent := SelectAgent(ctx, agents.Dispatcher(), agents.Registry(), "[summary] reset session", false, sessionID)
+		if agent == nil {
+			return 0, fmt.Errorf("no agent available for summary refresh; reset aborted")
+		}
+		if err := summary.Generate(ctx, agent, sessionID, summaryHistories); err != nil {
+			return 0, fmt.Errorf("summary refresh failed; reset aborted to avoid context loss: %w", err)
+		}
+	}
+
+	return sessionManager.ResetHistoryKeepSummary(sessionID)
+}

--- a/internal/agents/exec/selectAgent.go
+++ b/internal/agents/exec/selectAgent.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	ProbeTimeout          = 5 * time.Second
+	ProbeTimeout          = 15 * time.Second
 	DispatcherCallTimeout = 10 * time.Second
 	DispatcherMaxRetry    = 3
 )
@@ -161,8 +161,15 @@ func ProbeAgent(ctx context.Context, a agentTypes.Agent, timeout time.Duration) 
 	}
 	probeCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
-	_, err := a.Send(probeCtx, []agentTypes.Message{{Role: "user", Content: "."}}, nil)
-	return err == nil
+	resp, err := a.Send(probeCtx, []agentTypes.Message{
+		{Role: "system", Content: "Reply with only: ok"},
+		{Role: "user", Content: "ping"},
+	}, nil)
+	if err != nil || resp == nil || len(resp.Choices) == 0 {
+		return false
+	}
+	content, _ := resp.Choices[0].Message.Content.(string)
+	return strings.TrimSpace(content) != ""
 }
 
 func ResolveAgent(ctx context.Context, bot agentTypes.Agent, registry agentTypes.AgentRegistry, userInput string, hasSkill bool, sessionID string) (agentTypes.Agent, []agentTypes.Agent, error) {

--- a/internal/agents/provider/claude/new.go
+++ b/internal/agents/provider/claude/new.go
@@ -39,7 +39,7 @@ func New(model ...string) (*Agent, error) {
 	}
 
 	return &Agent{
-		httpClient: provider.NewHTTPClient(),
+		httpClient: provider.NewHTTPClientNonStream(),
 		model:      usedModel,
 		apiKey:     apiKey,
 		workDir:    workDir,

--- a/internal/agents/provider/copilot/new.go
+++ b/internal/agents/provider/copilot/new.go
@@ -52,7 +52,7 @@ func New(model ...string) (*Agent, error) {
 	// }
 
 	agent := &Agent{
-		httpClient: provider.NewHTTPClient(),
+		httpClient: provider.NewHTTPClientNonStream(),
 		model:      usedModel,
 		workDir:    workDir,
 	}
@@ -89,7 +89,7 @@ func Authenticate(ctx context.Context) error {
 		return fmt.Errorf("os.Getwd: %w", err)
 	}
 	a := &Agent{
-		httpClient: provider.NewHTTPClient(),
+		httpClient: provider.NewHTTPClientNonStream(),
 		workDir:    workDir,
 	}
 	token, err := a.Login(ctx)

--- a/internal/agents/provider/deepseek/new.go
+++ b/internal/agents/provider/deepseek/new.go
@@ -1,4 +1,4 @@
-package gemini
+package deepseek
 
 import (
 	"fmt"
@@ -19,18 +19,18 @@ type Agent struct {
 }
 
 const (
-	prefix = "gemini@"
+	prefix = "deepseek@"
 )
 
 func New(model ...string) (*Agent, error) {
 	if len(model) == 0 || !strings.HasPrefix(model[0], prefix) {
-		return nil, fmt.Errorf("gemini.New: model arg required with %q prefix", prefix)
+		return nil, fmt.Errorf("deepseek.New: model arg required with %q prefix", prefix)
 	}
 	usedModel := strings.TrimPrefix(model[0], prefix)
 
-	apiKey := keychain.Get("GEMINI_API_KEY")
+	apiKey := keychain.Get("DEEPSEEK_API_KEY")
 	if apiKey == "" {
-		return nil, fmt.Errorf("keychain.Get: GEMINI_API_KEY is required")
+		return nil, fmt.Errorf("keychain.Get: DEEPSEEK_API_KEY is required")
 	}
 
 	workDir, _ := os.Getwd()

--- a/internal/agents/provider/deepseek/send.go
+++ b/internal/agents/provider/deepseek/send.go
@@ -1,0 +1,71 @@
+package deepseek
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/pardnchiu/agenvoy/internal/agents/exec"
+	"github.com/pardnchiu/agenvoy/internal/agents/provider"
+	agentTypes "github.com/pardnchiu/agenvoy/internal/agents/types"
+	"github.com/pardnchiu/agenvoy/internal/filesystem"
+	toolTypes "github.com/pardnchiu/agenvoy/internal/tools/types"
+	go_pkg_http "github.com/pardnchiu/go-pkg/http"
+)
+
+const (
+	chatAPI = "https://api.deepseek.com/v1/chat/completions"
+)
+
+func (a *Agent) Execute(ctx context.Context, skill *filesystem.Skill, userInput string, events chan<- agentTypes.Event, allowAll bool) error {
+	data := exec.ExecData{
+		Agent:   a,
+		WorkDir: a.workDir,
+		Skill:   skill,
+		Content: userInput,
+	}
+	session, err := exec.GetSession(data)
+	if err != nil {
+		return fmt.Errorf("exec.GetSession: %w", err)
+	}
+	return exec.Execute(ctx, data, session, events, allowAll)
+}
+
+func (a *Agent) Send(ctx context.Context, messages []agentTypes.Message, tools []toolTypes.Tool) (*agentTypes.Output, error) {
+	var merged []agentTypes.Message
+	var systemParts []string
+	for _, m := range messages {
+		if m.Role == "system" {
+			if s, ok := m.Content.(string); ok && s != "" {
+				systemParts = append(systemParts, s)
+			}
+		} else {
+			merged = append(merged, m)
+		}
+	}
+	if len(systemParts) > 0 {
+		merged = append([]agentTypes.Message{{Role: "system", Content: strings.Join(systemParts, "\n\n")}}, merged...)
+	}
+
+	body := map[string]any{
+		"model":    a.model,
+		"messages": merged,
+		"tools":    tools,
+	}
+	if provider.SupportTemperature("deepseek", a.model) {
+		body["temperature"] = 0.2
+	}
+
+	result, _, err := go_pkg_http.POST[agentTypes.Output](ctx, a.httpClient, chatAPI, map[string]string{
+		"Authorization": "Bearer " + a.apiKey,
+		"Content-Type":  "application/json",
+	}, body, "json")
+	if err != nil {
+		return nil, fmt.Errorf("http.POST: %w", err)
+	}
+	if result.Error != nil {
+		return nil, fmt.Errorf("http.POST: %s", result.Error.Message)
+	}
+
+	return &result, nil
+}

--- a/internal/agents/provider/grok/new.go
+++ b/internal/agents/provider/grok/new.go
@@ -1,4 +1,4 @@
-package gemini
+package grok
 
 import (
 	"fmt"
@@ -19,18 +19,18 @@ type Agent struct {
 }
 
 const (
-	prefix = "gemini@"
+	prefix = "grok@"
 )
 
 func New(model ...string) (*Agent, error) {
 	if len(model) == 0 || !strings.HasPrefix(model[0], prefix) {
-		return nil, fmt.Errorf("gemini.New: model arg required with %q prefix", prefix)
+		return nil, fmt.Errorf("grok.New: model arg required with %q prefix", prefix)
 	}
 	usedModel := strings.TrimPrefix(model[0], prefix)
 
-	apiKey := keychain.Get("GEMINI_API_KEY")
+	apiKey := keychain.Get("GROK_API_KEY")
 	if apiKey == "" {
-		return nil, fmt.Errorf("keychain.Get: GEMINI_API_KEY is required")
+		return nil, fmt.Errorf("keychain.Get: GROK_API_KEY is required")
 	}
 
 	workDir, _ := os.Getwd()

--- a/internal/agents/provider/grok/send.go
+++ b/internal/agents/provider/grok/send.go
@@ -1,0 +1,74 @@
+package grok
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/pardnchiu/agenvoy/internal/agents/exec"
+	"github.com/pardnchiu/agenvoy/internal/agents/provider"
+	agentTypes "github.com/pardnchiu/agenvoy/internal/agents/types"
+	"github.com/pardnchiu/agenvoy/internal/filesystem"
+	toolTypes "github.com/pardnchiu/agenvoy/internal/tools/types"
+	go_pkg_http "github.com/pardnchiu/go-pkg/http"
+)
+
+const (
+	chatAPI = "https://api.x.ai/v1/chat/completions"
+)
+
+func (a *Agent) Execute(ctx context.Context, skill *filesystem.Skill, userInput string, events chan<- agentTypes.Event, allowAll bool) error {
+	data := exec.ExecData{
+		Agent:   a,
+		WorkDir: a.workDir,
+		Skill:   skill,
+		Content: userInput,
+	}
+	session, err := exec.GetSession(data)
+	if err != nil {
+		return fmt.Errorf("exec.GetSession: %w", err)
+	}
+	return exec.Execute(ctx, data, session, events, allowAll)
+}
+
+func (a *Agent) Send(ctx context.Context, messages []agentTypes.Message, tools []toolTypes.Tool) (*agentTypes.Output, error) {
+	var merged []agentTypes.Message
+	var systemParts []string
+	for _, m := range messages {
+		if m.Role == "system" {
+			if s, ok := m.Content.(string); ok && s != "" {
+				systemParts = append(systemParts, s)
+			}
+		} else {
+			merged = append(merged, m)
+		}
+	}
+	if len(systemParts) > 0 {
+		merged = append([]agentTypes.Message{{Role: "system", Content: strings.Join(systemParts, "\n\n")}}, merged...)
+	}
+
+	body := map[string]any{
+		"model":    a.model,
+		"messages": merged,
+		"tools":    tools,
+	}
+	if provider.SupportTemperature("grok", a.model) {
+		body["temperature"] = 0.2
+	}
+	if provider.SupportReasoningEffort("grok", a.model) {
+		body["reasoning_effort"] = provider.GetReasoningLevel()
+	}
+
+	result, _, err := go_pkg_http.POST[agentTypes.Output](ctx, a.httpClient, chatAPI, map[string]string{
+		"Authorization": "Bearer " + a.apiKey,
+		"Content-Type":  "application/json",
+	}, body, "json")
+	if err != nil {
+		return nil, fmt.Errorf("http.POST: %w", err)
+	}
+	if result.Error != nil {
+		return nil, fmt.Errorf("http.POST: %s", result.Error.Message)
+	}
+
+	return &result, nil
+}

--- a/internal/agents/provider/nvidia/new.go
+++ b/internal/agents/provider/nvidia/new.go
@@ -36,7 +36,7 @@ func New(model ...string) (*Agent, error) {
 	workDir, _ := os.Getwd()
 
 	return &Agent{
-		httpClient: provider.NewHTTPClient(),
+		httpClient: provider.NewHTTPClientNonStream(),
 		model:      usedModel,
 		apiKey:     apiKey,
 		workDir:    workDir,

--- a/internal/agents/provider/openai/new.go
+++ b/internal/agents/provider/openai/new.go
@@ -36,7 +36,7 @@ func New(model ...string) (*Agent, error) {
 	workDir, _ := os.Getwd()
 
 	return &Agent{
-		httpClient: provider.NewHTTPClient(),
+		httpClient: provider.NewHTTPClientNonStream(),
 		model:      usedModel,
 		apiKey:     apiKey,
 		workDir:    workDir,

--- a/internal/agents/provider/provider.go
+++ b/internal/agents/provider/provider.go
@@ -63,12 +63,14 @@ func parse(data []byte) map[string]ModelItem {
 
 func providers() map[string]map[string]ModelItem {
 	return map[string]map[string]ModelItem{
-		"claude":  parse(configs.ClaudeModels),
-		"codex":   parse(configs.CodexModels),
-		"copilot": parse(configs.CopilotModels),
-		"gemini":  parse(configs.GeminiModels),
-		"nvidia":  parse(configs.NvidiaModels),
-		"openai":  parse(configs.OpenaiModels),
+		"claude":   parse(configs.ClaudeModels),
+		"openai":   parse(configs.OpenaiModels),
+		"codex":    parse(configs.CodexModels),
+		"gemini":   parse(configs.GeminiModels),
+		"grok":     parse(configs.GrokModels),
+		"copilot":  parse(configs.CopilotModels),
+		"nvidia":   parse(configs.NvidiaModels),
+		"deepseek": parse(configs.DeepseekModels),
 	}
 }
 
@@ -102,4 +104,8 @@ func NewHTTPClient() *http.Client {
 		Timeout:   5 * time.Minute,
 		Transport: transport,
 	}
+}
+
+func NewHTTPClientNonStream() *http.Client {
+	return &http.Client{Timeout: 5 * time.Minute}
 }

--- a/internal/agents/summary/extract.go
+++ b/internal/agents/summary/extract.go
@@ -11,14 +11,20 @@ var (
 )
 
 func isSummaryJSON(m map[string]any) bool {
-	keys := []string{
-		"core_discussion", "discussion_log", "confirmed_needs", "current_conclusion",
+	newKeys := []string{"key_decisions", "past_discussions", "current_discussion"}
+	if countMatch(m, newKeys) >= 2 {
+		return true
 	}
-	matched := 0
+	legacyKeys := []string{"core_discussion", "discussion_log", "confirmed_needs", "current_conclusion"}
+	return countMatch(m, legacyKeys) >= 2
+}
+
+func countMatch(record map[string]any, keys []string) int {
+	num := 0
 	for _, key := range keys {
-		if _, exist := m[key]; exist {
-			matched++
+		if _, ok := record[key]; ok {
+			num++
 		}
 	}
-	return matched >= 2
+	return num
 }

--- a/internal/agents/summary/generate.go
+++ b/internal/agents/summary/generate.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"regexp"
 	"strings"
@@ -50,7 +51,7 @@ func filterAfterTime(messages []agentTypes.Message, cursor string) []agentTypes.
 	return out
 }
 
-func Generate(ctx context.Context, agent agentTypes.Agent, sessionID string, histories []agentTypes.Message) {
+func Generate(ctx context.Context, agent agentTypes.Agent, sessionID string, histories []agentTypes.Message) error {
 	raw, summaryMap := sessionManager.EnsureSummary(sessionID)
 	meta := sessionManager.GetSummaryMeta(sessionID)
 
@@ -61,12 +62,12 @@ func Generate(ctx context.Context, agent agentTypes.Agent, sessionID string, his
 		slog.Info("summary meta initialized from existing summary",
 			slog.String("session", sessionID),
 			slog.String("cursor", latest))
-		return
+		return nil
 	}
 
 	newHistories := filterAfterTime(histories, meta.LastMessageTime)
 	if len(newHistories) == 0 {
-		return
+		return nil
 	}
 
 	oldSummary := string(raw)
@@ -83,7 +84,7 @@ func Generate(ctx context.Context, agent agentTypes.Agent, sessionID string, his
 			slog.Warn("summary generatePass returned nil",
 				slog.String("session", sessionID),
 				slog.Int("chunk", i+1))
-			return
+			return fmt.Errorf("generatePass returned nil at chunk %d/%d", i+1, len(chunks))
 		}
 
 		if b, err := json.Marshal(newMap); err == nil {
@@ -96,6 +97,7 @@ func Generate(ctx context.Context, agent agentTypes.Agent, sessionID string, his
 		}
 		sessionManager.SaveSummaryMeta(sessionID, cursor)
 	}
+	return nil
 }
 
 func chunkMessages(messages []agentTypes.Message, size int) [][]agentTypes.Message {

--- a/internal/filesystem/path.go
+++ b/internal/filesystem/path.go
@@ -127,7 +127,7 @@ func Init() error {
 }
 
 func HistoryPath(sessionID string) string {
-	return filepath.Join(SessionsDir, sessionID, "history.md")
+	return filepath.Join(SessionsDir, sessionID, "history.json")
 }
 
 func InputHistoryPath(sessionID string) string {

--- a/internal/runtime/cli/selectAgent.go
+++ b/internal/runtime/cli/selectAgent.go
@@ -7,7 +7,9 @@ import (
 	"github.com/pardnchiu/agenvoy/internal/agents/provider/claude"
 	"github.com/pardnchiu/agenvoy/internal/agents/provider/compat"
 	"github.com/pardnchiu/agenvoy/internal/agents/provider/copilot"
+	"github.com/pardnchiu/agenvoy/internal/agents/provider/deepseek"
 	"github.com/pardnchiu/agenvoy/internal/agents/provider/gemini"
+	"github.com/pardnchiu/agenvoy/internal/agents/provider/grok"
 	"github.com/pardnchiu/agenvoy/internal/agents/provider/nvidia"
 	"github.com/pardnchiu/agenvoy/internal/agents/provider/openai"
 	openaicodex "github.com/pardnchiu/agenvoy/internal/agents/provider/openaiCodex"
@@ -16,15 +18,17 @@ import (
 
 func SelectAgent(model string) agentTypes.Agent {
 	agentMap := map[string]func(string) (agentTypes.Agent, error){
-		"copilot": func(m string) (agentTypes.Agent, error) { return copilot.New(m) },
-		"openai":  func(m string) (agentTypes.Agent, error) { return openai.New(m) },
-		"codex":   func(m string) (agentTypes.Agent, error) { return openaicodex.New(m) },
-		"compat":  func(m string) (agentTypes.Agent, error) { return compat.New(m) },
-		"claude":  func(m string) (agentTypes.Agent, error) { return claude.New(m) },
-		"gemini":  func(m string) (agentTypes.Agent, error) { return gemini.New(m) },
-		"nvidia":  func(m string) (agentTypes.Agent, error) { return nvidia.New(m) },
+		"copilot":  func(m string) (agentTypes.Agent, error) { return copilot.New(m) },
+		"openai":   func(m string) (agentTypes.Agent, error) { return openai.New(m) },
+		"codex":    func(m string) (agentTypes.Agent, error) { return openaicodex.New(m) },
+		"compat":   func(m string) (agentTypes.Agent, error) { return compat.New(m) },
+		"claude":   func(m string) (agentTypes.Agent, error) { return claude.New(m) },
+		"gemini":   func(m string) (agentTypes.Agent, error) { return gemini.New(m) },
+		"nvidia":   func(m string) (agentTypes.Agent, error) { return nvidia.New(m) },
+		"grok":     func(m string) (agentTypes.Agent, error) { return grok.New(m) },
+		"deepseek": func(m string) (agentTypes.Agent, error) { return deepseek.New(m) },
 	}
-	provider := strings.SplitN(model, "@", 2)[0]
+	provider, _, _ := strings.Cut(model, "@")
 	name, _, _ := strings.Cut(provider, "[")
 	fn, ok := agentMap[name]
 	if !ok {

--- a/internal/runtime/tui/cmdSelector.go
+++ b/internal/runtime/tui/cmdSelector.go
@@ -40,6 +40,7 @@ var commands = []Command{
 	{"new", "create / add new session · name conflict-checked"},
 	{"remove-session", "delete / purge current session · double-confirm · torii + sessions/ wiped"},
 	{"reset", "reset / refresh current session · double-confirm · summary regen first then drop history + tool_calls + action.log"},
+	{"summary", "force / regenerate summary now · no confirm · runs the hourly cron pass on demand"},
 	{"bot", "edit / rename current session · name / description (persona)"},
 	{"discord", "enable / disable Discord bot · gateway validated on enable"},
 	{"telegram", "enable / disable Telegram bot · getMe validated on enable"},

--- a/internal/runtime/tui/cmdSelector.go
+++ b/internal/runtime/tui/cmdSelector.go
@@ -39,6 +39,7 @@ var commands = []Command{
 	{"switch", "switch / change current session via picker"},
 	{"new", "create / add new session · name conflict-checked"},
 	{"remove-session", "delete / purge current session · double-confirm · torii + sessions/ wiped"},
+	{"reset", "reset / refresh current session · double-confirm · summary regen first then drop history + tool_calls + action.log"},
 	{"bot", "edit / rename current session · name / description (persona)"},
 	{"discord", "enable / disable Discord bot · gateway validated on enable"},
 	{"telegram", "enable / disable Telegram bot · getMe validated on enable"},

--- a/internal/runtime/tui/commandReset.go
+++ b/internal/runtime/tui/commandReset.go
@@ -1,0 +1,103 @@
+package tui
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/pardnchiu/agenvoy/internal/agents/exec"
+	"github.com/pardnchiu/agenvoy/internal/utils"
+)
+
+type ResetSessionConfirm1 struct {
+	id  string
+	yes bool
+}
+
+type ResetSessionConfirm2 struct {
+	id  string
+	yes bool
+}
+
+func (t TUI) commandReset() (TUI, tea.Cmd, bool) {
+	sid := strings.TrimSpace(t.currentSessionID)
+	if sid == "" {
+		return t, tea.Println(hintStyle.Render("no active session") + "\n"), true
+	}
+
+	label := utils.ShortenSessionID(sid)
+	t.popup = &Popup{
+		kind:     popupSingleSelect,
+		title:    fmt.Sprintf("Reset history for %s ?", label),
+		subtitle: "Summary will be regenerated first; bot identity and summary are kept.",
+		options:  []string{"No", "Yes"},
+		values:   []string{"no", "yes"},
+		cursor:   0,
+		onConfirm: func(chosen string) any {
+			return ResetSessionConfirm1{id: sid, yes: chosen == "yes"}
+		},
+	}
+	return t, nil, true
+}
+
+func (t TUI) openResetConfirm2(sid string) (TUI, tea.Cmd) {
+	t.popup = &Popup{
+		kind:     popupSingleSelect,
+		title:    "Are you sure? Raw history will be permanently dropped.",
+		subtitle: fmt.Sprintf("%s — summary refresh runs first; abort if refresh fails.", utils.ShortenSessionID(sid)),
+		options:  []string{"No", "Yes, reset it"},
+		values:   []string{"no", "yes"},
+		cursor:   0,
+		onConfirm: func(chosen string) any {
+			return ResetSessionConfirm2{id: sid, yes: chosen == "yes"}
+		},
+	}
+	return t, nil
+}
+
+type ResetSessionDone struct {
+	id   string
+	keys int
+	err  error
+}
+
+func (t TUI) runResetSession(sid string) (TUI, tea.Cmd) {
+	t.running = true
+	t.runStartedAt = time.Now()
+	t.runTarget = utils.ShortenSessionID(sid)
+	t.activity = "resetting (summary refresh first)…"
+
+	return t, tea.Batch(
+		tea.Println(hintStyle.Render(fmt.Sprintf("⎯ refreshing summary for %s, then clearing history…", utils.ShortenSessionID(sid))) + "\n"),
+		t.spinner.Tick,
+		func() tea.Msg {
+			ctx := context.Background()
+			keys, err := exec.ResetSessionWithSummary(ctx, sid)
+			return ResetSessionDone{id: sid, keys: keys, err: err}
+		},
+	)
+}
+
+func (t TUI) finishResetSession(msg ResetSessionDone) (TUI, tea.Cmd) {
+	t.running = false
+	t.activity = ""
+	t.runTarget = ""
+
+	if msg.err != nil {
+		return t, tea.Println(errorStyle.Render(fmt.Sprintf("[!] reset failed: %v", msg.err)) + "\n")
+	}
+
+	t.tokens = 0
+	t.lastIn = 0
+	t.lastOut = 0
+
+	seq := []tea.Cmd{
+		tea.ClearScreen,
+		tea.Println(headerBlock(t.cwd, t.daemonStatus, t.httpStatus, t.discordStatus, t.telegramStatus)),
+		tea.Println(hintStyle.Render(fmt.Sprintf("⎯ reset: %s (summary kept, %d torii keys purged)", utils.ShortenSessionID(msg.id), msg.keys)) + "\n"),
+	}
+	return t, tea.Sequence(seq...)
+}

--- a/internal/runtime/tui/commandSummary.go
+++ b/internal/runtime/tui/commandSummary.go
@@ -1,0 +1,55 @@
+package tui
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/pardnchiu/agenvoy/internal/agents/exec"
+	"github.com/pardnchiu/agenvoy/internal/utils"
+)
+
+type SummaryDone struct {
+	id    string
+	count int
+	err   error
+}
+
+func (t TUI) commandSummary() (TUI, tea.Cmd, bool) {
+	sid := strings.TrimSpace(t.currentSessionID)
+	if sid == "" {
+		return t, tea.Println(hintStyle.Render("no active session") + "\n"), true
+	}
+
+	t.running = true
+	t.runStartedAt = time.Now()
+	t.runTarget = utils.ShortenSessionID(sid)
+	t.activity = "regenerating summary…"
+
+	return t, tea.Batch(
+		tea.Println(hintStyle.Render(fmt.Sprintf("⎯ refreshing summary for %s…", utils.ShortenSessionID(sid))) + "\n"),
+		t.spinner.Tick,
+		func() tea.Msg {
+			ctx := context.Background()
+			count, err := exec.ForceSummary(ctx, sid)
+			return SummaryDone{id: sid, count: count, err: err}
+		},
+	), true
+}
+
+func (t TUI) finishSummary(msg SummaryDone) (TUI, tea.Cmd) {
+	t.running = false
+	t.activity = ""
+	t.runTarget = ""
+
+	if msg.err != nil {
+		return t, tea.Println(errorStyle.Render(fmt.Sprintf("[!] summary failed: %v", msg.err)) + "\n")
+	}
+	if msg.count == 0 {
+		return t, tea.Println(hintStyle.Render(fmt.Sprintf("⎯ summary: %s (nothing new to summarize)", utils.ShortenSessionID(msg.id))) + "\n")
+	}
+	return t, tea.Println(hintStyle.Render(fmt.Sprintf("⎯ summary: %s (%d messages processed)", utils.ShortenSessionID(msg.id), msg.count)) + "\n")
+}

--- a/internal/runtime/tui/handlerCommand.go
+++ b/internal/runtime/tui/handlerCommand.go
@@ -45,6 +45,9 @@ func (t TUI) handleCommand(cmd string) (TUI, tea.Cmd, bool) {
 	case "/reset":
 		return t.commandReset()
 
+	case "/summary":
+		return t.commandSummary()
+
 	case "/bot":
 		return t.commandBot(parts)
 

--- a/internal/runtime/tui/handlerCommand.go
+++ b/internal/runtime/tui/handlerCommand.go
@@ -42,6 +42,9 @@ func (t TUI) handleCommand(cmd string) (TUI, tea.Cmd, bool) {
 	case "/remove-session":
 		return t.commandRemoveSession()
 
+	case "/reset":
+		return t.commandReset()
+
 	case "/bot":
 		return t.commandBot(parts)
 

--- a/internal/runtime/tui/update.go
+++ b/internal/runtime/tui/update.go
@@ -503,6 +503,10 @@ func (t TUI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		next, cmd := t.finishResetSession(msg)
 		return next, cmd
 
+	case SummaryDone:
+		next, cmd := t.finishSummary(msg)
+		return next, cmd
+
 	case TaskEditSelect:
 		next, cmd := t.openTaskEditRequirement(msg.skill, msg.at)
 		return next, cmd

--- a/internal/runtime/tui/update.go
+++ b/internal/runtime/tui/update.go
@@ -485,6 +485,24 @@ func (t TUI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		next, cmd := t.runRemoveSession(msg.id)
 		return next, cmd
 
+	case ResetSessionConfirm1:
+		if !msg.yes {
+			return t, tea.Println(hintStyle.Render("⎯ reset cancelled") + "\n")
+		}
+		next, cmd := t.openResetConfirm2(msg.id)
+		return next, cmd
+
+	case ResetSessionConfirm2:
+		if !msg.yes {
+			return t, tea.Println(hintStyle.Render("⎯ reset cancelled") + "\n")
+		}
+		next, cmd := t.runResetSession(msg.id)
+		return next, cmd
+
+	case ResetSessionDone:
+		next, cmd := t.finishResetSession(msg)
+		return next, cmd
+
 	case TaskEditSelect:
 		next, cmd := t.openTaskEditRequirement(msg.skill, msg.at)
 		return next, cmd

--- a/internal/session/reset.go
+++ b/internal/session/reset.go
@@ -1,0 +1,34 @@
+package session
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/pardnchiu/agenvoy/internal/filesystem"
+	"github.com/pardnchiu/agenvoy/internal/runtime/torii"
+)
+
+func ResetHistoryKeepSummary(sessionID string) (int, error) {
+	if sessionID == "" {
+		return 0, fmt.Errorf("session id is required")
+	}
+	sessionDir := filepath.Join(filesystem.SessionsDir, sessionID)
+
+	if err := os.Remove(filesystem.HistoryPath(sessionID)); err != nil && !os.IsNotExist(err) {
+		return 0, fmt.Errorf("os.Remove history.json: %w", err)
+	}
+	if err := os.RemoveAll(filepath.Join(sessionDir, "tool_calls")); err != nil {
+		return 0, fmt.Errorf("os.RemoveAll tool_calls: %w", err)
+	}
+	if err := os.Remove(filepath.Join(sessionDir, "action.log")); err != nil && !os.IsNotExist(err) {
+		return 0, fmt.Errorf("os.Remove action.log: %w", err)
+	}
+
+	db := torii.DB(torii.DBSessionHist)
+	keys := db.Keys(sessionID + ":*")
+	if len(keys) == 0 {
+		return 0, nil
+	}
+	return db.Del(keys...), nil
+}

--- a/internal/session/summary.go
+++ b/internal/session/summary.go
@@ -84,29 +84,8 @@ func GetSummaryPrompt(sessionID string, cutoff time.Time) string {
 	}
 
 	if !cutoff.IsZero() && summaryMap != nil {
-		if logs, ok := summaryMap["discussion_log"].([]any); ok {
-			filtered := make([]any, 0, len(logs))
-			for _, item := range logs {
-				m, ok := item.(map[string]any)
-				if !ok {
-					continue
-				}
-				t, ok := m["time"].(string)
-				if !ok {
-					filtered = append(filtered, item)
-					continue
-				}
-				// discussion_log time format: "2006-01-02 15:04"
-				if parsed, err := time.ParseInLocation("2006-01-02 15:04", t, time.Local); err == nil {
-					if !parsed.Before(cutoff) {
-						filtered = append(filtered, item)
-					}
-				} else {
-					filtered = append(filtered, item)
-				}
-			}
-			summaryMap["discussion_log"] = filtered
-		}
+		filterByTimeField(summaryMap, "past_discussions", "last_discussed", cutoff)
+		filterByTimeField(summaryMap, "discussion_log", "time", cutoff)
 		if b, err := json.Marshal(summaryMap); err == nil {
 			raw = b
 		}
@@ -148,4 +127,32 @@ func SaveSummary(sessionID string, data any) {
 			slog.String("session", sessionID),
 			slog.String("error", err.Error()))
 	}
+}
+
+func filterByTimeField(summaryMap map[string]any, listField, timeField string, cutoff time.Time) {
+	items, ok := summaryMap[listField].([]any)
+	if !ok {
+		return
+	}
+	filtered := make([]any, 0, len(items))
+	for _, item := range items {
+		record, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		t, ok := record[timeField].(string)
+		if !ok {
+			filtered = append(filtered, item)
+			continue
+		}
+		parsed, err := time.ParseInLocation("2006-01-02 15:04", t, time.Local)
+		if err != nil {
+			filtered = append(filtered, item)
+			continue
+		}
+		if !parsed.Before(cutoff) {
+			filtered = append(filtered, item)
+		}
+	}
+	summaryMap[listField] = filtered
 }

--- a/internal/tools/runCommand.go
+++ b/internal/tools/runCommand.go
@@ -64,13 +64,15 @@ func runCommand(ctx context.Context, e *toolTypes.Executor, argv []string) (stri
 
 	binary := filepath.Base(argv[0])
 
-	if binary == "sh" && len(argv) >= 3 && argv[1] == "-c" {
-		inner := strings.Fields(argv[2])
-		if len(inner) == 0 {
-			return "", fmt.Errorf("sh -c requires a non-empty command string")
+	if (binary == "sh" || binary == "bash") && len(argv) >= 3 && argv[1] == "-c" {
+		if !e.AllowedCommand[binary] {
+			return "", fmt.Errorf("failed to run command: %s is not allowed", binary)
 		}
-		if !e.AllowedCommand[filepath.Base(inner[0])] {
-			return "", fmt.Errorf("failed to run command: %s is not allowed", inner[0])
+		if strings.TrimSpace(argv[2]) == "" {
+			return "", fmt.Errorf("%s -c requires a non-empty command string", binary)
+		}
+		if err := validateShellScript(argv[2], e.AllowedCommand); err != nil {
+			return "", err
 		}
 	} else {
 		if binary == "cd" {

--- a/internal/tools/runCommandShell.go
+++ b/internal/tools/runCommandShell.go
@@ -1,0 +1,95 @@
+package tools
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"mvdan.cc/sh/v3/syntax"
+)
+
+var shellAllow = map[string]bool{
+	":": true, "true": true, "false": true,
+	"cd": true, "pwd": true,
+	"echo": true, "printf": true, "read": true,
+	"test": true, "[": true,
+	"set": true, "unset": true, "shift": true,
+	"export": true, "readonly": true, "local": true, "declare": true, "typeset": true,
+	"return": true, "exit": true, "break": true, "continue": true,
+	"trap": true, "wait": true, "umask": true,
+	"alias": true, "unalias": true, "hash": true, "type": true,
+	"getopts": true, "let": true,
+}
+
+func validateShellScript(script string, allowed map[string]bool) error {
+	file, err := syntax.NewParser().Parse(strings.NewReader(script), "")
+	if err != nil {
+		return fmt.Errorf("sh -c parse: %w", err)
+	}
+	var bad error
+	syntax.Walk(file, func(node syntax.Node) bool {
+		if bad != nil {
+			return false
+		}
+		call, ok := node.(*syntax.CallExpr)
+		if !ok || len(call.Args) == 0 {
+			return true
+		}
+		bin, ok := staticWord(call.Args[0])
+		if !ok {
+			bad = fmt.Errorf("sh -c: dynamic command (variable or substitution) not allowed")
+			return false
+		}
+		base := filepath.Base(bin)
+		if shellAllow[base] {
+			return true
+		}
+		if !allowed[base] {
+			bad = fmt.Errorf("failed to run command: %s is not allowed", bin)
+			return false
+		}
+		if (base == "sh" || base == "bash") && len(call.Args) >= 3 {
+			flag, ok := staticWord(call.Args[1])
+			if !ok || flag != "-c" {
+				return true
+			}
+			inner, ok := staticWord(call.Args[2])
+			if !ok {
+				bad = fmt.Errorf("sh -c: nested %s -c with dynamic script not allowed", base)
+				return false
+			}
+			if err := validateShellScript(inner, allowed); err != nil {
+				bad = err
+				return false
+			}
+		}
+		return true
+	})
+	return bad
+}
+
+func staticWord(w *syntax.Word) (string, bool) {
+	if w == nil {
+		return "", false
+	}
+	var sb strings.Builder
+	for _, p := range w.Parts {
+		switch x := p.(type) {
+		case *syntax.Lit:
+			sb.WriteString(x.Value)
+		case *syntax.SglQuoted:
+			sb.WriteString(x.Value)
+		case *syntax.DblQuoted:
+			for _, pp := range x.Parts {
+				lit, ok := pp.(*syntax.Lit)
+				if !ok {
+					return "", false
+				}
+				sb.WriteString(lit.Value)
+			}
+		default:
+			return "", false
+		}
+	}
+	return sb.String(), true
+}

--- a/wiki/Providers.md
+++ b/wiki/Providers.md
@@ -2,7 +2,7 @@
 
 > [中文](Providers.zh.md)
 
-Agenvoy supports seven LLM providers behind a unified `Agent.Send()` interface.
+Agenvoy supports nine LLM providers behind a unified `Agent.Send()` interface.
 
 ## Supported list
 
@@ -14,9 +14,11 @@ Agenvoy supports seven LLM providers behind a unified `Agent.Send()` interface.
 | Google Gemini | `gemini` | gemini-2.x / 3.x families |
 | GitHub Copilot | `copilot` | Requires GitHub OAuth (one-shot login flow) |
 | Nvidia NIM | `nvidia` | Llama, Mistral, and other open-weight hosted models |
+| xAI Grok | `grok` | grok-4 / grok-3 families incl. `grok-code-fast-1`; non-streaming HTTP client |
+| DeepSeek | `deepseek` | `deepseek-chat` (tool use) and `deepseek-reasoner` (CoT, temperature disabled); non-streaming HTTP client |
 | Compat | `compat` | Any custom OpenAI-compatible endpoint |
 
-> **On the `providors/` spelling** — intentional convention; do not "fix" it. Provider JSON catalogs live under `configs/jsons/providors/`. Six static files ship today (`claude.json`, `openai.json`, `codex.json`, `gemini.json`, `copilot.json`, `nvidia.json`); `compat` is constructed at runtime from user-supplied endpoints.
+> **On the `providors/` spelling** — intentional convention; do not "fix" it. Provider JSON catalogs live under `configs/jsons/providors/`. Eight static files ship today (`claude.json`, `openai.json`, `codex.json`, `gemini.json`, `copilot.json`, `nvidia.json`, `grok.json`, `deepseek.json`); `compat` is constructed at runtime from user-supplied endpoints.
 
 ## Provider configuration
 

--- a/wiki/Providers.zh.md
+++ b/wiki/Providers.zh.md
@@ -2,7 +2,7 @@
 
 > [English](Providers.md)
 
-Agenvoy 透過統一的 `Agent.Send()` 介面支援 7 家 LLM provider。
+Agenvoy 透過統一的 `Agent.Send()` 介面支援 9 家 LLM provider。
 
 ## 支援清單
 
@@ -14,9 +14,11 @@ Agenvoy 透過統一的 `Agent.Send()` 介面支援 7 家 LLM provider。
 | Google Gemini | `gemini` | gemini-2.x / 3.x 系列 |
 | GitHub Copilot | `copilot` | 需 GitHub OAuth（一次性登入） |
 | Nvidia NIM | `nvidia` | Llama、Mistral 等 hosted 開源模型 |
+| xAI Grok | `grok` | grok-4／grok-3 系列含 `grok-code-fast-1`；非串流 HTTP client |
+| DeepSeek | `deepseek` | `deepseek-chat`（tool use）與 `deepseek-reasoner`（CoT，停用 temperature）；非串流 HTTP client |
 | Compat | `compat` | 任何 OpenAI 相容格式的自訂 endpoint |
 
-> **`providors/` 拼寫** —— 是慣例非錯字，請勿「修正」。Provider JSON 目錄在 `configs/jsons/providors/`，現有 6 份靜態 catalog（`claude.json`、`openai.json`、`codex.json`、`gemini.json`、`copilot.json`、`nvidia.json`）；`compat` 由使用者輸入動態建構。
+> **`providors/` 拼寫** —— 是慣例非錯字，請勿「修正」。Provider JSON 目錄在 `configs/jsons/providors/`，現有 8 份靜態 catalog（`claude.json`、`openai.json`、`codex.json`、`gemini.json`、`copilot.json`、`nvidia.json`、`grok.json`、`deepseek.json`）；`compat` 由使用者輸入動態建構。
 
 ## Provider 配置
 


### PR DESCRIPTION
Expands the cloud provider catalogue with two non-streaming completion backends and splits the shared HTTP client to host streaming and non-streaming transports side by side. Adds TUI ergonomics for manual summary regeneration and a guarded session-reset flow that aborts when the summary refresh itself fails. Hardens shell command execution with an AST validator that blocks dynamic-binary bypass vectors previously missed by token-level scanning.
