### PR TITLE
Add MCP authentication flow and normalize authorization headers

### DIFF
--- a/internal/runtime/tui/commandMcpAdd.go
+++ b/internal/runtime/tui/commandMcpAdd.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"fmt"
+	"maps"
 	"sort"
 	"strings"
 
@@ -14,15 +15,16 @@ import (
 )
 
 type mcpAddDraft struct {
-	name      string
-	transport string
-	command   string
-	args      []string
-	env       map[string]string
-	url       string
-	headers   map[string]string
-	scope     string
-	sessionID string
+	name           string
+	transport      string
+	command        string
+	args           []string
+	env            map[string]string
+	url            string
+	headers        map[string]string
+	authHeaderName string
+	scope          string
+	sessionID      string
 }
 
 type McpAddName struct {
@@ -47,6 +49,26 @@ type McpAddEnv struct {
 
 type McpAddURL struct {
 	url string
+}
+
+type McpAddAuthMethod struct {
+	method string
+}
+
+type McpAddBearerToken struct {
+	token string
+}
+
+type McpAddAPIKeyHeader struct {
+	header string
+}
+
+type McpAddAPIKeyValue struct {
+	value string
+}
+
+type McpAddBasicToken struct {
+	token string
 }
 
 type McpAddHeaders struct {
@@ -143,10 +165,76 @@ func (t TUI) openMcpAddHeaders() (TUI, tea.Cmd) {
 	t.popup = &Popup{
 		kind:      popupText,
 		multiline: true,
-		title:     "Headers (KEY=VALUE per line · ctrl+s submit · blank to skip)",
-		subtitle:  "example:\nAuthorization=Bearer ${TOKEN}\nX-Trace=1",
+		title:     "Extra headers (KEY=VALUE per line · ctrl+s submit · blank to skip)",
+		subtitle:  "example:\nX-Trace=1\nX-Client=agenvoy",
 		onConfirm: func(value string) any {
 			return McpAddHeaders{raw: value}
+		},
+	}
+	return t, nil
+}
+
+func (t TUI) openMcpAddAuthMethod() (TUI, tea.Cmd) {
+	t.popup = &Popup{
+		kind:  popupSingleSelect,
+		title: "Authentication",
+		options: []string{
+			"none    no auth",
+			"bearer  Authorization: Bearer token",
+			"api key custom header token",
+			"basic   Authorization: Basic token",
+		},
+		values: []string{"none", "bearer", "apikey", "basic"},
+		onConfirm: func(chosen string) any {
+			return McpAddAuthMethod{method: chosen}
+		},
+	}
+	return t, nil
+}
+
+func (t TUI) openMcpAddBearerToken() (TUI, tea.Cmd) {
+	t.popup = &Popup{
+		kind:     popupText,
+		title:    "Bearer token",
+		subtitle: "raw token or ${TOKEN}; Bearer is added automatically",
+		onConfirm: func(value string) any {
+			return McpAddBearerToken{token: strings.TrimSpace(value)}
+		},
+	}
+	return t, nil
+}
+
+func (t TUI) openMcpAddAPIKeyHeader() (TUI, tea.Cmd) {
+	t.popup = &Popup{
+		kind:     popupText,
+		title:    "API key header name",
+		subtitle: "blank uses X-API-Key",
+		onConfirm: func(value string) any {
+			return McpAddAPIKeyHeader{header: strings.TrimSpace(value)}
+		},
+	}
+	return t, nil
+}
+
+func (t TUI) openMcpAddAPIKeyValue(header string) (TUI, tea.Cmd) {
+	t.popup = &Popup{
+		kind:     popupText,
+		title:    fmt.Sprintf("%s value", header),
+		subtitle: "raw key or ${TOKEN}",
+		onConfirm: func(value string) any {
+			return McpAddAPIKeyValue{value: strings.TrimSpace(value)}
+		},
+	}
+	return t, nil
+}
+
+func (t TUI) openMcpAddBasicToken() (TUI, tea.Cmd) {
+	t.popup = &Popup{
+		kind:     popupText,
+		title:    "Basic auth token",
+		subtitle: "base64 user:pass or ${BASIC_TOKEN}; Basic is added automatically",
+		onConfirm: func(value string) any {
+			return McpAddBasicToken{token: strings.TrimSpace(value)}
 		},
 	}
 	return t, nil
@@ -239,6 +327,50 @@ func parseKV(raw string) map[string]string {
 		return nil
 	}
 	return out
+}
+
+func mergeMcpHeaders(base, extra map[string]string) map[string]string {
+	if len(base) == 0 && len(extra) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(base)+len(extra))
+	maps.Copy(out, base)
+	maps.Copy(out, extra)
+	return out
+}
+
+func bearerAuthorizationHeader(token string) map[string]string {
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return nil
+	}
+	if strings.Contains(token, " ") {
+		return map[string]string{"Authorization": token}
+	}
+	return map[string]string{"Authorization": "Bearer " + token}
+}
+
+func apiKeyHeader(header, value string) map[string]string {
+	header = strings.TrimSpace(header)
+	value = strings.TrimSpace(value)
+	if header == "" {
+		header = "X-API-Key"
+	}
+	if value == "" {
+		return nil
+	}
+	return map[string]string{header: value}
+}
+
+func basicAuthorizationHeader(token string) map[string]string {
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return nil
+	}
+	if strings.Contains(token, " ") {
+		return map[string]string{"Authorization": token}
+	}
+	return map[string]string{"Authorization": "Basic " + token}
 }
 
 func parseArgsCSV(raw string) []string {

--- a/internal/runtime/tui/update.go
+++ b/internal/runtime/tui/update.go
@@ -424,11 +424,52 @@ func (t TUI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return t, tea.Println(errorStyle.Render("[!] url required") + "\n")
 		}
 		t.mcpAdd.url = msg.url
+		next, cmd := t.openMcpAddAuthMethod()
+		return next, cmd
+
+	case McpAddAuthMethod:
+		switch msg.method {
+		case "none":
+			next, cmd := t.openMcpAddHeaders()
+			return next, cmd
+		case "bearer":
+			next, cmd := t.openMcpAddBearerToken()
+			return next, cmd
+		case "apikey":
+			next, cmd := t.openMcpAddAPIKeyHeader()
+			return next, cmd
+		case "basic":
+			next, cmd := t.openMcpAddBasicToken()
+			return next, cmd
+		}
+		t.mcpAdd = nil
+		return t, nil
+
+	case McpAddBearerToken:
+		t.mcpAdd.headers = bearerAuthorizationHeader(msg.token)
+		next, cmd := t.openMcpAddHeaders()
+		return next, cmd
+
+	case McpAddAPIKeyHeader:
+		t.mcpAdd.authHeaderName = msg.header
+		if t.mcpAdd.authHeaderName == "" {
+			t.mcpAdd.authHeaderName = "X-API-Key"
+		}
+		next, cmd := t.openMcpAddAPIKeyValue(t.mcpAdd.authHeaderName)
+		return next, cmd
+
+	case McpAddAPIKeyValue:
+		t.mcpAdd.headers = apiKeyHeader(t.mcpAdd.authHeaderName, msg.value)
+		next, cmd := t.openMcpAddHeaders()
+		return next, cmd
+
+	case McpAddBasicToken:
+		t.mcpAdd.headers = basicAuthorizationHeader(msg.token)
 		next, cmd := t.openMcpAddHeaders()
 		return next, cmd
 
 	case McpAddHeaders:
-		t.mcpAdd.headers = parseKV(msg.raw)
+		t.mcpAdd.headers = mergeMcpHeaders(t.mcpAdd.headers, parseKV(msg.raw))
 		next, cmd := t.openMcpAddScope()
 		return next, cmd
 

--- a/internal/toolAdapter/mcp/config.go
+++ b/internal/toolAdapter/mcp/config.go
@@ -101,10 +101,21 @@ func (c ServerConfig) Expand() ServerConfig {
 	if len(c.Headers) > 0 {
 		out.Headers = make(map[string]string, len(c.Headers))
 		for k, v := range c.Headers {
-			out.Headers[k] = os.ExpandEnv(v)
+			out.Headers[k] = normalizeHeaderValue(k, os.ExpandEnv(v))
 		}
 	}
 	return out
+}
+
+func normalizeHeaderValue(key, value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" || !strings.EqualFold(strings.TrimSpace(key), "Authorization") {
+		return value
+	}
+	if len(strings.Fields(value)) > 1 {
+		return value
+	}
+	return "Bearer " + value
 }
 
 func (c ServerConfig) IsHTTP() bool {

--- a/internal/toolAdapter/mcp/config_test.go
+++ b/internal/toolAdapter/mcp/config_test.go
@@ -49,7 +49,10 @@ func TestServerConfig_Expand(t *testing.T) {
 		Command: "npx",
 		Args:    []string{"--token", "$TEST_MCP_TOKEN"},
 		Env:     map[string]string{"API_KEY": "$TEST_MCP_TOKEN"},
-		Headers: map[string]string{"Authorization": "Bearer $TEST_MCP_TOKEN"},
+		Headers: map[string]string{
+			"Authorization": "Bearer $TEST_MCP_TOKEN",
+			"X-Token":       "$TEST_MCP_TOKEN",
+		},
 	}
 
 	expanded := cfg.Expand()
@@ -65,6 +68,42 @@ func TestServerConfig_Expand(t *testing.T) {
 	}
 	if expanded.Headers["Authorization"] != "Bearer secret123" {
 		t.Errorf("headers Authorization = %q", expanded.Headers["Authorization"])
+	}
+	if expanded.Headers["X-Token"] != "secret123" {
+		t.Errorf("headers X-Token = %q", expanded.Headers["X-Token"])
+	}
+}
+
+func TestServerConfig_Expand_NormalizesBearerAuthorization(t *testing.T) {
+	os.Setenv("TEST_MCP_TOKEN", "secret123")
+	defer os.Unsetenv("TEST_MCP_TOKEN")
+
+	cfg := ServerConfig{
+		Headers: map[string]string{"Authorization": "$TEST_MCP_TOKEN"},
+	}
+
+	expanded := cfg.Expand()
+	if expanded.Headers["Authorization"] != "Bearer secret123" {
+		t.Errorf("headers Authorization = %q", expanded.Headers["Authorization"])
+	}
+}
+
+func TestServerConfig_Expand_KeepsExplicitAuthorizationScheme(t *testing.T) {
+	tests := []string{
+		"Bearer secret123",
+		"Basic c2VjcmV0",
+		"token ghp_secret123",
+	}
+
+	for _, auth := range tests {
+		cfg := ServerConfig{
+			Headers: map[string]string{"Authorization": auth},
+		}
+
+		expanded := cfg.Expand()
+		if expanded.Headers["Authorization"] != auth {
+			t.Errorf("headers Authorization = %q, want %q", expanded.Headers["Authorization"], auth)
+		}
 	}
 }
 


### PR DESCRIPTION
Tightens MCP server onboarding with a guided authentication flow and safer header handling. It also closes a common connection gap by normalizing authorization values before runtime use.
