### PR TITLE
Fix Gemini enum schema handling and sync OpenAI key

### DIFF
--- a/internal/agents/provider/gemini/send.go
+++ b/internal/agents/provider/gemini/send.go
@@ -184,6 +184,7 @@ func (a *Agent) convertToTools(tools []toolTypes.Tool) []map[string]any {
 	for i, tool := range tools {
 		var params map[string]any
 		json.Unmarshal(tool.Function.Parameters, &params)
+		stringifyEnums(params)
 
 		newTools[i] = map[string]any{
 			"name":        tool.Function.Name,
@@ -192,6 +193,30 @@ func (a *Agent) convertToTools(tools []toolTypes.Tool) []map[string]any {
 		}
 	}
 	return newTools
+}
+
+func stringifyEnums(m map[string]any) {
+	if vals, ok := m["enum"]; ok {
+		if list, ok := vals.([]any); ok {
+			for i, v := range list {
+				if _, ok := v.(string); !ok {
+					list[i] = fmt.Sprintf("%v", v)
+				}
+			}
+		}
+	}
+	for _, v := range m {
+		switch child := v.(type) {
+		case map[string]any:
+			stringifyEnums(child)
+		case []any:
+			for _, item := range child {
+				if obj, ok := item.(map[string]any); ok {
+					stringifyEnums(obj)
+				}
+			}
+		}
+	}
 }
 
 func (a *Agent) generateRequestBody(messages []Content, prompt string, newTools []map[string]any) map[string]any {

--- a/internal/runtime/kuradb/kuradb.go
+++ b/internal/runtime/kuradb/kuradb.go
@@ -7,6 +7,9 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"os/exec"
+	"runtime"
+	"strings"
 	"time"
 
 	"github.com/pardnchiu/agenvoy/internal/filesystem"
@@ -14,6 +17,7 @@ import (
 
 const (
 	BinaryPath        = "/usr/local/bin/kura"
+	serviceKey        = "kuradb"
 	healthInterval    = 1 * time.Minute
 	healthRequestTime = 5 * time.Second
 	healthMaxStrikes  = 3
@@ -24,6 +28,35 @@ func Remove() error {
 		return fmt.Errorf("os.Remove %s: %w", filesystem.KuradbEndpointPath, err)
 	}
 	return nil
+}
+
+func SyncOpenAIKey(value string) error {
+	if value == "" {
+		return nil
+	}
+	switch runtime.GOOS {
+	case "darwin":
+		exec.Command("security", "delete-generic-password",
+			"-s", serviceKey,
+			"-a", "OPENAI_API_KEY").Run()
+		cmd := exec.Command("security", "add-generic-password",
+			"-s", serviceKey,
+			"-a", "OPENAI_API_KEY",
+			"-w", value)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return fmt.Errorf("security add-generic-password: %s", strings.TrimSpace(string(out)))
+		}
+		return nil
+	default:
+		cmd := exec.Command("secret-tool", "store",
+			"--label", serviceKey+"/OPENAI_API_KEY",
+			"service", serviceKey, "account", "OPENAI_API_KEY")
+		cmd.Stdin = strings.NewReader(value)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return fmt.Errorf("secret-tool store: %s", strings.TrimSpace(string(out)))
+		}
+		return nil
+	}
 }
 
 func IsInstalled() bool {

--- a/internal/runtime/tui/update.go
+++ b/internal/runtime/tui/update.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pardnchiu/agenvoy/internal/agents/exec"
 	"github.com/pardnchiu/agenvoy/internal/filesystem"
 	"github.com/pardnchiu/agenvoy/internal/runtime"
+	"github.com/pardnchiu/agenvoy/internal/runtime/kuradb"
 	"github.com/pardnchiu/agenvoy/internal/session/config"
 	configBot "github.com/pardnchiu/agenvoy/internal/session/config/bot"
 	"github.com/pardnchiu/go-pkg/filesystem/keychain"
@@ -691,6 +692,9 @@ func (t TUI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		if err := keychain.Set("OPENAI_API_KEY", token); err != nil {
 			return t, tea.Println(errorStyle.Render(fmt.Sprintf("[!] kuradb keychain.Set: %v", err)) + "\n")
+		}
+		if err := kuradb.SyncOpenAIKey(token); err != nil {
+			return t, tea.Println(errorStyle.Render(fmt.Sprintf("[!] kuradb SyncOpenAIKey: %v", err)) + "\n")
 		}
 		if err := config.SaveKey("OPENAI_API_KEY"); err != nil {
 			return t, tea.Println(errorStyle.Render(fmt.Sprintf("[!] kuradb session.SaveKey: %v", err)) + "\n")

--- a/internal/tools/interactive/storeSecret.go
+++ b/internal/tools/interactive/storeSecret.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/pardnchiu/agenvoy/internal/runtime"
+	"github.com/pardnchiu/agenvoy/internal/runtime/kuradb"
 	"github.com/pardnchiu/agenvoy/internal/session/config"
 	toolRegister "github.com/pardnchiu/agenvoy/internal/tools/register"
 	toolTypes "github.com/pardnchiu/agenvoy/internal/tools/types"
@@ -61,6 +62,11 @@ func registStoreSecret() {
 
 			if err := keychain.Set(key, value); err != nil {
 				return "", fmt.Errorf("keychain Set: %w", err)
+			}
+			if key == "OPENAI_API_KEY" {
+				if err := kuradb.SyncOpenAIKey(value); err != nil {
+					return "", fmt.Errorf("kuradb SyncOpenAIKey: %w", err)
+				}
 			}
 
 			if err := config.SaveKey(key); err != nil {


### PR DESCRIPTION
Fixes a Gemini API integration failure caused by non-string enum values in tool schemas, and resolves a keychain service mismatch that prevented KuraDB from reading its OpenAI credentials.
