### PR TITLE
Add runtime monitoring and enhance warning logging

### DIFF
--- a/cmd/app/cmdDeamon.go
+++ b/cmd/app/cmdDeamon.go
@@ -29,6 +29,7 @@ import (
 	discordTool "github.com/pardnchiu/agenvoy/internal/runtime/discord/tool"
 	"github.com/pardnchiu/agenvoy/internal/runtime/kuradb"
 	kuradbTool "github.com/pardnchiu/agenvoy/internal/runtime/kuradb/tool"
+	"github.com/pardnchiu/agenvoy/internal/runtime/monitor"
 	"github.com/pardnchiu/agenvoy/internal/runtime/telegram"
 	telegramTool "github.com/pardnchiu/agenvoy/internal/runtime/telegram/tool"
 	"github.com/pardnchiu/agenvoy/internal/runtime/torii"
@@ -246,6 +247,7 @@ func cmdDaemon() {
 	reloadDiscord()
 	reloadTelegram()
 	reloadKuradb()
+	monitor.Start(context.Background())
 
 	route := routes.New()
 	server := &http.Server{

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/gin-gonic/gin v1.12.0
 	github.com/go-telegram/bot v1.20.0
 	github.com/pardnchiu/ToriiDB v0.5.1
-	github.com/pardnchiu/go-bot v0.3.5
+	github.com/pardnchiu/go-bot v0.3.6
 	github.com/pardnchiu/go-browser v0.1.3
 	github.com/pardnchiu/go-pkg v0.13.0
 	github.com/pardnchiu/go-scheduler v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -116,8 +116,8 @@ github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/pardnchiu/ToriiDB v0.5.1 h1:+jEtX4L1Pb1CZMYk485f6ulkR0w6I3jvz69fzmge0Ho=
 github.com/pardnchiu/ToriiDB v0.5.1/go.mod h1:0p0IsrySqXyXvKIJswKKG1Zi6wQ2TD/LdKcKx4It/EA=
-github.com/pardnchiu/go-bot v0.3.5 h1:VpYKUrNFERrZPCzIn5hzk4U5QiIctQmq8w1cmkmiuo0=
-github.com/pardnchiu/go-bot v0.3.5/go.mod h1:OtqtjyXnlRFlh6AEgxNE6Tykqic8rUWQqmco/TAvNF4=
+github.com/pardnchiu/go-bot v0.3.6 h1:XkEaGxg/gNX/jWDkY1C7Uw2aWOadjVCa2n0fkBB6dqw=
+github.com/pardnchiu/go-bot v0.3.6/go.mod h1:OtqtjyXnlRFlh6AEgxNE6Tykqic8rUWQqmco/TAvNF4=
 github.com/pardnchiu/go-browser v0.1.3 h1:bbpfMppFrWR3KX8jKMUAmyzSL8VjJYZiSgkHw5haZQY=
 github.com/pardnchiu/go-browser v0.1.3/go.mod h1:F4Ms8dIbPb23MX0FMZ6w3PKnjFs+wNsd4QJmirXkEd0=
 github.com/pardnchiu/go-pkg v0.13.0 h1:E0qGiEQPpf0hWLl9U3gU2AiDbDm7DwX1xQargoZ5rDM=

--- a/internal/agents/exec/execute.go
+++ b/internal/agents/exec/execute.go
@@ -311,10 +311,10 @@ func Execute(ctx context.Context, data ExecData, session *agentTypes.AgentSessio
 			}
 			if isContextLengthError(err) {
 				trimmedToolCalls = trimmedToolCalls || trimOnContextExceeded(&session.OldHistories, &session.ToolHistories)
-				slog.Debug("data.Agent.Send context length exceeded, trimming oldest exchange",
+				slog.Warn("data.Agent.Send context length exceeded, trimming oldest exchange",
 					slog.String("session", session.ID))
 			} else {
-				slog.Debug("data.Agent.Send",
+				slog.Warn("data.Agent.Send",
 					slog.String("session", session.ID),
 					slog.String("error", err.Error()),
 					slog.Bool("timeout", isTimeout),
@@ -332,7 +332,7 @@ func Execute(ctx context.Context, data ExecData, session *agentTypes.AgentSessio
 							continue
 						}
 						if !ProbeAgent(ctx, cand, ProbeTimeout) {
-							slog.Debug("fallback probe failed",
+							slog.Warn("fallback probe failed",
 								slog.String("session", session.ID),
 								slog.String("name", cand.Name()))
 							continue

--- a/internal/agents/exec/selectAgent.go
+++ b/internal/agents/exec/selectAgent.go
@@ -102,7 +102,7 @@ func SelectAgentNames(ctx context.Context, bot agentTypes.Agent, registry agentT
 				if sendErr == nil {
 					break
 				}
-				slog.Debug("dispatcher routing attempt failed",
+				slog.Warn("dispatcher routing attempt failed",
 					slog.String("name", bot.Name()),
 					slog.String("error", sendErr.Error()))
 			}
@@ -205,7 +205,7 @@ func ResolveAgent(ctx context.Context, bot agentTypes.Agent, registry agentTypes
 			return a, rest, nil
 		}
 		dead[a.Name()] = true
-		slog.Debug("agent probe failed",
+		slog.Warn("agent probe failed",
 			slog.String("name", a.Name()),
 			slog.Duration("timeout", ProbeTimeout))
 	}

--- a/internal/agents/exec/toolCall.go
+++ b/internal/agents/exec/toolCall.go
@@ -84,7 +84,11 @@ func toolCall(ctx context.Context, exec *toolTypes.Executor, choice agentTypes.O
 		if exec.StubTools[toolName] || activatedInBatch[toolName] {
 			if exec.StubTools[toolName] {
 				activateArgs, _ := json.Marshal(map[string]any{"query": "select:" + toolName})
-				_, _ = toolRegister.Dispatch(ctx, exec, "search_tools", activateArgs)
+				if _, err := toolRegister.Dispatch(ctx, exec, "search_tools", activateArgs); err != nil {
+					slog.Warn("stub tool activation failed",
+						slog.String("name", toolName),
+						slog.String("error", err.Error()))
+				}
 				delete(exec.StubTools, toolName)
 			}
 			activatedInBatch[toolName] = true

--- a/internal/agents/provider/copilot/login.go
+++ b/internal/agents/provider/copilot/login.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"os/exec"
 	"runtime"
@@ -98,7 +99,11 @@ func OpenBrowser(url string) {
 		return
 	}
 	if cmd != nil {
-		_ = cmd.Start()
+		if err := cmd.Start(); err != nil {
+			slog.Warn("openBrowser cmd.Start",
+				slog.String("url", url),
+				slog.String("error", err.Error()))
+		}
 	}
 }
 

--- a/internal/agents/provider/openaiCodex/login.go
+++ b/internal/agents/provider/openaiCodex/login.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/url"
@@ -218,5 +219,9 @@ func openBrowser(link string) {
 	default:
 		return
 	}
-	_ = cmd.Start()
+	if err := cmd.Start(); err != nil {
+		slog.Warn("openBrowser cmd.Start",
+			slog.String("url", link),
+			slog.String("error", err.Error()))
+	}
 }

--- a/internal/filesystem/git.go
+++ b/internal/filesystem/git.go
@@ -3,6 +3,7 @@ package filesystem
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"path/filepath"
 	"strings"
 	"time"
@@ -151,12 +152,23 @@ func RunCommitSkillDir(ctx context.Context, path string, isNew bool) {
 	if isNew {
 		act = "add"
 	}
-	_ = CommitSkillDir(ctx, act, GetSkillName(path))
+	name := GetSkillName(path)
+	if err := CommitSkillDir(ctx, act, name); err != nil {
+		slog.Warn("CommitSkillDir",
+			slog.String("action", act),
+			slog.String("name", name),
+			slog.String("error", err.Error()))
+	}
 }
 
 func RunTrashCommitSkillDir(ctx context.Context, name string) {
 	if err := CheckSkillGitDir(ctx); err != nil {
 		return
 	}
-	_ = CommitSkillDir(ctx, "trash", name)
+	if err := CommitSkillDir(ctx, "trash", name); err != nil {
+		slog.Warn("CommitSkillDir",
+			slog.String("action", "trash"),
+			slog.String("name", name),
+			slog.String("error", err.Error()))
+	}
 }

--- a/internal/runtime/listener.go
+++ b/internal/runtime/listener.go
@@ -250,7 +250,7 @@ func (l *Listener[CID, MID]) OnCallback(ctx context.Context, chatID CID, msgID M
 	state := l.cur[chatID]
 	if state == nil {
 		l.mu.Unlock()
-		slog.Debug("connector.OnCallback miss (no state)",
+		slog.Warn("connector.OnCallback miss (no state)",
 			slog.String("prefix", l.prefix),
 			slog.Any("chat", chatID),
 			slog.Any("msg", msgID))
@@ -259,7 +259,7 @@ func (l *Listener[CID, MID]) OnCallback(ctx context.Context, chatID CID, msgID M
 	if state.message != msgID {
 		expected := state.message
 		l.mu.Unlock()
-		slog.Debug("connector.OnCallback miss (msg mismatch)",
+		slog.Warn("connector.OnCallback miss (msg mismatch)",
 			slog.String("prefix", l.prefix),
 			slog.Any("chat", chatID),
 			slog.Any("got_msg", msgID),

--- a/internal/runtime/monitor/monitor.go
+++ b/internal/runtime/monitor/monitor.go
@@ -1,0 +1,124 @@
+package monitor
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	goruntime "runtime"
+	"runtime/metrics"
+	"time"
+)
+
+const (
+	tickInterval    = 30 * time.Second
+	cpuWarnPercent  = 80.0
+	ramWarnBytes    = uint64(2) << 30
+	netProbeTarget  = "1.1.1.1:443"
+	netProbeTimeout = 5 * time.Second
+)
+
+func Start(ctx context.Context) {
+	go run(ctx)
+}
+
+func run(ctx context.Context) {
+	ticker := time.NewTicker(tickInterval)
+	defer ticker.Stop()
+
+	lastCPU, hasCPU := sampleCPUSeconds()
+	lastTick := time.Now()
+
+	var cpuOver, ramOver, netDown bool
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case now := <-ticker.C:
+			if cur, ok := sampleCPUSeconds(); ok {
+				if hasCPU {
+					elapsed := now.Sub(lastTick).Seconds()
+					if elapsed > 0 {
+						pct := (cur - lastCPU) / elapsed / float64(goruntime.NumCPU()) * 100
+						if pct >= cpuWarnPercent {
+							slog.Warn("monitor: high CPU",
+								slog.Float64("percent", pct),
+								slog.Int("cpus", goruntime.NumCPU()))
+							cpuOver = true
+						} else if cpuOver {
+							slog.Info("monitor: CPU recovered",
+								slog.Float64("percent", pct))
+							cpuOver = false
+						}
+					}
+				}
+				lastCPU = cur
+				lastTick = now
+				hasCPU = true
+			}
+
+			var m goruntime.MemStats
+			goruntime.ReadMemStats(&m)
+			if m.Sys >= ramWarnBytes {
+				slog.Warn("monitor: high RAM",
+					slog.String("sys", humanBytes(m.Sys)),
+					slog.String("alloc", humanBytes(m.Alloc)))
+				ramOver = true
+			} else if ramOver {
+				slog.Info("monitor: RAM recovered",
+					slog.String("sys", humanBytes(m.Sys)))
+				ramOver = false
+			}
+
+			if err := probeNetwork(ctx); err != nil {
+				slog.Warn("monitor: no network",
+					slog.String("target", netProbeTarget),
+					slog.String("error", err.Error()))
+				netDown = true
+			} else if netDown {
+				slog.Info("monitor: network recovered",
+					slog.String("target", netProbeTarget))
+				netDown = false
+			}
+		}
+	}
+}
+
+func sampleCPUSeconds() (float64, bool) {
+	samples := []metrics.Sample{{Name: "/cpu/classes/total:cpu-seconds"}}
+	metrics.Read(samples)
+	if samples[0].Value.Kind() != metrics.KindFloat64 {
+		return 0, false
+	}
+	return samples[0].Value.Float64(), true
+}
+
+func probeNetwork(ctx context.Context) error {
+	probeCtx, cancel := context.WithTimeout(ctx, netProbeTimeout)
+	defer cancel()
+	dialer := &net.Dialer{}
+	conn, err := dialer.DialContext(probeCtx, "tcp", netProbeTarget)
+	if err != nil {
+		return err
+	}
+	return conn.Close()
+}
+
+func humanBytes(b uint64) string {
+	const (
+		k = 1024
+		m = k * 1024
+		g = m * 1024
+	)
+	switch {
+	case b >= g:
+		return fmt.Sprintf("%.2fGiB", float64(b)/float64(g))
+	case b >= m:
+		return fmt.Sprintf("%.2fMiB", float64(b)/float64(m))
+	case b >= k:
+		return fmt.Sprintf("%.2fKiB", float64(b)/float64(k))
+	default:
+		return fmt.Sprintf("%dB", b)
+	}
+}

--- a/internal/runtime/tui/commandDiscord.go
+++ b/internal/runtime/tui/commandDiscord.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -103,7 +104,10 @@ func disableDiscord() tea.Cmd {
 		if !cfg.DiscordEnabled && keychain.Get(discord.Key) == "" {
 			return DiscordDone{action: "disable"}
 		}
-		_ = keychain.Delete(discord.Key)
+		if err := keychain.Delete(discord.Key); err != nil {
+			slog.Warn("keychain.Delete discord token",
+				slog.String("error", err.Error()))
+		}
 		cfg.DiscordEnabled = false
 		if err := session.Save(cfg); err != nil {
 			return DiscordDone{action: "disable", err: fmt.Errorf("session.Save: %w", err)}

--- a/internal/runtime/tui/commandTelegram.go
+++ b/internal/runtime/tui/commandTelegram.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -103,7 +104,10 @@ func disableTelegram() tea.Cmd {
 		if !cfg.TelegramEnabled && keychain.Get(telegram.Key) == "" {
 			return TelegramDone{action: "disable"}
 		}
-		_ = keychain.Delete(telegram.Key)
+		if err := keychain.Delete(telegram.Key); err != nil {
+			slog.Warn("keychain.Delete telegram token",
+				slog.String("error", err.Error()))
+		}
 		cfg.TelegramEnabled = false
 		if err := session.Save(cfg); err != nil {
 			return TelegramDone{action: "disable", err: fmt.Errorf("session.Save: %w", err)}

--- a/internal/tools/executor.go
+++ b/internal/tools/executor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"sort"
 
 	"github.com/pardnchiu/agenvoy/extensions"
@@ -145,7 +146,11 @@ func Execute(ctx context.Context, e *toolTypes.Executor, name string, args json.
 
 	if e.StubTools[name] {
 		activateArgs, _ := json.Marshal(map[string]any{"query": "select:" + name})
-		_, _ = toolRegister.Dispatch(ctx, e, "search_tools", activateArgs)
+		if _, err := toolRegister.Dispatch(ctx, e, "search_tools", activateArgs); err != nil {
+			slog.Warn("stub tool activation failed",
+				slog.String("name", name),
+				slog.String("error", err.Error()))
+		}
 		delete(e.StubTools, name)
 	}
 


### PR DESCRIPTION
Adds a startup resource monitor that watches CPU, RAM, and network reachability, escalating threshold breaches to the daemon log. Transient retry, probe, and silent-fallback paths across the daemon now also surface at warn level, so operational issues become visible before they cascade.
