### PR TITLE
Sync OpenAI API key and refresh chat-derived bot names

### DIFF
--- a/cmd/app/cmdDeamon.go
+++ b/cmd/app/cmdDeamon.go
@@ -151,9 +151,12 @@ func reloadKuradb() {
 	}
 	lastKuradbEnabled = newEnabled
 
-	if !newEnabled || !kuradb.IsInstalled() || strings.TrimSpace(keychain.Get("OPENAI_API_KEY")) == "" {
+	openaiKey := strings.TrimSpace(keychain.Get("OPENAI_API_KEY"))
+	if !newEnabled || !kuradb.IsInstalled() || openaiKey == "" {
 		return
 	}
+
+	kuradb.SyncOpenAIKey(openaiKey)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	kuradbCancel = cancel

--- a/internal/runtime/tui/commandBot.go
+++ b/internal/runtime/tui/commandBot.go
@@ -39,6 +39,7 @@ func (t TUI) commandBot(parts []string) (TUI, tea.Cmd, bool) {
 		return t, t.botSaveCmd(sid, name, body), true
 	}
 
+	refreshBotName(sid)
 	existingName, existingBody := configBot.Get(sid)
 	t.popup = &Popup{
 		kind:  popupText,

--- a/internal/runtime/tui/commandModelAdd.go
+++ b/internal/runtime/tui/commandModelAdd.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pardnchiu/agenvoy/internal/agents/provider"
 	"github.com/pardnchiu/agenvoy/internal/agents/provider/copilot"
 	openaicodex "github.com/pardnchiu/agenvoy/internal/agents/provider/openaiCodex"
+	"github.com/pardnchiu/agenvoy/internal/runtime/kuradb"
 	"github.com/pardnchiu/agenvoy/internal/session/config"
 	"github.com/pardnchiu/go-pkg/filesystem/keychain"
 )
@@ -274,6 +275,12 @@ func (t TUI) runModelAddAPIKeySubmit(key string) (TUI, tea.Cmd) {
 	if err := keychain.Set(envKey, key); err != nil {
 		t.modelAdd = nil
 		return t, tea.Println(errorStyle.Render(fmt.Sprintf("[!] keychain.Set: %v", err)) + "\n")
+	}
+	if envKey == "OPENAI_API_KEY" {
+		if err := kuradb.SyncOpenAIKey(key); err != nil {
+			t.modelAdd = nil
+			return t, tea.Println(errorStyle.Render(fmt.Sprintf("[!] kuradb SyncOpenAIKey: %v", err)) + "\n")
+		}
 	}
 	if err := config.SaveKey(envKey); err != nil {
 		t.modelAdd = nil

--- a/internal/runtime/tui/commandSwitch.go
+++ b/internal/runtime/tui/commandSwitch.go
@@ -97,6 +97,7 @@ func listSessions() []Session {
 		if strings.HasPrefix(sid, "temp-") || strings.HasPrefix(sid, ".") {
 			continue
 		}
+		refreshBotName(sid)
 		name, _ := configBot.Get(sid)
 		results = append(results, Session{
 			id:   sid,

--- a/internal/runtime/tui/init.go
+++ b/internal/runtime/tui/init.go
@@ -18,6 +18,8 @@ import (
 	"github.com/pardnchiu/agenvoy/internal/runtime/telegram"
 	"github.com/pardnchiu/agenvoy/internal/session/config"
 	configBot "github.com/pardnchiu/agenvoy/internal/session/config/bot"
+	"github.com/pardnchiu/agenvoy/internal/utils"
+	go_pkg_filesystem "github.com/pardnchiu/go-pkg/filesystem"
 	"github.com/pardnchiu/go-pkg/filesystem/keychain"
 	go_pkg_filesystem_reader "github.com/pardnchiu/go-pkg/filesystem/reader"
 )
@@ -199,6 +201,8 @@ func newModel(ctx context.Context, userInput string, onceCall, allowAll bool) TU
 		cwd = "?"
 	}
 
+	refreshBotNames()
+
 	currentSID := ""
 	currentName := ""
 
@@ -269,6 +273,41 @@ func getHttpStatus() string {
 		return textStyle.Render("http:     ") + errorStyle.Render("failed")
 	}
 	return textStyle.Render("http:     ") + okayStyle.Render(filesystem.Port)
+}
+
+func refreshBotNames() {
+	dirs, err := go_pkg_filesystem_reader.ListDirs(filesystem.SessionsDir)
+	if err != nil {
+		return
+	}
+	for _, d := range dirs {
+		refreshBotName(d.Name)
+	}
+}
+
+func refreshBotName(sid string) {
+	var authPath, idKey string
+	switch {
+	case strings.HasPrefix(sid, "tg-"):
+		authPath = filesystem.TelegramAuthPath
+		idKey = "chat_id"
+	case strings.HasPrefix(sid, "dc-"):
+		authPath = filesystem.DiscordAuthPath
+		idKey = "channel_id"
+	default:
+		return
+	}
+	cfg, err := go_pkg_filesystem.ReadJSON[map[string]string](filesystem.SessionConfigPath(sid))
+	if err != nil {
+		return
+	}
+	id := cfg[idKey]
+	if id == "" {
+		return
+	}
+	if n := configBot.FormatName(utils.LookupChatName(authPath, id)); n != "" {
+		configBot.ReplaceDefault(sid, n)
+	}
 }
 
 func loadSessionTail(sid string) []tea.Cmd {

--- a/internal/runtime/tui/update.go
+++ b/internal/runtime/tui/update.go
@@ -750,6 +750,11 @@ func (t TUI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if err := keychain.Set(msg.key, msg.value); err != nil {
 			return t, tea.Println(errorStyle.Render(fmt.Sprintf("[!] keychain.Set %s: %v", msg.key, err)) + "\n")
 		}
+		if msg.key == "OPENAI_API_KEY" {
+			if err := kuradb.SyncOpenAIKey(msg.value); err != nil {
+				return t, tea.Println(errorStyle.Render(fmt.Sprintf("[!] kuradb SyncOpenAIKey: %v", err)) + "\n")
+			}
+		}
 		return t, tea.Println(hintStyle.Render(fmt.Sprintf("⎯ %s updated", msg.key)) + "\n")
 
 	case KuradbDone:

--- a/internal/session/config/bot/bot.go
+++ b/internal/session/config/bot/bot.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"unicode"
 
 	go_pkg_filesystem "github.com/pardnchiu/go-pkg/filesystem"
 	go_pkg_filesystem_reader "github.com/pardnchiu/go-pkg/filesystem/reader"
@@ -104,6 +105,50 @@ func SetModel(sessionID, model, reasoning string) {
 	if reasoning != "" {
 		bot.Reasoning = reasoning
 	}
+	writeBotFile(sessionID, bot)
+}
+
+func FormatName(raw string) string {
+	var sb strings.Builder
+	for _, r := range raw {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			sb.WriteRune(r)
+		}
+	}
+	return sb.String()
+}
+
+func UpdateName(prefix, name string) {
+	if prefix == "" || name == "" {
+		return
+	}
+	dirs, err := go_pkg_filesystem_reader.ListDirs(filesystem.SessionsDir)
+	if err != nil {
+		return
+	}
+	for _, d := range dirs {
+		sid := d.Name
+		if !strings.HasPrefix(sid, prefix) {
+			continue
+		}
+		bot := read(sid)
+		if bot.Name != "" && !strings.HasPrefix(bot.Name, "tg-") && !strings.HasPrefix(bot.Name, "dc-") {
+			continue
+		}
+		bot.Name = name
+		writeBotFile(sid, bot)
+	}
+}
+
+func ReplaceDefault(sessionID, name string) {
+	if sessionID == "" || name == "" {
+		return
+	}
+	bot := read(sessionID)
+	if bot.Name != "" && !strings.HasPrefix(bot.Name, "tg-") && !strings.HasPrefix(bot.Name, "dc-") {
+		return
+	}
+	bot.Name = name
 	writeBotFile(sessionID, bot)
 }
 

--- a/internal/session/discord/discord.go
+++ b/internal/session/discord/discord.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/pardnchiu/agenvoy/internal/filesystem"
 	configBot "github.com/pardnchiu/agenvoy/internal/session/config/bot"
+	"github.com/pardnchiu/agenvoy/internal/utils"
 	go_pkg_filesystem "github.com/pardnchiu/go-pkg/filesystem"
 	go_pkg_filesystem_reader "github.com/pardnchiu/go-pkg/filesystem/reader"
 )
@@ -45,10 +46,14 @@ func New(guildID, channelID, userID string) (string, error) {
 		}
 	}
 
-	if err := configBot.Save(sessionID, "", "", false); err != nil {
+	botName := configBot.FormatName(utils.LookupChatName(filesystem.DiscordAuthPath, channelID))
+	if err := configBot.Save(sessionID, botName, "", false); err != nil {
 		slog.Warn("configBot Save",
 			slog.String("session", sessionID),
 			slog.String("error", err.Error()))
+	}
+	if botName != "" {
+		configBot.ReplaceDefault(sessionID, botName)
 	}
 	return sessionID, nil
 }

--- a/internal/session/telegram/telegram.go
+++ b/internal/session/telegram/telegram.go
@@ -5,9 +5,11 @@ import (
 	"encoding/hex"
 	"fmt"
 	"log/slog"
+	"strconv"
 
 	"github.com/pardnchiu/agenvoy/internal/filesystem"
 	configBot "github.com/pardnchiu/agenvoy/internal/session/config/bot"
+	"github.com/pardnchiu/agenvoy/internal/utils"
 	go_pkg_filesystem "github.com/pardnchiu/go-pkg/filesystem"
 	go_pkg_filesystem_reader "github.com/pardnchiu/go-pkg/filesystem/reader"
 )
@@ -27,10 +29,14 @@ func New(chatID int64) (string, error) {
 		}
 	}
 
-	if err := configBot.Save(sessionID, "", "", false); err != nil {
+	botName := configBot.FormatName(utils.LookupChatName(filesystem.TelegramAuthPath, strconv.FormatInt(chatID, 10)))
+	if err := configBot.Save(sessionID, botName, "", false); err != nil {
 		slog.Warn("configBot Save",
 			slog.String("session", sessionID),
 			slog.String("error", err.Error()))
+	}
+	if botName != "" {
+		configBot.ReplaceDefault(sessionID, botName)
 	}
 	return sessionID, nil
 }


### PR DESCRIPTION
Keeps session identity aligned with chat context while making kuradb key propagation more reliable during runtime updates. This release improves naming continuity for existing and new chat sessions, and closes a sync gap around OpenAI credential refreshes.
