### PR TITLE
Add Cloudflare AI provider and remove leaked summary blocks

### DIFF
--- a/cmd/app/buildAgentRegistry.go
+++ b/cmd/app/buildAgentRegistry.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/pardnchiu/agenvoy/internal/agents/exec"
 	"github.com/pardnchiu/agenvoy/internal/agents/provider/claude"
+	"github.com/pardnchiu/agenvoy/internal/agents/provider/cloudflare"
 	"github.com/pardnchiu/agenvoy/internal/agents/provider/compat"
 	"github.com/pardnchiu/agenvoy/internal/agents/provider/copilot"
 	"github.com/pardnchiu/agenvoy/internal/agents/provider/deepseek"
@@ -30,6 +31,7 @@ func buildAgentRegistry() agentTypes.AgentRegistry {
 		"grok-oauth": func(m string) (agentTypes.Agent, error) { return grokoauth.New(m) },
 		"copilot":    func(m string) (agentTypes.Agent, error) { return copilot.New(m) },
 		"nvidia":     func(m string) (agentTypes.Agent, error) { return nvidia.New(m) },
+		"cloudflare":  func(m string) (agentTypes.Agent, error) { return cloudflare.New(m) },
 		"deepseek":    func(m string) (agentTypes.Agent, error) { return deepseek.New(m) },
 		"openrouter": func(m string) (agentTypes.Agent, error) { return openrouter.New(m) },
 		"compat":     func(m string) (agentTypes.Agent, error) { return compat.New(m) },

--- a/internal/agents/exec/execute.go
+++ b/internal/agents/exec/execute.go
@@ -43,6 +43,7 @@ const (
 
 var (
 	timestampHeaderRegex   = regexp.MustCompile(`(?m)^-{3,}\n.*\n-{3,}\n`)
+	summaryBlockRegex      = regexp.MustCompile(`(?s)<summary>\s*[\s\S]*?\s*</summary>|\[summary\]\s*[\s\S]*?\s*\[/summary\]`)
 	summaryLeakMarkerRegex = regexp.MustCompile(`(?i)(?:Prior Conversation Context|Prior summary|background summary of prior discussion|Strict rules:|"key_decisions"\s*:\s*\[|"current_discussion"\s*:\s*\{)`)
 )
 
@@ -52,6 +53,7 @@ func isGuardrailRefusal(content string) bool {
 
 func StripModelResponse(str string) string {
 	str = timestampHeaderRegex.ReplaceAllString(str, "")
+	str = summaryBlockRegex.ReplaceAllString(str, "")
 	if loc := summaryLeakMarkerRegex.FindStringIndex(str); loc != nil {
 		dropped := strings.TrimSpace(str[loc[0]:])
 		head := dropped

--- a/internal/agents/provider/cloudflare/new.go
+++ b/internal/agents/provider/cloudflare/new.go
@@ -1,0 +1,62 @@
+package cloudflare
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/pardnchiu/go-pkg/filesystem/keychain"
+
+	"github.com/pardnchiu/agenvoy/internal/agents/provider"
+)
+
+type Agent struct {
+	httpClient *http.Client
+	model      string
+	apiKey     string
+	accountID string
+	gatewayID string
+	workDir   string
+}
+
+const (
+	prefix = "cloudflare@"
+)
+
+func New(model ...string) (*Agent, error) {
+	if len(model) == 0 || !strings.HasPrefix(model[0], prefix) {
+		return nil, fmt.Errorf("cloudflare.New: model arg required with %q prefix", prefix)
+	}
+	usedModel := strings.TrimPrefix(model[0], prefix)
+
+	apiKey := keychain.Get("CLOUDFLARE_API_KEY")
+	if apiKey == "" {
+		return nil, fmt.Errorf("keychain.Get: CLOUDFLARE_API_KEY is required")
+	}
+
+	accountID := keychain.Get("CLOUDFLARE_ACCOUNT_ID")
+	if accountID == "" {
+		return nil, fmt.Errorf("keychain.Get: CLOUDFLARE_ACCOUNT_ID is required")
+	}
+
+	gatewayID := keychain.Get("CLOUDFLARE_GATEWAY_ID")
+	if gatewayID == "" {
+		gatewayID = "default"
+	}
+
+	workDir, _ := os.Getwd()
+
+	return &Agent{
+		httpClient: provider.NewHTTPClient(),
+		model:      usedModel,
+		apiKey:     apiKey,
+		accountID:  accountID,
+		gatewayID:  gatewayID,
+		workDir:    workDir,
+	}, nil
+}
+
+func (a *Agent) Name() string {
+	return a.model
+}

--- a/internal/agents/provider/cloudflare/send.go
+++ b/internal/agents/provider/cloudflare/send.go
@@ -1,0 +1,111 @@
+package cloudflare
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/pardnchiu/agenvoy/internal/agents/exec"
+	agentTypes "github.com/pardnchiu/agenvoy/internal/agents/types"
+	"github.com/pardnchiu/agenvoy/internal/filesystem/skill"
+	toolTypes "github.com/pardnchiu/agenvoy/internal/tools/types"
+	go_pkg_http "github.com/pardnchiu/go-pkg/http"
+)
+
+const (
+	runAPI = "https://api.cloudflare.com/client/v4/accounts/"
+)
+
+func (a *Agent) endpoint() string {
+	return runAPI + a.accountID + "/ai/run"
+}
+
+func (a *Agent) Execute(ctx context.Context, skill *skill.Skill, userInput string, events chan<- agentTypes.Event, allowAll bool) error {
+	data := exec.ExecData{
+		Agent:   a,
+		WorkDir: a.workDir,
+		Skill:   skill,
+		Content: userInput,
+	}
+	session, err := exec.GetSession(ctx, data)
+	if err != nil {
+		return fmt.Errorf("exec.GetSession: %w", err)
+	}
+	return exec.Execute(ctx, data, session, events, allowAll)
+}
+
+func flattenContent(c any) string {
+	switch v := c.(type) {
+	case string:
+		return v
+	case []any:
+		var buf strings.Builder
+		for _, item := range v {
+			m, ok := item.(map[string]any)
+			if !ok {
+				continue
+			}
+			t, _ := m["type"].(string)
+			switch t {
+			case "text", "input_text", "output_text":
+				text, _ := m["text"].(string)
+				if buf.Len() > 0 {
+					buf.WriteByte('\n')
+				}
+				buf.WriteString(text)
+			}
+		}
+		return buf.String()
+	}
+	return fmt.Sprintf("%v", c)
+}
+
+func (a *Agent) Send(ctx context.Context, messages []agentTypes.Message, tools []toolTypes.Tool) (*agentTypes.Output, error) {
+	var merged []agentTypes.Message
+	var systemParts []string
+	for _, m := range messages {
+		if m.Role == "system" {
+			s := flattenContent(m.Content)
+			if s != "" {
+				systemParts = append(systemParts, s)
+			}
+		} else {
+			merged = append(merged, agentTypes.Message{
+				Role:       m.Role,
+				Content:    flattenContent(m.Content),
+				ToolCalls:  m.ToolCalls,
+				ToolCallID: m.ToolCallID,
+			})
+		}
+	}
+	if len(systemParts) > 0 {
+		merged = append([]agentTypes.Message{{Role: "system", Content: strings.Join(systemParts, "\n\n")}}, merged...)
+	}
+
+	input := map[string]any{
+		"messages":   merged,
+		"max_tokens": 4096,
+	}
+	if len(tools) > 0 {
+		input["tools"] = tools
+	}
+
+	headers := map[string]string{
+		"Authorization":      "Bearer " + a.apiKey,
+		"Content-Type":       "application/json",
+		"cf-aig-gateway-id": a.gatewayID,
+	}
+
+	resp, _, err := go_pkg_http.POST[response](ctx, a.httpClient, a.endpoint(), headers, map[string]any{
+		"model": a.model,
+		"input": input,
+	}, "json")
+	if err != nil {
+		return nil, fmt.Errorf("http.POST: %w", err)
+	}
+	if len(resp.Errors) > 0 {
+		return nil, fmt.Errorf("http.POST: %s", resp.Errors[0].Message)
+	}
+
+	return &resp.Result, nil
+}

--- a/internal/agents/provider/cloudflare/type.go
+++ b/internal/agents/provider/cloudflare/type.go
@@ -1,0 +1,12 @@
+package cloudflare
+
+import agentTypes "github.com/pardnchiu/agenvoy/internal/agents/types"
+
+type response struct {
+	Result  agentTypes.Output `json:"result"`
+	Success bool              `json:"success"`
+	Errors  []struct {
+		Message string `json:"message"`
+		Code    int    `json:"code"`
+	} `json:"errors"`
+}

--- a/internal/runtime/tui/commandModelAdd.go
+++ b/internal/runtime/tui/commandModelAdd.go
@@ -37,6 +37,10 @@ type ModelAddCompatURLSubmit struct{ url string }
 type ModelAddCompatKeySubmit struct{ key string }
 type ModelAddModelMultiPick struct{ chosen string }
 type ModelAddDone struct{ err error }
+type ModelAddAccountIDReplace struct{ replace string }
+type ModelAddAccountIDSubmit struct{ id string }
+type ModelAddGatewayIDPick struct{ chosen string }
+type ModelAddGatewayIDSubmit struct{ id string }
 type CompatModelsResult struct{ ids []string }
 type RemoteModelsResult struct{ ids []string }
 type OpenAIMethodPick struct{ method string }
@@ -62,6 +66,7 @@ var modelAddProviders = []struct {
 	{"deepseek", "DeepSeek        API key"},
 	{"nvidia", "NVIDIA NIM      API key"},
 	{"openrouter", "OpenRouter      API key"},
+	{"cloudflare", "Cloudflare      Workers AI · API token + account ID"},
 	{"compat", "Local/Custom    Ollama, LM Studio, or custom URL"},
 }
 
@@ -113,6 +118,8 @@ func (t TUI) runModelAddProviderPick(name string) (TUI, tea.Cmd) {
 			},
 		}
 		return t, nil
+	case "cloudflare":
+		return t.openModelAddAccountID()
 	case "copilot", "codex", "grok-oauth":
 		return t.modelAddViaOAuth()
 	case "compat":
@@ -335,6 +342,113 @@ func (t TUI) runModelAddAPIKeySubmit(key string) (TUI, tea.Cmd) {
 	if err := config.SaveKey(envKey); err != nil {
 		t.modelAdd = nil
 		return t, tea.Println(errorStyle.Render(fmt.Sprintf("[!] session.SaveKey: %v", err)) + "\n")
+	}
+	if t.modelAdd.provider == "cloudflare" {
+		return t.openModelAddGatewayID()
+	}
+	return t.openModelAddModelPick()
+}
+
+func (t TUI) openModelAddAccountID() (TUI, tea.Cmd) {
+	if keychain.Get("CLOUDFLARE_ACCOUNT_ID") != "" {
+		t.popup = &Popup{
+			kind:    popupSingleSelect,
+			title:   "Cloudflare account ID exists · replace?",
+			options: []string{"No   keep existing", "Yes  overwrite"},
+			values:  []string{"no", "yes"},
+			onConfirm: func(chosen string) any {
+				return ModelAddAccountIDReplace{replace: chosen}
+			},
+		}
+		return t, nil
+	}
+	t.popup = &Popup{
+		kind:  popupText,
+		title: "Cloudflare account ID",
+		onConfirm: func(value string) any {
+			return ModelAddAccountIDSubmit{id: strings.TrimSpace(value)}
+		},
+	}
+	return t, nil
+}
+
+func (t TUI) runModelAddAccountIDReplace(replace string) (TUI, tea.Cmd) {
+	if t.modelAdd == nil {
+		return t, tea.Println(errorStyle.Render("[!] model add state lost") + "\n")
+	}
+	if replace == "yes" {
+		t.popup = &Popup{
+			kind:  popupText,
+			title: "Cloudflare account ID (new)",
+			onConfirm: func(value string) any {
+				return ModelAddAccountIDSubmit{id: strings.TrimSpace(value)}
+			},
+		}
+		return t, nil
+	}
+	return t.openModelAddAPIKey()
+}
+
+func (t TUI) runModelAddAccountIDSubmit(id string) (TUI, tea.Cmd) {
+	if t.modelAdd == nil {
+		return t, tea.Println(errorStyle.Render("[!] model add state lost") + "\n")
+	}
+	if id == "" {
+		t.modelAdd = nil
+		return t, tea.Println(errorStyle.Render("[!] account ID required") + "\n")
+	}
+	if err := keychain.Set("CLOUDFLARE_ACCOUNT_ID", id); err != nil {
+		t.modelAdd = nil
+		return t, tea.Println(errorStyle.Render(fmt.Sprintf("[!] keychain.Set: %v", err)) + "\n")
+	}
+	return t.openModelAddAPIKey()
+}
+
+func (t TUI) openModelAddGatewayID() (TUI, tea.Cmd) {
+	t.popup = &Popup{
+		kind:    popupSingleSelect,
+		title:   "Cloudflare AI Gateway ID",
+		options: []string{"default", "Custom   enter gateway ID"},
+		values:  []string{"default", "custom"},
+		onConfirm: func(chosen string) any {
+			return ModelAddGatewayIDPick{chosen: chosen}
+		},
+	}
+	return t, nil
+}
+
+func (t TUI) runModelAddGatewayIDPick(chosen string) (TUI, tea.Cmd) {
+	if t.modelAdd == nil {
+		return t, tea.Println(errorStyle.Render("[!] model add state lost") + "\n")
+	}
+	if chosen == "custom" {
+		t.popup = &Popup{
+			kind:  popupText,
+			title: "Cloudflare AI Gateway ID",
+			onConfirm: func(value string) any {
+				return ModelAddGatewayIDSubmit{id: strings.TrimSpace(value)}
+			},
+		}
+		return t, nil
+	}
+	if err := keychain.Set("CLOUDFLARE_GATEWAY_ID", "default"); err != nil {
+		t.modelAdd = nil
+		return t, tea.Println(errorStyle.Render(fmt.Sprintf("[!] keychain.Set: %v", err)) + "\n")
+	}
+	return t.openModelAddModelPick()
+}
+
+func (t TUI) runModelAddGatewayIDSubmit(id string) (TUI, tea.Cmd) {
+	if t.modelAdd == nil {
+		return t, tea.Println(errorStyle.Render("[!] model add state lost") + "\n")
+	}
+	if id == "" {
+		t.modelAdd = nil
+		return t, tea.Println(errorStyle.Render("[!] gateway ID required") + "\n")
+	}
+	if err := keychain.Set("CLOUDFLARE_GATEWAY_ID", id); err != nil {
+		t.modelAdd = nil
+		return t, tea.Println(errorStyle.Render(fmt.Sprintf("[!] keychain.Set: %v", err)) + "\n")
 	}
 	return t.openModelAddModelPick()
 }
@@ -680,6 +794,17 @@ func remoteModelsEndpoint(prov string) (string, map[string]string) {
 		}
 	}
 
+	if prov == "cloudflare" {
+		apiKey := keychain.Get("CLOUDFLARE_API_KEY")
+		accountID := keychain.Get("CLOUDFLARE_ACCOUNT_ID")
+		if apiKey == "" || accountID == "" {
+			return "", nil
+		}
+		return "https://api.cloudflare.com/client/v4/accounts/" + accountID + "/ai/models/search", map[string]string{
+			"Authorization": "Bearer " + apiKey,
+		}
+	}
+
 	info, ok := remoteModelsProviders[prov]
 	if !ok {
 		return "", nil
@@ -711,8 +836,31 @@ type geminiModelsResponse struct {
 	} `json:"models"`
 }
 
+type cloudflareModelsResponse struct {
+	Result []struct {
+		Name string `json:"name"`
+		Task struct {
+			Name string `json:"name"`
+		} `json:"task"`
+	} `json:"result"`
+}
+
 func fetchRemoteModelIDs(ctx context.Context, endpoint string, headers map[string]string, prov string) []string {
 	client := &http.Client{Timeout: 10 * time.Second}
+
+	if prov == "cloudflare" {
+		data, status, err := go_pkg_http.GET[cloudflareModelsResponse](ctx, client, endpoint, headers)
+		if err != nil || status != http.StatusOK {
+			return nil
+		}
+		ids := make([]string, 0, len(data.Result))
+		for _, m := range data.Result {
+			if m.Name != "" && m.Task.Name == "Text Generation" {
+				ids = append(ids, m.Name)
+			}
+		}
+		return ids
+	}
 
 	if prov == "gemini" {
 		data, status, err := go_pkg_http.GET[geminiModelsResponse](ctx, client, endpoint, headers)

--- a/internal/runtime/tui/update.go
+++ b/internal/runtime/tui/update.go
@@ -586,6 +586,18 @@ func (t TUI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case ModelAddAPIKeySubmit:
 		return t.runModelAddAPIKeySubmit(msg.key)
 
+	case ModelAddAccountIDReplace:
+		return t.runModelAddAccountIDReplace(msg.replace)
+
+	case ModelAddAccountIDSubmit:
+		return t.runModelAddAccountIDSubmit(msg.id)
+
+	case ModelAddGatewayIDPick:
+		return t.runModelAddGatewayIDPick(msg.chosen)
+
+	case ModelAddGatewayIDSubmit:
+		return t.runModelAddGatewayIDSubmit(msg.id)
+
 	case ModelAddCompatNameSubmit:
 		return t.runModelAddCompatNameSubmit(msg.name)
 


### PR DESCRIPTION
Adds Cloudflare Workers AI as a provider with native AI Gateway routing, account-based authentication, and content flattening for text-only models. Hardens the response stripping pipeline to catch leaked summary blocks before they reach the user.
