### PR TITLE
Track base history length for chat session restoration

### DIFF
--- a/internal/runtime/discord/session.go
+++ b/internal/runtime/discord/session.go
@@ -29,6 +29,7 @@ func getSession(in go_bot_discord.Input, content string, data exec.ExecData) (*a
 
 	oldHistory, maxHistory := sessionHistory.Get(sessionID)
 	sess.Histories = oldHistory
+	sess.BaseLen = len(oldHistory)
 
 	sess.SystemPrompts = exec.BuildSystemPrompts(data.WorkDir, data.ExtraSystemPrompt, agents.Scanner(), sessionID, data.AllowAll, false, data.ExcludeSkills)
 	if summary := summary.GetPrompt(sessionID, exec.OldestMessageTime(maxHistory)); summary != "" {

--- a/internal/runtime/telegram/session.go
+++ b/internal/runtime/telegram/session.go
@@ -32,6 +32,7 @@ func getSession(chatID int64, username, content string, data exec.ExecData, over
 
 	oldHistory, maxHistory := sessionHistory.Get(histSessionID)
 	sess.Histories = oldHistory
+	sess.BaseLen = len(oldHistory)
 
 	sess.SystemPrompts = exec.BuildSystemPrompts(data.WorkDir, data.ExtraSystemPrompt, agents.Scanner(), chatSessionID, data.AllowAll, false, data.ExcludeSkills)
 	if summary := summary.GetPrompt(histSessionID, exec.OldestMessageTime(maxHistory)); summary != "" {


### PR DESCRIPTION
Fixes a history duplication bug introduced during the v0.25.8 session package refactor, where Telegram and Discord sessions omitted the base-length marker and re-appended the full conversation on every turn.
