### PR TITLE
Synchronize updates to dynamic tool registry

### DIFF
--- a/internal/tools/searcher/searchTools.go
+++ b/internal/tools/searcher/searchTools.go
@@ -63,6 +63,7 @@ Prefer unmarked tools (mcp__* > script_* > api_*) over [system-default] for same
 				toolDic[tool.Function.Name] = tool
 			}
 
+			e.ToolsMu.Lock()
 			for _, match := range matches {
 				if e.ExcludeTools[match.Name] {
 					continue
@@ -79,6 +80,7 @@ Prefer unmarked tools (mcp__* > script_* > api_*) over [system-default] for same
 				e.Tools = append(e.Tools, full)
 				delete(e.StubTools, match.Name)
 			}
+			e.ToolsMu.Unlock()
 
 			raw, err := json.Marshal(ToolMatch{
 				Injected:   matches,

--- a/internal/tools/types/executor.go
+++ b/internal/tools/types/executor.go
@@ -3,6 +3,7 @@ package toolTypes
 import (
 	"context"
 	"encoding/json"
+	"sync"
 
 	"github.com/pardnchiu/agenvoy/internal/runtime"
 	apiAdapter "github.com/pardnchiu/agenvoy/internal/toolAdapter/api"
@@ -15,6 +16,7 @@ type ScriptToolExecutor interface {
 }
 
 type Executor struct {
+	ToolsMu          sync.Mutex
 	WorkDir          string
 	SessionID        string
 	Allowed          []string // * limit to these folders to use


### PR DESCRIPTION
Synchronizes dynamic tool registry mutations to prevent concurrent discovery requests from corrupting shared executor state.
