### PR TITLE
Refactor TUI command flow and add admin channel support

### DIFF
--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -25,6 +25,8 @@ import (
 func init() {
 	exec.RegisterPushHook("dc-", discord.PushDiscordResult)
 	exec.RegisterPushHook("tg-", telegram.PushTelegramResult)
+	exec.RegisterAdminSender("tg", telegram.SendAdminCode)
+	exec.RegisterAdminSender("dc", discord.SendAdminCode)
 }
 
 func main() {

--- a/internal/agents/exec/adminChannel.go
+++ b/internal/agents/exec/adminChannel.go
@@ -1,0 +1,87 @@
+package exec
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+
+	"github.com/pardnchiu/agenvoy/internal/filesystem"
+	sessionManager "github.com/pardnchiu/agenvoy/internal/session"
+	"github.com/pardnchiu/agenvoy/internal/utils"
+)
+
+type AdminSendFunc func(ctx context.Context, targetID, text string) error
+
+var (
+	adminSenderMu sync.RWMutex
+	adminSenders  = map[string]AdminSendFunc{}
+)
+
+func RegisterAdminSender(prefix string, fn AdminSendFunc) {
+	adminSenderMu.Lock()
+	adminSenders[prefix] = fn
+	adminSenderMu.Unlock()
+}
+
+func ParseAdminChannel(v string) (prefix, id string, ok bool) {
+	v = strings.TrimSpace(v)
+	switch {
+	case strings.HasPrefix(v, "tg@"):
+		prefix, id = "tg", strings.TrimSpace(v[len("tg@"):])
+	case strings.HasPrefix(v, "dc@"):
+		prefix, id = "dc", strings.TrimSpace(v[len("dc@"):])
+	default:
+		return "", "", false
+	}
+	if id == "" {
+		return "", "", false
+	}
+	return prefix, id, true
+}
+
+func NotifyAdminCode(ctx context.Context, code, sourceName string) {
+	cfg, err := sessionManager.Load()
+	if err != nil || cfg == nil {
+		return
+	}
+	value := strings.TrimSpace(cfg.AdminChannel)
+	if value == "" {
+		return
+	}
+
+	prefix, id, ok := ParseAdminChannel(value)
+	if !ok {
+		slog.Warn("admin_channel malformed; verification code stays log-only",
+			slog.String("value", value))
+		return
+	}
+
+	var authPath string
+	switch prefix {
+	case "tg":
+		authPath = filesystem.TelegramAuthPath
+	case "dc":
+		authPath = filesystem.DiscordAuthPath
+	}
+	if !utils.IsAuthorized(authPath, id) {
+		slog.Warn("admin_channel not in auth file; verification code stays log-only",
+			slog.String("channel", value))
+		return
+	}
+
+	adminSenderMu.RLock()
+	send, ok := adminSenders[prefix]
+	adminSenderMu.RUnlock()
+	if !ok {
+		return
+	}
+
+	text := fmt.Sprintf("%s requested access · verification code: %s", sourceName, code)
+	if err := send(ctx, id, text); err != nil {
+		slog.Warn("admin_channel send failed",
+			slog.String("channel", value),
+			slog.String("error", err.Error()))
+	}
+}

--- a/internal/agents/exec/execWithSubagent.go
+++ b/internal/agents/exec/execWithSubagent.go
@@ -88,6 +88,7 @@ func ExecWithSubagent(ctx context.Context, task, sessionIDInput, model, systemPr
 		ToolHistories: []agentTypes.Message{},
 		Tools:         []agentTypes.Message{},
 		Histories:     histories,
+		BaseLen:       len(oldHistory),
 		UserInput:     agentTypes.Message{Role: "user", Content: userText},
 	}
 	if summary := sessionManager.GetSummaryPrompt(sessionID, OldestMessageTime(maxHistory)); summary != "" {

--- a/internal/agents/exec/execute.go
+++ b/internal/agents/exec/execute.go
@@ -549,23 +549,19 @@ func saveNewHistory(choice agentTypes.OutputChoices, session *agentTypes.AgentSe
 		return nil
 	}
 
-	newHistories := make([]agentTypes.Message, 0, len(session.Histories))
-	for _, message := range session.Histories {
+	base := min(max(session.BaseLen, 0), len(session.Histories))
+	delta := make([]agentTypes.Message, 0, len(session.Histories)-base)
+	for _, message := range session.Histories[base:] {
 		if message.Role == "system" ||
 			message.Role == "tool" ||
 			(message.Role == "assistant" && len(message.ToolCalls) > 0) {
 			continue
 		}
-		newHistories = append(newHistories, message)
+		delta = append(delta, message)
 	}
 
-	historyBytes, err := json.Marshal(newHistories)
-	if err != nil {
-		return fmt.Errorf("json.Marshal: %w", err)
-	}
-
-	if err = sessionManager.SaveHistory(session.ID, string(historyBytes)); err != nil {
-		return fmt.Errorf("sessionManager.SaveHistory: %w", err)
+	if err := sessionManager.AppendHistory(session.ID, delta); err != nil {
+		return fmt.Errorf("sessionManager.AppendHistory: %w", err)
 	}
 
 	writeSessionHistEntry(session.ID, choice.Message)

--- a/internal/agents/exec/getSession.go
+++ b/internal/agents/exec/getSession.go
@@ -85,6 +85,7 @@ func GetSession(execData ExecData) (*agentTypes.AgentSession, error) {
 
 	oldHistory, maxHistory := sessionManager.GetHistory(overrideID)
 	session.Histories = oldHistory
+	session.BaseLen = len(oldHistory)
 
 	session.SystemPrompts = BuildSystemPrompts(execData.WorkDir, execData.ExtraSystemPrompt, scanner, overrideID, execData.AllowAll, execData.WebMode, execData.ExcludeSkills)
 	if summary := sessionManager.GetSummaryPrompt(overrideID, OldestMessageTime(maxHistory)); summary != "" {

--- a/internal/agents/types/agent.go
+++ b/internal/agents/types/agent.go
@@ -33,6 +33,7 @@ type AgentSession struct {
 	ToolHistories   []Message
 	Tools           []Message
 	Histories       []Message
+	BaseLen         int
 	Stateless       bool
 	VerifyRounds    int
 	VerifyFeedbacks []string

--- a/internal/routes/handler/send.go
+++ b/internal/routes/handler/send.go
@@ -174,6 +174,7 @@ func newSession(data exec.ExecData, sessionID string) (*agentTypes.AgentSession,
 
 	oldHistory, maxHistory := sessionManager.GetHistory(sessionID)
 	session.Histories = oldHistory
+	session.BaseLen = len(oldHistory)
 	session.OldHistories = maxHistory
 
 	if summary := sessionManager.GetSummaryPrompt(sessionID, exec.OldestMessageTime(maxHistory)); summary != "" {

--- a/internal/runtime/discord/admin.go
+++ b/internal/runtime/discord/admin.go
@@ -1,0 +1,25 @@
+package discord
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	go_bot_discord "github.com/pardnchiu/go-bot/discord"
+	"github.com/pardnchiu/go-pkg/filesystem/keychain"
+)
+
+func SendAdminCode(ctx context.Context, channelID, text string) error {
+	token := strings.TrimSpace(keychain.Get(Key))
+	if token == "" {
+		return fmt.Errorf("discord token missing")
+	}
+	client, err := go_bot_discord.New(token)
+	if err != nil {
+		return fmt.Errorf("github.com/pardnchiu/go-bot/discord New: %w", err)
+	}
+	if _, err := client.Send(ctx, strings.TrimSpace(channelID), "", text); err != nil {
+		return fmt.Errorf("github.com/pardnchiu/go-bot/discord Bot.Send: %w", err)
+	}
+	return nil
+}

--- a/internal/runtime/discord/run.go
+++ b/internal/runtime/discord/run.go
@@ -110,6 +110,7 @@ func run(ctx context.Context, b *Bot, in go_bot_discord.Input) error {
 		slog.Info("Discord Verification Code",
 			slog.String("name", channelName(in)),
 			slog.String("code", code))
+		exec.NotifyAdminCode(ctx, code, "Discord "+channelName(in))
 		prompt, err := b.client.SendInput(ctx, in.ChannelID, "", "Enter the 6-digit verification code printed in the daemon log.")
 		if err != nil {
 			slog.Warn("github.com/pardnchiu/go-bot/discord Bot.client.SendInput",

--- a/internal/runtime/telegram/admin.go
+++ b/internal/runtime/telegram/admin.go
@@ -1,0 +1,31 @@
+package telegram
+
+import (
+	"context"
+	"fmt"
+	"html"
+	"strconv"
+	"strings"
+
+	go_bot_telegram "github.com/pardnchiu/go-bot/telegram"
+	"github.com/pardnchiu/go-pkg/filesystem/keychain"
+)
+
+func SendAdminCode(ctx context.Context, chatID, text string) error {
+	token := strings.TrimSpace(keychain.Get(Key))
+	if token == "" {
+		return fmt.Errorf("telegram token missing")
+	}
+	id, err := strconv.ParseInt(strings.TrimSpace(chatID), 10, 64)
+	if err != nil {
+		return fmt.Errorf("parse chatID %q: %w", chatID, err)
+	}
+	client, err := go_bot_telegram.New(token)
+	if err != nil {
+		return fmt.Errorf("github.com/pardnchiu/go-bot/telegram New: %w", err)
+	}
+	if _, err := client.Send(ctx, id, 0, html.EscapeString(text), go_bot_telegram.WithSendType(go_bot_telegram.TypeHTML)); err != nil {
+		return fmt.Errorf("github.com/pardnchiu/go-bot/telegram Bot.Send: %w", err)
+	}
+	return nil
+}

--- a/internal/runtime/telegram/chunk.go
+++ b/internal/runtime/telegram/chunk.go
@@ -63,9 +63,6 @@ func chunk(text string) []string {
 	return chunks
 }
 
-// scanOpenTags walks tags in order; opening tags push onto stack, closing
-// tags pop the most recent matching name. Voids/self-closing tags are
-// ignored. Returns tags still open at end of input.
 func scanOpenTags(s string) []openTag {
 	var stack []openTag
 	matches := tagRegex.FindAllStringSubmatch(s, -1)

--- a/internal/runtime/telegram/filegroup.go
+++ b/internal/runtime/telegram/filegroup.go
@@ -1,0 +1,79 @@
+package telegram
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	go_bot_telegram "github.com/pardnchiu/go-bot/telegram"
+)
+
+const (
+	fileGroupWindow = 1500 * time.Millisecond
+)
+
+type fileGroup struct {
+	inputs []go_bot_telegram.Input
+	timer  *time.Timer
+}
+
+type fileGroupBuffer struct {
+	mu     sync.Mutex
+	groups map[string]*fileGroup
+}
+
+func newFileGroupBuffer() *fileGroupBuffer {
+	return &fileGroupBuffer{groups: make(map[string]*fileGroup)}
+}
+
+func fileGroupID(input go_bot_telegram.Input) string {
+	if input.Raw == nil || input.Raw.Message == nil {
+		return ""
+	}
+	return input.Raw.Message.MediaGroupID
+}
+
+func (fb *fileGroupBuffer) add(bot *Bot, groupID string, input go_bot_telegram.Input) {
+	fb.mu.Lock()
+	defer fb.mu.Unlock()
+
+	group, ok := fb.groups[groupID]
+	if !ok {
+		group = &fileGroup{}
+		fb.groups[groupID] = group
+	}
+	group.inputs = append(group.inputs, input)
+	if group.timer != nil {
+		group.timer.Stop()
+	}
+	group.timer = time.AfterFunc(fileGroupWindow, func() { fb.flush(bot, groupID) })
+}
+
+func (fb *fileGroupBuffer) flush(bot *Bot, groupID string) {
+	fb.mu.Lock()
+	group, ok := fb.groups[groupID]
+	if ok {
+		delete(fb.groups, groupID)
+	}
+	fb.mu.Unlock()
+	if !ok || len(group.inputs) == 0 {
+		return
+	}
+
+	response := group.inputs[0]
+	if response.Caption == "" {
+		for _, in := range group.inputs {
+			if in.Caption != "" {
+				response.Caption = in.Caption
+				break
+			}
+		}
+	}
+
+	if err := run(context.Background(), bot, response, group.inputs); err != nil {
+		slog.Warn("run",
+			slog.String("chat", chatName(response)),
+			slog.String("error", err.Error()))
+	}
+}

--- a/internal/runtime/telegram/new.go
+++ b/internal/runtime/telegram/new.go
@@ -24,9 +24,10 @@ import (
 const Key = "TELEGRAM_TOKEN"
 
 type Bot struct {
-	client   *telegram.Bot
-	cancel   context.CancelFunc
-	listener *runtime.Listener[int64, int]
+	client    *telegram.Bot
+	cancel    context.CancelFunc
+	listener  *runtime.Listener[int64, int]
+	fileGroup *fileGroupBuffer
 }
 
 var current atomic.Pointer[Bot]
@@ -55,10 +56,14 @@ func New() (*Bot, error) {
 		return nil, fmt.Errorf("github.com/pardnchiu/go-bot/telegram New: %w", err)
 	}
 
-	bot := &Bot{client: client}
+	bot := &Bot{client: client, fileGroup: newFileGroupBuffer()}
 
 	client.Reply(func(ctx context.Context, in telegram.Input) string {
-		if err := run(ctx, bot, in); err != nil {
+		if gid := fileGroupID(in); gid != "" {
+			bot.fileGroup.add(bot, gid, in)
+			return ""
+		}
+		if err := run(ctx, bot, in, []telegram.Input{in}); err != nil {
 			slog.Warn("run",
 				slog.String("chat", chatName(in)),
 				slog.String("error", err.Error()))

--- a/internal/runtime/telegram/run.go
+++ b/internal/runtime/telegram/run.go
@@ -121,6 +121,7 @@ func run(ctx context.Context, b *Bot, in go_bot_telegram.Input, attachInputs []g
 		slog.Info("Telegram Verification Code",
 			slog.String("name", chatName(in)),
 			slog.String("code", code))
+		exec.NotifyAdminCode(ctx, code, "Telegram "+chatName(in))
 		prompt, err := b.client.SendInput(ctx, in.ChatID, 0, "Enter the 6-digit verification code printed in the daemon log.")
 		if err != nil {
 			slog.Warn("github.com/pardnchiu/go-bot/telegram Bot.client.SendInput",

--- a/internal/runtime/telegram/run.go
+++ b/internal/runtime/telegram/run.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -36,17 +37,24 @@ func chatName(in go_bot_telegram.Input) string {
 	return in.Username
 }
 
-func run(ctx context.Context, b *Bot, in go_bot_telegram.Input) error {
+func inputHasAttachment(in go_bot_telegram.Input) bool {
+	if len(in.Photo) > 0 || in.Document != nil {
+		return true
+	}
+	if in.Raw != nil && in.Raw.Message != nil {
+		m := in.Raw.Message
+		return m.Voice != nil || m.Audio != nil || m.Video != nil || m.VideoNote != nil
+	}
+	return false
+}
+
+func run(ctx context.Context, b *Bot, in go_bot_telegram.Input, attachInputs []go_bot_telegram.Input) error {
 	isCallback := in.CallbackData != "" || len(in.CallbackPicks) > 0
 	content := strings.TrimSpace(in.Text)
 	if content == "" {
 		content = strings.TrimSpace(in.Caption)
 	}
-	hasAttachment := len(in.Photo) > 0 || in.Document != nil
-	if !hasAttachment && in.Raw != nil && in.Raw.Message != nil {
-		m := in.Raw.Message
-		hasAttachment = m.Voice != nil || m.Audio != nil || m.Video != nil || m.VideoNote != nil
-	}
+	hasAttachment := slices.ContainsFunc(attachInputs, inputHasAttachment)
 	if !isCallback && content == "" && !hasAttachment {
 		return nil
 	}
@@ -133,7 +141,10 @@ func run(ctx context.Context, b *Bot, in go_bot_telegram.Input) error {
 	}
 
 	if hasAttachment {
-		paths := saveAttachments(ctx, b, in)
+		var paths []string
+		for _, ai := range attachInputs {
+			paths = append(paths, saveAttachments(ctx, b, ai)...)
+		}
 		if len(paths) > 0 {
 			var lines []string
 			if content != "" {

--- a/internal/runtime/tui/cmdSelector.go
+++ b/internal/runtime/tui/cmdSelector.go
@@ -46,7 +46,7 @@ var commands = []Command{
 	{"bot", "edit / rename current session · name / description (persona)"},
 	{"discord", "enable / disable Discord bot · gateway validated on enable"},
 	{"telegram", "enable / disable Telegram bot · getMe validated on enable"},
-	{"kuradb", "enable / disable KuraDB RAG · install.sh + OPENAI_API_KEY on enable"},
+	{"kuradb", "enable / disable / update KuraDB RAG · install.sh + OPENAI_API_KEY on enable"},
 	{"cron", "add / remove / edit scheduled recurring task"},
 	{"task", "add / remove / edit one-shot scheduled task"},
 	{"update", "update / upgrade · fetch latest release · rebuild · quit TUI"},

--- a/internal/runtime/tui/cmdSelector.go
+++ b/internal/runtime/tui/cmdSelector.go
@@ -47,6 +47,7 @@ var commands = []Command{
 	{"discord", "enable / disable Discord bot · gateway validated on enable"},
 	{"telegram", "enable / disable Telegram bot · getMe validated on enable"},
 	{"kuradb", "enable / disable / update KuraDB RAG · install.sh + OPENAI_API_KEY on enable"},
+	{"admin-channel", "set / clear relay for new-chat verification codes · pick authorized chat or tg@<id>/dc@<id>"},
 	{"cron", "add / remove / edit scheduled recurring task"},
 	{"task", "add / remove / edit one-shot scheduled task"},
 	{"update", "update / upgrade · fetch latest release · rebuild · quit TUI"},

--- a/internal/runtime/tui/commandAdminChannel.go
+++ b/internal/runtime/tui/commandAdminChannel.go
@@ -1,0 +1,73 @@
+package tui
+
+import (
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/pardnchiu/agenvoy/internal/filesystem"
+	"github.com/pardnchiu/agenvoy/internal/session"
+	"github.com/pardnchiu/agenvoy/internal/utils"
+)
+
+type AdminChannelSubmit struct {
+	value string
+}
+
+func adminChannelLabel(prefix string, e utils.ChatEntry) string {
+	if strings.TrimSpace(e.Name) == "" {
+		return prefix + " · " + e.ID
+	}
+	return prefix + " · " + e.Name + " (" + e.ID + ")"
+}
+
+func (t TUI) commandAdminChannel(parts []string) (TUI, tea.Cmd, bool) {
+	if len(parts) > 1 {
+		value := strings.TrimSpace(strings.Join(parts[1:], " "))
+		return t, func() tea.Msg { return AdminChannelSubmit{value: value} }, true
+	}
+
+	current := ""
+	if cfg, err := session.Load(); err == nil && cfg != nil {
+		current = strings.TrimSpace(cfg.AdminChannel)
+	}
+
+	var options, values []string
+	add := func(label, value string) {
+		if value != "" && value == current {
+			label = "✓ " + label
+		}
+		options = append(options, label)
+		values = append(values, value)
+	}
+
+	add("(clear) · code stays log-only", "")
+	for _, e := range utils.ListChats(filesystem.TelegramAuthPath) {
+		add(adminChannelLabel("tg", e), "tg@"+e.ID)
+	}
+	for _, e := range utils.ListChats(filesystem.DiscordAuthPath) {
+		add(adminChannelLabel("dc", e), "dc@"+e.ID)
+	}
+
+	cursor := 0
+	for i, v := range values {
+		if v != "" && v == current {
+			cursor = i
+			break
+		}
+	}
+
+	t.popup = &Popup{
+		kind:       popupSingleSelect,
+		title:      "Admin Channel · relay new-chat verification codes",
+		subtitle:   "pick an authorized chat/channel · only listed (already-verified) targets receive codes",
+		options:    options,
+		values:     values,
+		cursor:     cursor,
+		maxVisible: cmdSelectorMaxVisible,
+		onConfirm: func(chosen string) any {
+			return AdminChannelSubmit{value: chosen}
+		},
+	}
+	return t, nil, true
+}

--- a/internal/runtime/tui/commandKuradb.go
+++ b/internal/runtime/tui/commandKuradb.go
@@ -30,7 +30,7 @@ type KuradbDone struct {
 func (t TUI) commandKuradb(parts []string) (TUI, tea.Cmd, bool) {
 	if len(parts) > 1 {
 		switch parts[1] {
-		case "enable", "disable":
+		case "enable", "disable", "update":
 			action := parts[1]
 			return t, func() tea.Msg { return KuradbAction{action: action} }, true
 		}
@@ -40,15 +40,17 @@ func (t TUI) commandKuradb(parts []string) (TUI, tea.Cmd, bool) {
 	if cfg, err := session.Load(); err == nil && cfg != nil {
 		enabled = cfg.KuradbEnabled
 	}
+	options := []string{"enable", "disable"}
 	cursor := 0
 	if enabled {
+		options = append(options, "update")
 		cursor = 1
 	}
 	t.popup = &Popup{
 		kind:    popupSingleSelect,
 		title:   "KuraDB",
-		options: []string{"enable", "disable"},
-		values:  []string{"enable", "disable"},
+		options: options,
+		values:  options,
 		cursor:  cursor,
 		onConfirm: func(chosen string) any {
 			return KuradbAction{action: chosen}
@@ -93,6 +95,48 @@ kura add agenvoy 2>/dev/null || true
 			return KuradbDone{action: "enable", err: fmt.Errorf("session.Save: %w", err)}
 		}
 		return KuradbDone{action: "enable"}
+	})
+}
+
+func runKuradbUpdateExec() tea.Cmd {
+	if cfg, err := session.Load(); err == nil && cfg != nil {
+		cfg.KuradbEnabled = false
+		if err := session.Save(cfg); err != nil {
+			return func() tea.Msg {
+				return KuradbDone{action: "update", err: fmt.Errorf("session.Save(stop): %w", err)}
+			}
+		}
+	}
+
+	script := fmt.Sprintf(`set -e
+curl -fsSL %s | bash
+kura add agenvoy 2>/dev/null || true
+`, kuradbInstallURL)
+
+	cmd := exec.Command("bash", "-c", script)
+	cmd.Env = os.Environ()
+	return tea.ExecProcess(cmd, func(err error) tea.Msg {
+		if err != nil {
+			if kuradb.IsInstalled() {
+				if cfg, lerr := session.Load(); lerr == nil && cfg != nil {
+					cfg.KuradbEnabled = true
+					_ = session.Save(cfg)
+				}
+			}
+			return KuradbDone{action: "update", err: fmt.Errorf("install script: %w", err)}
+		}
+		if !kuradb.IsInstalled() {
+			return KuradbDone{action: "update", err: fmt.Errorf("kura binary not at %s after install", kuradb.BinaryPath)}
+		}
+		cfg, err := session.Load()
+		if err != nil {
+			return KuradbDone{action: "update", err: fmt.Errorf("session.Load: %w", err)}
+		}
+		cfg.KuradbEnabled = true
+		if err := session.Save(cfg); err != nil {
+			return KuradbDone{action: "update", err: fmt.Errorf("session.Save: %w", err)}
+		}
+		return KuradbDone{action: "update"}
 	})
 }
 

--- a/internal/runtime/tui/handlerCommand.go
+++ b/internal/runtime/tui/handlerCommand.go
@@ -75,6 +75,9 @@ func (t TUI) handleCommand(cmd string) (TUI, tea.Cmd, bool) {
 	case "/kuradb":
 		return t.commandKuradb(parts)
 
+	case "/admin-channel":
+		return t.commandAdminChannel(parts)
+
 	case "/cron":
 		return t.commandCron(parts)
 

--- a/internal/runtime/tui/update.go
+++ b/internal/runtime/tui/update.go
@@ -672,6 +672,11 @@ func (t TUI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				tea.Println(hintStyle.Render("⎯ kuradb removing")+"\n"),
 				runKuradbDisableExec(),
 			)
+		case "update":
+			return t, tea.Sequence(
+				tea.Println(hintStyle.Render("⎯ kuradb updating")+"\n"),
+				runKuradbUpdateExec(),
+			)
 		}
 		return t, nil
 

--- a/internal/runtime/tui/update.go
+++ b/internal/runtime/tui/update.go
@@ -11,6 +11,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/pardnchiu/agenvoy/internal/agents"
+	"github.com/pardnchiu/agenvoy/internal/agents/exec"
 	"github.com/pardnchiu/agenvoy/internal/runtime"
 	"github.com/pardnchiu/agenvoy/internal/session"
 	"github.com/pardnchiu/go-pkg/filesystem/keychain"
@@ -695,6 +696,26 @@ func (t TUI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			tea.Println(hintStyle.Render("⎯ kuradb installing")+"\n"),
 			runKuradbEnableExec(),
 		)
+
+	case AdminChannelSubmit:
+		value := strings.TrimSpace(msg.value)
+		if value != "" {
+			if _, _, ok := exec.ParseAdminChannel(value); !ok {
+				return t, tea.Println(errorStyle.Render("[!] admin-channel: format must be tg@<chatID> or dc@<channelID>") + "\n")
+			}
+		}
+		cfg, err := session.Load()
+		if err != nil || cfg == nil {
+			return t, tea.Println(errorStyle.Render(fmt.Sprintf("[!] admin-channel: session.Load: %v", err)) + "\n")
+		}
+		cfg.AdminChannel = value
+		if err := session.Save(cfg); err != nil {
+			return t, tea.Println(errorStyle.Render(fmt.Sprintf("[!] admin-channel: session.Save: %v", err)) + "\n")
+		}
+		if value == "" {
+			return t, tea.Println(hintStyle.Render("⎯ admin-channel cleared") + "\n")
+		}
+		return t, tea.Println(hintStyle.Render("⎯ admin-channel set · "+value) + "\n")
 
 	case AllowReportAction:
 		next, cmd := t.openAllowReportConfirm(msg.action)

--- a/internal/session/config.go
+++ b/internal/session/config.go
@@ -46,6 +46,7 @@ type Config struct {
 	TelegramEnabled  bool          `json:"telegram_enabled"`
 	TelegramUsername string        `json:"telegram_username"`
 	KuradbEnabled    bool          `json:"kuradb_enabled"`
+	AdminChannel     string        `json:"admin_channel"`
 }
 
 func (c *Config) UnmarshalJSON(data []byte) error {

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -4,12 +4,14 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io/fs"
 	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	go_pkg_filesystem "github.com/pardnchiu/go-pkg/filesystem"
@@ -18,6 +20,42 @@ import (
 	agentTypes "github.com/pardnchiu/agenvoy/internal/agents/types"
 	"github.com/pardnchiu/agenvoy/internal/filesystem"
 )
+
+var (
+	historyMuMap sync.Map
+)
+
+func AppendHistory(sessionID string, delta []agentTypes.Message) error {
+	if sessionID == "" || len(delta) == 0 {
+		return nil
+	}
+
+	mu, _ := historyMuMap.LoadOrStore(sessionID, &sync.Mutex{})
+	lock := mu.(*sync.Mutex)
+	lock.Lock()
+	defer lock.Unlock()
+
+	sessionDir := filepath.Join(filesystem.SessionsDir, sessionID)
+	if err := go_pkg_filesystem.CheckDir(sessionDir, true); err != nil {
+		return fmt.Errorf("github.com/pardnchiu/go-pkg/filesystem CheckDir: %w", err)
+	}
+	historyPath := filepath.Join(sessionDir, "history.json")
+
+	latest, err := go_pkg_filesystem.ReadJSON[[]agentTypes.Message](historyPath)
+	if err != nil {
+		latest = nil // first turn / missing file: start fresh
+	}
+	latest = append(latest, delta...)
+
+	data, err := json.Marshal(latest)
+	if err != nil {
+		return fmt.Errorf("json.Marshal: %w", err)
+	}
+	if err := go_pkg_filesystem.WriteFile(historyPath, string(data), 0644); err != nil {
+		return fmt.Errorf("github.com/pardnchiu/go-pkg/filesystem WriteFile: %w", err)
+	}
+	return nil
+}
 
 func SaveToToolCall(sessionID, content string) {
 	now := time.Now()
@@ -201,15 +239,3 @@ func latestModTime(dir string) time.Time {
 	return latest
 }
 
-func SaveHistory(sessionID, content string) error {
-	sessionDir := filepath.Join(filesystem.SessionsDir, sessionID)
-	if err := go_pkg_filesystem.CheckDir(sessionDir, true); err != nil {
-		return fmt.Errorf("github.com/pardnchiu/go-pkg/filesystem CheckDir: %w", err)
-	}
-
-	historyPath := filepath.Join(sessionDir, "history.json")
-	if err := go_pkg_filesystem.WriteFile(historyPath, content, 0644); err != nil {
-		return fmt.Errorf("github.com/pardnchiu/go-pkg/filesystem WriteFile: %w", err)
-	}
-	return nil
-}


### PR DESCRIPTION
Routes verification codes from unauthorized chats to a designated admin channel, relaying across messaging runtimes so an operator can authorize new chats out-of-band. Hardens session history so concurrent turns no longer clobber one another and buffers grouped media into a single turn. KuraDB control in the TUI gains an in-place update action.
