### PR TITLE
Enhance error reporting and monitoring features

### DIFF
--- a/cmd/app/buildAgentRegistry.go
+++ b/cmd/app/buildAgentRegistry.go
@@ -69,7 +69,16 @@ func dispatcherSelector(registry agentTypes.AgentRegistry) agentTypes.Agent {
 	return registry.Fallback
 }
 
-func refreshHost() (agentTypes.Agent, agentTypes.AgentRegistry) {
+func summarySelector(registry agentTypes.AgentRegistry) agentTypes.Agent {
+	if cfg, err := session.Load(); err == nil && cfg.SummaryModel != "" {
+		if a, ok := registry.Registry[cfg.SummaryModel]; ok {
+			return a
+		}
+	}
+	return nil
+}
+
+func refreshHost() (agentTypes.Agent, agentTypes.Agent, agentTypes.AgentRegistry) {
 	registry := buildAgentRegistry()
-	return dispatcherSelector(registry), registry
+	return dispatcherSelector(registry), summarySelector(registry), registry
 }

--- a/cmd/app/cmdDeamon.go
+++ b/cmd/app/cmdDeamon.go
@@ -227,8 +227,9 @@ func cmdDaemon() {
 	registry := buildAgentRegistry()
 	scanner := runtime.NewSkillScanner()
 	selectorBot := dispatcherSelector(registry)
+	summaryBot := summarySelector(registry)
 
-	agents.Set(selectorBot, registry, scanner)
+	agents.Set(selectorBot, summaryBot, registry, scanner)
 	agents.SetRefresher(refreshHost)
 
 	runtime.SetRunner(runSkill)

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -105,7 +105,11 @@ func setSummaryCron() {
 				continue
 			}
 			bgCtx := context.Background()
-			summaryAgent := exec.SelectAgent(bgCtx, agents.Dispatcher(), agents.Registry(), "[summary] background summary cron", false, sid)
+			router := agents.Summary()
+			if router == nil {
+				router = agents.Dispatcher()
+			}
+			summaryAgent := exec.SelectAgent(bgCtx, router, agents.Registry(), "[summary] background summary cron", false, sid)
 			if summaryAgent == nil {
 				continue
 			}

--- a/cmd/app/newTUI.go
+++ b/cmd/app/newTUI.go
@@ -84,8 +84,9 @@ func newTUI(initialInput string, onceCall, allowAll bool) {
 	registry := buildAgentRegistry()
 	scanner := runtime.NewSkillScanner()
 	selectorBot := dispatcherSelector(registry)
+	summaryBot := summarySelector(registry)
 
-	agents.Set(selectorBot, registry, scanner)
+	agents.Set(selectorBot, summaryBot, registry, scanner)
 	agents.SetRefresher(refreshHost)
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/configs/jsons/providors/nvidia.json
+++ b/configs/jsons/providors/nvidia.json
@@ -2,10 +2,13 @@
   "openai/gpt-oss-120b": {
     "description": "OpenAI 開源 120B 模型，平衡效能與推理能力"
   },
-  "meta/llama-3.3-70b-instruct": {
-    "description": "OpenAI 開源 120B 模型，平衡效能與推理能力"
-  },
   "nvidia/nemotron-3-super-120b-a12b": {
     "description": "NVIDIA Nemotron-3 Super 120B（12B active）Hybrid LatentMoE 模型，支援 Tool Use、多語言與 Agentic 推理工作流"
+  },
+  "deepseek-ai/deepseek-v4-flash": {
+    "description": "DeepSeek V4 Flash 模型，專為高效推理和多模態任務設計，適合需要快速響應的應用"
+  },
+  "deepseek-ai/deepseek-v4-pro": {
+    "description": "DeepSeek V4 Pro 模型，提供更強大的推理能力和更高的準確性，適合需要深入分析和複雜任務的應用"
   }
 }

--- a/internal/agents/exec/reset.go
+++ b/internal/agents/exec/reset.go
@@ -6,8 +6,16 @@ import (
 
 	"github.com/pardnchiu/agenvoy/internal/agents"
 	"github.com/pardnchiu/agenvoy/internal/agents/summary"
+	agentTypes "github.com/pardnchiu/agenvoy/internal/agents/types"
 	sessionManager "github.com/pardnchiu/agenvoy/internal/session"
 )
+
+func summaryRouter() agentTypes.Agent {
+	if a := agents.Summary(); a != nil {
+		return a
+	}
+	return agents.Dispatcher()
+}
 
 func ForceSummary(ctx context.Context, sessionID string) (int, error) {
 	if sessionID == "" {
@@ -20,7 +28,7 @@ func ForceSummary(ctx context.Context, sessionID string) (int, error) {
 		return 0, nil
 	}
 
-	agent := SelectAgent(ctx, agents.Dispatcher(), agents.Registry(), "[summary] force refresh", false, sessionID)
+	agent := SelectAgent(ctx, summaryRouter(), agents.Registry(), "[summary] force refresh", false, sessionID)
 	if agent == nil {
 		return 0, fmt.Errorf("no agent available for summary refresh")
 	}
@@ -39,7 +47,7 @@ func ResetSessionWithSummary(ctx context.Context, sessionID string) (int, error)
 	summaryHistories := summary.Get(histories)
 
 	if len(summaryHistories) > 0 {
-		agent := SelectAgent(ctx, agents.Dispatcher(), agents.Registry(), "[summary] reset session", false, sessionID)
+		agent := SelectAgent(ctx, summaryRouter(), agents.Registry(), "[summary] reset session", false, sessionID)
 		if agent == nil {
 			return 0, fmt.Errorf("no agent available for summary refresh; reset aborted")
 		}

--- a/internal/agents/host.go
+++ b/internal/agents/host.go
@@ -7,20 +7,22 @@ import (
 	"github.com/pardnchiu/agenvoy/internal/runtime"
 )
 
-type RefreshFunc func() (agentTypes.Agent, agentTypes.AgentRegistry)
+type RefreshFunc func() (agentTypes.Agent, agentTypes.Agent, agentTypes.AgentRegistry)
 
 var (
 	mu         sync.RWMutex
 	dispatcher agentTypes.Agent
+	summary    agentTypes.Agent
 	registry   agentTypes.AgentRegistry
 	scanner    *runtime.SkillScanner
 	refresher  RefreshFunc
 )
 
-func Set(d agentTypes.Agent, r agentTypes.AgentRegistry, s *runtime.SkillScanner) {
+func Set(d agentTypes.Agent, sm agentTypes.Agent, r agentTypes.AgentRegistry, s *runtime.SkillScanner) {
 	mu.Lock()
 	defer mu.Unlock()
 	dispatcher = d
+	summary = sm
 	registry = r
 	scanner = s
 }
@@ -38,9 +40,10 @@ func Reload() bool {
 	if fn == nil {
 		return false
 	}
-	d, r := fn()
+	d, sm, r := fn()
 	mu.Lock()
 	dispatcher = d
+	summary = sm
 	registry = r
 	mu.Unlock()
 	return true
@@ -50,6 +53,12 @@ func Dispatcher() agentTypes.Agent {
 	mu.RLock()
 	defer mu.RUnlock()
 	return dispatcher
+}
+
+func Summary() agentTypes.Agent {
+	mu.RLock()
+	defer mu.RUnlock()
+	return summary
 }
 
 func Registry() agentTypes.AgentRegistry {

--- a/internal/runtime/monitor/monitor.go
+++ b/internal/runtime/monitor/monitor.go
@@ -1,12 +1,18 @@
 package monitor
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"log/slog"
 	"net"
+	"os/exec"
+	"path/filepath"
 	goruntime "runtime"
 	"runtime/metrics"
+	"slices"
+	"strconv"
+	"strings"
 	"time"
 )
 
@@ -16,6 +22,8 @@ const (
 	ramWarnBytes    = uint64(2) << 30
 	netProbeTarget  = "1.1.1.1:443"
 	netProbeTimeout = 5 * time.Second
+	topProcessCount = 3
+	psTimeout       = 3 * time.Second
 )
 
 func Start(ctx context.Context) {
@@ -42,9 +50,14 @@ func run(ctx context.Context) {
 					if elapsed > 0 {
 						pct := (cur - lastCPU) / elapsed / float64(goruntime.NumCPU()) * 100
 						if pct >= cpuWarnPercent {
-							slog.Warn("monitor: high CPU",
+							attrs := []any{
 								slog.Float64("percent", pct),
-								slog.Int("cpus", goruntime.NumCPU()))
+								slog.Int("cpus", goruntime.NumCPU()),
+							}
+							if top := topCPU(ctx, topProcessCount); top != "" {
+								attrs = append(attrs, slog.String("top", top))
+							}
+							slog.Warn("monitor: high CPU", attrs...)
 							cpuOver = true
 						} else if cpuOver {
 							slog.Info("monitor: CPU recovered",
@@ -92,6 +105,50 @@ func sampleCPUSeconds() (float64, bool) {
 		return 0, false
 	}
 	return samples[0].Value.Float64(), true
+}
+
+func topCPU(ctx context.Context, n int) string {
+	cmdCtx, cancel := context.WithTimeout(ctx, psTimeout)
+	defer cancel()
+	out, err := exec.CommandContext(cmdCtx, "ps", "-Ao", "pid,pcpu,comm").Output()
+	if err != nil {
+		return ""
+	}
+
+	type proc struct {
+		pid  string
+		pcpu float64
+		name string
+	}
+	var procs []proc
+	first := true
+	for line := range strings.SplitSeq(string(out), "\n") {
+		if first {
+			first = false
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 3 {
+			continue
+		}
+		pcpu, err := strconv.ParseFloat(fields[1], 64)
+		if err != nil {
+			continue
+		}
+		procs = append(procs, proc{
+			pid:  fields[0],
+			pcpu: pcpu,
+			name: filepath.Base(strings.Join(fields[2:], " ")),
+		})
+	}
+
+	slices.SortFunc(procs, func(a, b proc) int { return cmp.Compare(b.pcpu, a.pcpu) })
+	procs = procs[:min(n, len(procs))]
+	parts := make([]string, 0, len(procs))
+	for _, p := range procs {
+		parts = append(parts, fmt.Sprintf("%s[%s] %.1f%%", p.name, p.pid, p.pcpu))
+	}
+	return strings.Join(parts, ", ")
 }
 
 func probeNetwork(ctx context.Context) error {

--- a/internal/runtime/monitor/monitor.go
+++ b/internal/runtime/monitor/monitor.go
@@ -34,8 +34,7 @@ func run(ctx context.Context) {
 	ticker := time.NewTicker(tickInterval)
 	defer ticker.Stop()
 
-	lastCPU, hasCPU := sampleCPUSeconds()
-	lastTick := time.Now()
+	lastTotal, lastIdle, hasCPU := sampleCPU()
 
 	var cpuOver, ramOver, netDown bool
 
@@ -43,31 +42,29 @@ func run(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			return
-		case now := <-ticker.C:
-			if cur, ok := sampleCPUSeconds(); ok {
-				if hasCPU {
-					elapsed := now.Sub(lastTick).Seconds()
-					if elapsed > 0 {
-						pct := (cur - lastCPU) / elapsed / float64(goruntime.NumCPU()) * 100
-						if pct >= cpuWarnPercent {
-							attrs := []any{
-								slog.Float64("percent", pct),
-								slog.Int("cpus", goruntime.NumCPU()),
-							}
-							if top := topCPU(ctx, topProcessCount); top != "" {
-								attrs = append(attrs, slog.String("top", top))
-							}
-							slog.Warn("monitor: high CPU", attrs...)
-							cpuOver = true
-						} else if cpuOver {
-							slog.Info("monitor: CPU recovered",
-								slog.Float64("percent", pct))
-							cpuOver = false
+		case <-ticker.C:
+			if curTotal, curIdle, ok := sampleCPU(); ok {
+				if hasCPU && curTotal > lastTotal {
+					dTotal := curTotal - lastTotal
+					dIdle := curIdle - lastIdle
+					pct := min(max((dTotal-dIdle)/dTotal*100, 0), 100)
+					if pct >= cpuWarnPercent {
+						attrs := []any{
+							slog.Float64("percent", pct),
+							slog.Int("cpus", goruntime.NumCPU()),
 						}
+						if top := topCPU(ctx, topProcessCount); top != "" {
+							attrs = append(attrs, slog.String("top", top))
+						}
+						slog.Warn("monitor: high CPU", attrs...)
+						cpuOver = true
+					} else if cpuOver {
+						slog.Info("monitor: CPU recovered",
+							slog.Float64("percent", pct))
+						cpuOver = false
 					}
 				}
-				lastCPU = cur
-				lastTick = now
+				lastTotal, lastIdle = curTotal, curIdle
 				hasCPU = true
 			}
 
@@ -98,13 +95,16 @@ func run(ctx context.Context) {
 	}
 }
 
-func sampleCPUSeconds() (float64, bool) {
-	samples := []metrics.Sample{{Name: "/cpu/classes/total:cpu-seconds"}}
-	metrics.Read(samples)
-	if samples[0].Value.Kind() != metrics.KindFloat64 {
-		return 0, false
+func sampleCPU() (total, idle float64, ok bool) {
+	samples := []metrics.Sample{
+		{Name: "/cpu/classes/total:cpu-seconds"},
+		{Name: "/cpu/classes/idle:cpu-seconds"},
 	}
-	return samples[0].Value.Float64(), true
+	metrics.Read(samples)
+	if samples[0].Value.Kind() != metrics.KindFloat64 || samples[1].Value.Kind() != metrics.KindFloat64 {
+		return 0, 0, false
+	}
+	return samples[0].Value.Float64(), samples[1].Value.Float64(), true
 }
 
 func topCPU(ctx context.Context, n int) string {

--- a/internal/runtime/tui/cmdSelector.go
+++ b/internal/runtime/tui/cmdSelector.go
@@ -24,6 +24,7 @@ type CmdSelectorItem struct {
 	descStyled  string
 	isSkill     bool
 	isScheduler bool
+	isAllow     bool
 }
 
 type Command struct {
@@ -113,6 +114,7 @@ func getCmdSelectorItems(query, sessionID string) []CmdSelectorItem {
 			desc:  c.desc,
 		}
 		if c.name == "allow-skill" || c.name == "allow-cmd" {
+			item.isAllow = true
 			item.descStyled = errorStyle.Render("!(dangerously)") + hintStyle.Render(strings.TrimPrefix(c.desc, "!(dangerously)"))
 		}
 		switch {
@@ -207,7 +209,12 @@ func getCmdSelectorItems(query, sessionID string) []CmdSelectorItem {
 	byLabel := func(s []CmdSelectorItem) func(i, j int) bool {
 		return func(i, j int) bool { return s[i].label < s[j].label }
 	}
-	sort.SliceStable(cmdNameItems, byLabel(cmdNameItems))
+	sort.SliceStable(cmdNameItems, func(i, j int) bool {
+		if cmdNameItems[i].isAllow != cmdNameItems[j].isAllow {
+			return !cmdNameItems[i].isAllow
+		}
+		return cmdNameItems[i].label < cmdNameItems[j].label
+	})
 	sort.SliceStable(cmdDescItems, byLabel(cmdDescItems))
 	sort.SliceStable(skillItems, byLabel(skillItems))
 	sort.SliceStable(schedulerItems, byLabel(schedulerItems))
@@ -279,6 +286,9 @@ func renderCmdSelector(p *CmdSelector) string {
 		it := p.items[i]
 		marker := "  "
 		labelStyle := textStyle
+		if it.isAllow {
+			labelStyle = errorStyle
+		}
 		if i == p.cursor {
 			marker = systemStyle.Render("> ")
 			labelStyle = systemStyle
@@ -287,6 +297,8 @@ func renderCmdSelector(p *CmdSelector) string {
 				labelStyle = warnStyle
 			case it.isSkill:
 				labelStyle = skillStyle
+			case it.isAllow:
+				labelStyle = errorStyle
 			}
 		}
 		pad := strings.Repeat(" ", maxLabel-lipgloss.Width(it.label))

--- a/internal/runtime/tui/cmdSelector.go
+++ b/internal/runtime/tui/cmdSelector.go
@@ -34,7 +34,8 @@ type Command struct {
 var commands = []Command{
 	{"model", "add / remove provider · pick session model"},
 	{"mcp", "add / remove MCP server · global or session scope"},
-	{"dispatcher", "pick / set dispatcher model from registry"},
+	{"dispatcher-model", "pick / set dispatcher model from registry"},
+	{"summary-model", "pick / set summary model · falls back to dispatcher if unset"},
 	{"reasoning", "set reasoning depth · global (dispatcher) / session"},
 	{"switch", "switch / change current session via picker"},
 	{"new", "create / add new session · name conflict-checked"},

--- a/internal/runtime/tui/cmdSelector.go
+++ b/internal/runtime/tui/cmdSelector.go
@@ -56,6 +56,7 @@ var commands = []Command{
 	{"cmd", "run / exec shell command directly in cwd · sh -c"},
 	{"allow-skill", "!(dangerously) skip permission · always-allow skill"},
 	{"allow-cmd", "!(dangerously) append binary to config.white_list · daemon restart required"},
+	{"allow-report", "!(exposes logs) enable / disable daily upload of daemon WARN/ERROR to developer"},
 	{"key", "update / rotate keychain value · pick from recorded keys"},
 	{"clear", "clear visible transcript / history · memory untouched"},
 	{"exit", "exit / quit TUI · daemon keeps running"},
@@ -113,9 +114,16 @@ func getCmdSelectorItems(query, sessionID string) []CmdSelectorItem {
 			label: "/" + c.name,
 			desc:  c.desc,
 		}
-		if c.name == "allow-skill" || c.name == "allow-cmd" {
+		if strings.HasPrefix(c.name, "allow-") {
 			item.isAllow = true
-			item.descStyled = errorStyle.Render("!(dangerously)") + hintStyle.Render(strings.TrimPrefix(c.desc, "!(dangerously)"))
+			if strings.HasPrefix(c.desc, "!(") {
+				if i := strings.IndexByte(c.desc, ')'); i >= 0 {
+					item.descStyled = errorStyle.Render(c.desc[:i+1]) + hintStyle.Render(c.desc[i+1:])
+				}
+			}
+			if item.descStyled == "" {
+				item.descStyled = errorStyle.Render(c.desc)
+			}
 		}
 		switch {
 		case query == "" || strings.Contains(c.name, query):

--- a/internal/runtime/tui/commandAllowReport.go
+++ b/internal/runtime/tui/commandAllowReport.go
@@ -1,0 +1,137 @@
+package tui
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	go_pkg_filesystem "github.com/pardnchiu/go-pkg/filesystem"
+
+	"github.com/pardnchiu/agenvoy/internal/filesystem"
+	"github.com/pardnchiu/agenvoy/internal/runtime"
+)
+
+const (
+	reportSkillName = "report_error_to_developer"
+	reportCronExpr  = "0 9,15,21 * * *"
+)
+
+const reportSkillBody = `---
+name: report_error_to_developer
+description: 每天 09:00 / 15:00 / 21:00 收集過去 6 小時的 daemon WARN/ERROR 並上傳給開發者。
+---
+
+# Report Errors To Developer
+
+呼叫 report_error 工具，參數 h=6。
+
+該工具會自行掃描過去 6 小時的 WARN/ERROR：有錯誤就上傳給開發者，沒有就略過。
+
+完成後只回一行簡短結果（例如「已上傳 N 行」或「過去 6 小時無錯誤」），不要貼出完整 log。
+`
+
+type AllowReportAction struct{ action string }
+
+type AllowReportConfirm struct {
+	action string
+	yes    bool
+}
+
+func (t TUI) commandAllowReport(parts []string) (TUI, tea.Cmd, bool) {
+	if len(parts) > 1 {
+		switch parts[1] {
+		case "enable", "disable":
+			action := parts[1]
+			return t, func() tea.Msg { return AllowReportAction{action: action} }, true
+		}
+	}
+
+	cursor := 0
+	if reportScheduleEnabled() {
+		cursor = 1
+	}
+	t.popup = &Popup{
+		kind:    popupSingleSelect,
+		title:   "Report errors to developer",
+		options: []string{"enable", "disable"},
+		values:  []string{"enable", "disable"},
+		cursor:  cursor,
+		onConfirm: func(chosen string) any {
+			return AllowReportAction{action: chosen}
+		},
+	}
+	return t, nil, true
+}
+
+func (t TUI) openAllowReportConfirm(action string) (TUI, tea.Cmd) {
+	var title, subtitle, yesLabel string
+	switch action {
+	case "enable":
+		title = "Expose WARN/ERROR logs to the developer?"
+		subtitle = "Daemon WARN/ERROR lines from the last 6h will be uploaded to report.agenvoy.com every day at 09:00 / 15:00 / 21:00."
+		yesLabel = "Yes, enable"
+	case "disable":
+		title = "Stop sending error reports to the developer?"
+		subtitle = "The daily 09:00 / 15:00 / 21:00 schedule will be removed."
+		yesLabel = "Yes, disable"
+	default:
+		return t, nil
+	}
+	t.popup = &Popup{
+		kind:     popupSingleSelect,
+		title:    title,
+		subtitle: subtitle,
+		options:  []string{"No", yesLabel},
+		values:   []string{"no", "yes"},
+		cursor:   0,
+		onConfirm: func(chosen string) any {
+			return AllowReportConfirm{action: action, yes: chosen == "yes"}
+		},
+	}
+	return t, nil
+}
+
+func reportScheduleEnabled() bool {
+	crons, err := runtime.LoadCrons()
+	if err != nil {
+		return false
+	}
+	for _, c := range crons {
+		if c.Skill == reportSkillName {
+			return true
+		}
+	}
+	return false
+}
+
+func (t TUI) runAllowReportEnable() (TUI, tea.Cmd) {
+	if err := go_pkg_filesystem.CheckDir(filesystem.ScheduleSkillDir(reportSkillName), true); err != nil {
+		return t, tea.Println(errorStyle.Render(fmt.Sprintf("[!] allow-report: %v", err)) + "\n")
+	}
+	if err := go_pkg_filesystem.WriteFile(filesystem.ScheduleSkillPath(reportSkillName), reportSkillBody, 0644); err != nil {
+		return t, tea.Println(errorStyle.Render(fmt.Sprintf("[!] allow-report: %v", err)) + "\n")
+	}
+	if _, err := runtime.RemoveCron(reportSkillName); err != nil {
+		return t, tea.Println(errorStyle.Render(fmt.Sprintf("[!] allow-report: %v", err)) + "\n")
+	}
+	entry := runtime.CronEntry{
+		Expression: reportCronExpr,
+		SessionID:  strings.TrimSpace(t.currentSessionID),
+		Skill:      reportSkillName,
+	}
+	if err := runtime.AppendCron(entry); err != nil {
+		return t, tea.Println(errorStyle.Render(fmt.Sprintf("[!] allow-report: %v", err)) + "\n")
+	}
+	return t, tea.Println(hintStyle.Render("⎯ allow-report enabled · daily 09:00 / 15:00 / 21:00 · daemon reloading") + "\n")
+}
+
+func (t TUI) runAllowReportDisable() (TUI, tea.Cmd) {
+	if _, err := runtime.RemoveCron(reportSkillName); err != nil {
+		return t, tea.Println(errorStyle.Render(fmt.Sprintf("[!] allow-report: %v", err)) + "\n")
+	}
+	if err := filesystem.TrashScheduleSkill(context.Background(), reportSkillName); err != nil {
+		return t, tea.Println(errorStyle.Render(fmt.Sprintf("[!] allow-report: %v", err)) + "\n")
+	}
+	return t, tea.Println(hintStyle.Render("⎯ allow-report disabled · schedule removed") + "\n")
+}

--- a/internal/runtime/tui/commandSummaryModel.go
+++ b/internal/runtime/tui/commandSummaryModel.go
@@ -1,0 +1,79 @@
+package tui
+
+import (
+	"fmt"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/pardnchiu/agenvoy/internal/session"
+)
+
+type SummaryModelSelect struct {
+	name string
+}
+
+func (t TUI) commandSummaryModel() (TUI, tea.Cmd, bool) {
+	cfg, err := session.Load()
+	if err != nil {
+		return t, tea.Println(errorStyle.Render(fmt.Sprintf("[!] session.Load: %v", err)) + "\n"), true
+	}
+	if len(cfg.Models) == 0 {
+		return t, tea.Println(hintStyle.Render("no models configured · use /model") + "\n"), true
+	}
+
+	options := make([]string, 0, len(cfg.Models)+1)
+	values := make([]string, 0, len(cfg.Models)+1)
+	cursor := 0
+
+	options = append(options, hintStyle.Render("(use dispatcher)"))
+	values = append(values, "")
+	if cfg.SummaryModel == "" {
+		options[0] += "  " + hintStyle.Render("[current]")
+	}
+
+	for i, m := range cfg.Models {
+		label := m.Name
+		if m.Description != "" {
+			label = fmt.Sprintf("%s  %s", m.Name, hintStyle.Render(m.Description))
+		}
+		if cfg.SummaryModel != "" && m.Name == cfg.SummaryModel {
+			label += "  " + hintStyle.Render("[current]")
+			cursor = i + 1
+		}
+		options = append(options, label)
+		values = append(values, m.Name)
+	}
+
+	t.popup = &Popup{
+		kind:    popupSingleSelect,
+		title:   "Select summary model",
+		options: options,
+		values:  values,
+		cursor:  cursor,
+		onConfirm: func(chosen string) any {
+			return SummaryModelSelect{name: chosen}
+		},
+	}
+	return t, nil, true
+}
+
+func (t TUI) runSummaryModelSelect(name string) (TUI, tea.Cmd) {
+	cfg, err := session.Load()
+	if err != nil {
+		return t, tea.Println(errorStyle.Render(fmt.Sprintf("[!] session.Load: %v", err)) + "\n")
+	}
+	if cfg.SummaryModel == name {
+		if name == "" {
+			return t, tea.Println(hintStyle.Render("⎯ summary unchanged: (use dispatcher)") + "\n")
+		}
+		return t, tea.Println(hintStyle.Render(fmt.Sprintf("⎯ summary unchanged: %s", name)) + "\n")
+	}
+
+	cfg.SummaryModel = name
+	if err := session.Save(cfg); err != nil {
+		return t, tea.Println(errorStyle.Render(fmt.Sprintf("[!] session.Save: %v", err)) + "\n")
+	}
+	if name == "" {
+		return t, tea.Println(hintStyle.Render("⎯ summary: (use dispatcher)") + "\n")
+	}
+	return t, tea.Println(hintStyle.Render(fmt.Sprintf("⎯ summary: %s", name)) + "\n")
+}

--- a/internal/runtime/tui/commnadModelRemove.go
+++ b/internal/runtime/tui/commnadModelRemove.go
@@ -31,6 +31,9 @@ func (t TUI) commandModelRemove() (TUI, tea.Cmd, bool) {
 		if cfg.DispatcherModel != "" && m.Name == cfg.DispatcherModel {
 			label += "  " + warnStyle.Render("[dispatcher]")
 		}
+		if cfg.SummaryModel != "" && m.Name == cfg.SummaryModel {
+			label += "  " + warnStyle.Render("[summary]")
+		}
 		options[i] = label
 		values[i] = m.Name
 	}
@@ -74,6 +77,11 @@ func (t TUI) runModelRemove(name string) (TUI, tea.Cmd) {
 		cfg.DispatcherModel = ""
 		clearedDispatcher = true
 	}
+	clearedSummary := false
+	if cfg.SummaryModel == name {
+		cfg.SummaryModel = ""
+		clearedSummary = true
+	}
 
 	if err := session.Save(cfg); err != nil {
 		return t, tea.Println(errorStyle.Render(fmt.Sprintf("[!] session.Save: %v", err)) + "\n")
@@ -82,6 +90,9 @@ func (t TUI) runModelRemove(name string) (TUI, tea.Cmd) {
 	lines := []string{hintStyle.Render(fmt.Sprintf("⎯ removed: %s", name))}
 	if clearedDispatcher {
 		lines = append(lines, warnStyle.Render("dispatcher cleared · run /model or set a new dispatcher"))
+	}
+	if clearedSummary {
+		lines = append(lines, warnStyle.Render("summary model cleared · falls back to dispatcher"))
 	}
 	if len(cfg.Models) == 0 {
 		lines = append(lines, warnStyle.Render("⎯ no model configured · /model global add"))

--- a/internal/runtime/tui/handlerCommand.go
+++ b/internal/runtime/tui/handlerCommand.go
@@ -57,8 +57,11 @@ func (t TUI) handleCommand(cmd string) (TUI, tea.Cmd, bool) {
 	case "/mcp":
 		return t.commandMcp(parts)
 
-	case "/dispatcher":
+	case "/dispatcher-model":
 		return t.commandDispatcher()
+
+	case "/summary-model":
+		return t.commandSummaryModel()
 
 	case "/reasoning":
 		return t.commandReasoning(parts)

--- a/internal/runtime/tui/handlerCommand.go
+++ b/internal/runtime/tui/handlerCommand.go
@@ -102,6 +102,9 @@ func (t TUI) handleCommand(cmd string) (TUI, tea.Cmd, bool) {
 	case "/allow-cmd":
 		return t.commandAllowCmd(parts)
 
+	case "/allow-report":
+		return t.commandAllowReport(parts)
+
 	case "/key":
 		return t.commandKey(parts)
 	}

--- a/internal/runtime/tui/update.go
+++ b/internal/runtime/tui/update.go
@@ -719,6 +719,11 @@ func (t TUI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		agents.Reload()
 		return next, cmd
 
+	case SummaryModelSelect:
+		next, cmd := t.runSummaryModelSelect(msg.name)
+		agents.Reload()
+		return next, cmd
+
 	case ReasoningSelect:
 		next, cmd := t.runReasoningSelect(msg.level)
 		return next, cmd

--- a/internal/runtime/tui/update.go
+++ b/internal/runtime/tui/update.go
@@ -691,6 +691,21 @@ func (t TUI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			runKuradbEnableExec(),
 		)
 
+	case AllowReportAction:
+		next, cmd := t.openAllowReportConfirm(msg.action)
+		return next, cmd
+
+	case AllowReportConfirm:
+		if !msg.yes {
+			return t, tea.Println(hintStyle.Render("⎯ allow-report cancelled") + "\n")
+		}
+		if msg.action == "enable" {
+			next, cmd := t.runAllowReportEnable()
+			return next, cmd
+		}
+		next, cmd := t.runAllowReportDisable()
+		return next, cmd
+
 	case KeySelect:
 		next, cmd := t.openKeyValuePrompt(msg.key)
 		return next, cmd

--- a/internal/session/config.go
+++ b/internal/session/config.go
@@ -35,6 +35,7 @@ type ModelEntry struct {
 
 type Config struct {
 	DispatcherModel  string        `json:"dispatcher_model"`
+	SummaryModel     string        `json:"summary_model"`
 	ReasoningLevel   string        `json:"reasoning_level"`
 	Models           []ModelEntry  `json:"models"`
 	Compats          []CompatEntry `json:"compats"`

--- a/internal/tools/register.go
+++ b/internal/tools/register.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pardnchiu/agenvoy/internal/tools/external"
 	"github.com/pardnchiu/agenvoy/internal/tools/file"
 	"github.com/pardnchiu/agenvoy/internal/tools/listLog"
+	"github.com/pardnchiu/agenvoy/internal/tools/reportError"
 	toolRegister "github.com/pardnchiu/agenvoy/internal/tools/register"
 	toolScheduler "github.com/pardnchiu/agenvoy/internal/tools/scheduler"
 	toolSearcher "github.com/pardnchiu/agenvoy/internal/tools/searcher"
@@ -29,6 +30,7 @@ func init() {
 	file.Register()
 	errorMemory.Register()
 	listLog.Register()
+	reportError.Register()
 	toolScheduler.Register()
 	toolSearcher.Register()
 

--- a/internal/tools/reportError/register.go
+++ b/internal/tools/reportError/register.go
@@ -1,0 +1,150 @@
+package reportError
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/pardnchiu/agenvoy/internal/filesystem"
+	toolRegister "github.com/pardnchiu/agenvoy/internal/tools/register"
+	toolTypes "github.com/pardnchiu/agenvoy/internal/tools/types"
+)
+
+const (
+	tailWindowBytes = int64(8 * 1024 * 1024)
+	maxReportLines  = 500
+)
+
+func Register() {
+	toolRegister.Regist(toolRegister.Def{
+		Name:        "report_error",
+		AlwaysAllow: true,
+		Concurrent:  true,
+		Description: "Summarize daemon-side failures by scanning daemon.log and returning only WARN/ERROR lines from the last `h` hours. Call ONLY when the current user input explicitly contains 'report error' or 'report_error' — never infer it from generic phrasing like 'check errors / what went wrong / 排錯', which route to list_log instead.",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"h": map[string]any{
+					"type":        "integer",
+					"description": "Look-back window in hours: keep only records whose timestamp is within the last `h` hours from now. Default 1, minimum 1, maximum 168 (one week). Lines without a parseable timestamp inherit the previous line's time (multi-line entries are kept together).",
+					"default":     1,
+					"minimum":     1,
+					"maximum":     168,
+				},
+			},
+		},
+		Handler: handler,
+	})
+}
+
+func handler(_ context.Context, _ *toolTypes.Executor, args json.RawMessage) (string, error) {
+	var params struct {
+		H int `json:"h"`
+	}
+	if err := json.Unmarshal(args, &params); err != nil {
+		return "", fmt.Errorf("json.Unmarshal: %w", err)
+	}
+	if params.H <= 0 {
+		params.H = 1
+	}
+	params.H = min(params.H, 168)
+	cutoff := time.Now().Add(-time.Duration(params.H) * time.Hour)
+
+	path := filepath.Join(filesystem.AgenvoyDir, "daemon.log")
+	f, err := os.Open(path)
+	if err != nil {
+		return "", fmt.Errorf("os.Open: %w", err)
+	}
+	defer f.Close()
+
+	st, err := f.Stat()
+	if err != nil {
+		return "", fmt.Errorf("Stat: %w", err)
+	}
+	size := st.Size()
+
+	offset := int64(0)
+	readSize := size
+	if size > tailWindowBytes {
+		offset = size - tailWindowBytes
+		readSize = tailWindowBytes
+	}
+
+	buf := make([]byte, readSize)
+	if readSize > 0 {
+		if _, err := f.ReadAt(buf, offset); err != nil {
+			return "", fmt.Errorf("ReadAt: %w", err)
+		}
+	}
+
+	text := string(buf)
+	if offset > 0 {
+		if i := strings.IndexByte(text, '\n'); i >= 0 {
+			text = text[i+1:]
+		} else {
+			text = ""
+		}
+	}
+
+	lines := strings.Split(text, "\n")
+	collected := make([]string, 0, maxReportLines)
+	var lastTime time.Time
+	var haveTime bool
+	for _, line := range lines {
+		if line == "" {
+			continue
+		}
+		if t, ok := parseLineTime(line); ok {
+			lastTime = t
+			haveTime = true
+		}
+		if haveTime && lastTime.Before(cutoff) {
+			continue
+		}
+		if !isWarnOrError(line) {
+			continue
+		}
+		collected = append(collected, line)
+	}
+
+	truncated := false
+	if len(collected) > maxReportLines {
+		collected = collected[len(collected)-maxReportLines:]
+		truncated = true
+	}
+
+	if len(collected) == 0 {
+		return fmt.Sprintf("(no WARN/ERROR lines in the last %dh)", params.H), nil
+	}
+	out := strings.Join(collected, "\n")
+	if truncated {
+		out = fmt.Sprintf("(showing last %d of more matches; narrow `h`)\n%s", maxReportLines, out)
+	}
+	return out, nil
+}
+
+func isWarnOrError(line string) bool {
+	return strings.Contains(line, "WARN") || strings.Contains(line, "ERROR")
+}
+
+func parseLineTime(line string) (time.Time, bool) {
+	if rest, ok := strings.CutPrefix(line, "time="); ok {
+		ts, _, _ := strings.Cut(rest, " ")
+		if t, err := time.Parse("2006-01-02T15:04:05.000-07:00", ts); err == nil {
+			return t, true
+		}
+		if t, err := time.Parse(time.RFC3339Nano, ts); err == nil {
+			return t, true
+		}
+	}
+	if len(line) >= 19 {
+		if t, err := time.ParseInLocation("2006/01/02 15:04:05", line[:19], time.Local); err == nil {
+			return t, true
+		}
+	}
+	return time.Time{}, false
+}

--- a/internal/tools/reportError/register.go
+++ b/internal/tools/reportError/register.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
+
+	go_pkg_http "github.com/pardnchiu/go-pkg/http"
 
 	"github.com/pardnchiu/agenvoy/internal/filesystem"
 	toolRegister "github.com/pardnchiu/agenvoy/internal/tools/register"
@@ -17,6 +20,8 @@ import (
 const (
 	tailWindowBytes = int64(8 * 1024 * 1024)
 	maxReportLines  = 500
+	reportEndpoint  = "https://report.agenvoy.com"
+	uploadTimeout   = 30 * time.Second
 )
 
 func Register() {
@@ -24,7 +29,7 @@ func Register() {
 		Name:        "report_error",
 		AlwaysAllow: true,
 		Concurrent:  true,
-		Description: "Summarize daemon-side failures by scanning daemon.log and returning only WARN/ERROR lines from the last `h` hours. Call ONLY when the current user input explicitly contains 'report error' or 'report_error' — never infer it from generic phrasing like 'check errors / what went wrong / 排錯', which route to list_log instead.",
+		Description: "Collect daemon-side failures: scan daemon.log for WARN/ERROR lines in the last `h` hours and, when any are found, upload them to report.agenvoy.com (empty result uploads nothing). Returns the collected lines plus an upload-status line. Call ONLY when the current user input explicitly contains 'report error' or 'report_error' — never infer it from generic phrasing like 'check errors / what went wrong / 排錯', which route to list_log instead.",
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -41,7 +46,7 @@ func Register() {
 	})
 }
 
-func handler(_ context.Context, _ *toolTypes.Executor, args json.RawMessage) (string, error) {
+func handler(ctx context.Context, _ *toolTypes.Executor, args json.RawMessage) (string, error) {
 	var params struct {
 		H int `json:"h"`
 	}
@@ -122,9 +127,21 @@ func handler(_ context.Context, _ *toolTypes.Executor, args json.RawMessage) (st
 	}
 	out := strings.Join(collected, "\n")
 	if truncated {
-		out = fmt.Sprintf("(showing last %d of more matches; narrow `h`)\n%s", maxReportLines, out)
+		out += fmt.Sprintf("\n(showing last %d; more matched — narrow `h`)", maxReportLines)
 	}
-	return out, nil
+
+	if err := uploadReport(ctx, out); err != nil {
+		return out + fmt.Sprintf("\n\n(upload to %s failed: %v)", reportEndpoint, err), nil
+	}
+	return out + fmt.Sprintf("\n\n(uploaded %d lines to %s)", len(collected), reportEndpoint), nil
+}
+
+func uploadReport(ctx context.Context, body string) error {
+	client := &http.Client{Timeout: uploadTimeout}
+	if _, _, err := go_pkg_http.POST[string](ctx, client, reportEndpoint, nil, map[string]any{"report": body}, "json"); err != nil {
+		return fmt.Errorf("POST: %w", err)
+	}
+	return nil
 }
 
 func isWarnOrError(line string) bool {


### PR DESCRIPTION
Adds opt-in error reporting that collects recent daemon warnings and uploads them on a daily schedule behind an explicit consent gate. Corrects the CPU monitor, which previously counted idle capacity as usage and reported phantom load. Routing gains a dedicated summary-model slot that falls back to the dispatcher when unset.
