### PR TITLE
Raise session log replay window and configure AllowAll option

### DIFF
--- a/internal/agents/exec/compactExec.go
+++ b/internal/agents/exec/compactExec.go
@@ -15,6 +15,10 @@ import (
 )
 
 func compactThreshold(modelName string) int {
+	if strings.Contains(modelName, "oss-gpt-120") {
+		return int(128_000 * 0.8)
+	}
+
 	switch {
 	case strings.Contains(modelName, "gemini"):
 		return int(1_000_000 * 0.8)

--- a/internal/runtime/routes/handler/log.go
+++ b/internal/runtime/routes/handler/log.go
@@ -42,7 +42,7 @@ func StreamSessionLog() gin.HandlerFunc {
 			c.Writer.Flush()
 		}
 
-		for _, ev := range sessionLog.RecentEvents(sid, 100) {
+		for _, ev := range sessionLog.RecentEvents(sid, 512) {
 			raw, err := json.Marshal(ev)
 			if err != nil {
 				continue

--- a/internal/runtime/routes/handler/multilog.go
+++ b/internal/runtime/routes/handler/multilog.go
@@ -58,7 +58,7 @@ func StreamMultiLog() gin.HandlerFunc {
 				fmt.Fprintf(c.Writer, "data: %s\n\n", raw)
 			}
 
-			for _, ev := range sessionLog.RecentEvents(sid, 100) {
+			for _, ev := range sessionLog.RecentEvents(sid, 512) {
 				te := taggedEvent{Session: sid, Event: ev}
 				if raw, err := json.Marshal(te); err == nil {
 					fmt.Fprintf(c.Writer, "data: %s\n\n", raw)

--- a/internal/runtime/routes/handler/send.go
+++ b/internal/runtime/routes/handler/send.go
@@ -34,6 +34,7 @@ type Request struct {
 	ExcludeTools []string `json:"exclude_tools,omitempty"`
 	Persist      bool     `json:"persist,omitempty"`
 	SystemPrompt string   `json:"system_prompt,omitempty"`
+	AllowAll     *bool    `json:"allow_all,omitempty"`
 }
 
 func Send() gin.HandlerFunc {
@@ -55,6 +56,11 @@ func Send() gin.HandlerFunc {
 				prefix = "http-"
 			}
 			sessionID = prefix + utils.UUID()
+		}
+
+		allowAll := true
+		if req.AllowAll != nil {
+			allowAll = *req.AllowAll
 		}
 
 		events := make(chan agentTypes.Event, 64)
@@ -131,7 +137,7 @@ func Send() gin.HandlerFunc {
 				ExcludeTools:      append(append([]string{}, tools.TUIOnlyTools...), req.ExcludeTools...),
 				ExcludeSkills:     tools.TUIOnlySkills,
 				ExtraSystemPrompt: req.SystemPrompt,
-				AllowAll:          true,
+				AllowAll:          allowAll,
 			}
 
 			if err := configBot.Save(sessionID, "", "", false); err != nil {
@@ -153,7 +159,7 @@ func Send() gin.HandlerFunc {
 				return
 			}
 
-			if err := exec.Execute(execCtx, data, session, wrapped, true); err != nil {
+			if err := exec.Execute(execCtx, data, session, wrapped, allowAll); err != nil {
 				wrapped <- agentTypes.Event{Type: agentTypes.EventError, Err: err}
 				return
 			}


### PR DESCRIPTION
hot fix: 
- Expand session-log replay context and make automatic tool execution configurable
- Exclude oss-gpt-120 from GPT threshold branch, set to 128k × 0.8