### PR TITLE
Enhance patch_file for multi-target edits and session history

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,19 @@ curl -fsSL https://agenvoy.com/scripts/install.sh | bash
 
 ***
 
+## Developer Recommendations
+
+A cost-effective model setup to get started:
+
+- Apply for a free **[NVIDIA NIM](https://build.nvidia.com/explore/discover)** API token, then use it for:
+  - `gpt-oss-20b` as the **dispatcher** model
+  - `gpt-oss-120b` as the **fallback** and **summary** model
+- Use a subscription plan as your **primary** model:
+  - OpenAI ChatGPT Plus ($20/mo)
+  - SuperGrok ($30/mo)
+
+***
+
 ## How it compares
 
 | | **Agenvoy** | OpenClaw | Hermes-agent |

--- a/configs/prompts/skill_execution.md
+++ b/configs/prompts/skill_execution.md
@@ -23,7 +23,7 @@ Skill instructions may reference tool names from other environments. Always map 
 | AskUserQuestion / ask the user / prompt user / 詢問使用者 / 請使用者選擇 | `ask_user` | `{"questions": [{"question": "<prompt>", "options": ["<A>","<B>"], "multi_select": false}]}` — omit `options` for free-text; set `multi_select: true` for multi-choice |
 | Read file / open file / 讀取檔案 / 打開檔案 | `read_file` | `{"path": "<absolute path preferred>"}` |
 | Write file / create file / 寫入檔案 / 建立檔案 | `write_file` | `{"path": "<absolute path preferred>", "content": "<full file content>"}` |
-| Edit file / modify file / patch / 修改檔案 / 編輯檔案 | `patch_file` | `{"path": "<absolute path preferred>", "old_string": "<exact text>", "new_string": "<replacement>"}` |
+| Edit file / modify file / patch / 修改檔案 / 編輯檔案 | `patch_file` | `{"path": "<absolute path preferred>", "targets": [{"old_string": "<exact text>", "new_string": "<replacement>"}]}` |
 | Edit skill file / patch skill / 修改 skill 檔案 | `patch_skill` | `{"path": "<relative path under skills dir, e.g. my-skill/SKILL.md>", "old_string": "<exact text>", "new_string": "<replacement>"}` |
 | List files / 列出檔案 | `list_files` | `{"path": "<absolute directory path preferred>"}` |
 | Find files / glob / 搜尋檔案 | `glob_files` | `{"pattern": "<glob pattern>"}` |

--- a/doc/README.zh.md
+++ b/doc/README.zh.md
@@ -207,6 +207,19 @@ curl -fsSL https://agenvoy.com/scripts/install.sh | bash
 
 ***
 
+## 開發者建議
+
+一組省錢好上手的模型配置：
+
+- 申請免費的 **[NVIDIA NIM](https://build.nvidia.com/explore/discover)** API token，用於：
+  - `gpt-oss-20b` 作為 **dispatcher** 模型
+  - `gpt-oss-120b` 作為 **fallback** 與 **summary** 模型
+- 用訂閱制當作 **主力** 模型：
+  - OpenAI ChatGPT Plus（$20/月）
+  - SuperGrok（$30/月）
+
+***
+
 ## 與其他工具相比
 
 | | **Agenvoy** | OpenClaw | Hermes-agent |

--- a/internal/agents/exec/toolCall.go
+++ b/internal/agents/exec/toolCall.go
@@ -140,6 +140,19 @@ func truncateWriteArgs(argsJSON string) string {
 			m[field] = omitted
 		}
 	}
+	if targets, ok := m["targets"].([]any); ok {
+		for _, t := range targets {
+			tm, ok := t.(map[string]any)
+			if !ok {
+				continue
+			}
+			for _, field := range []string{"old_string", "new_string"} {
+				if _, ok := tm[field]; ok {
+					tm[field] = omitted
+				}
+			}
+		}
+	}
 	out, err := json.Marshal(m)
 	if err != nil {
 		return argsJSON

--- a/internal/runtime/discord/run.go
+++ b/internal/runtime/discord/run.go
@@ -15,7 +15,6 @@ import (
 	"github.com/pardnchiu/agenvoy/internal/agents"
 	"github.com/pardnchiu/agenvoy/internal/agents/exec"
 	"github.com/pardnchiu/agenvoy/internal/agents/external"
-	geminiSummary "github.com/pardnchiu/go-llm-router/core/gemini/summary"
 	agentTypes "github.com/pardnchiu/agenvoy/internal/agents/types"
 	"github.com/pardnchiu/agenvoy/internal/filesystem"
 	"github.com/pardnchiu/agenvoy/internal/filesystem/skill"
@@ -23,9 +22,12 @@ import (
 	"github.com/pardnchiu/agenvoy/internal/runtime/chatbot"
 	"github.com/pardnchiu/agenvoy/internal/session/config"
 	sessionDiscord "github.com/pardnchiu/agenvoy/internal/session/discord"
+	sessionHistory "github.com/pardnchiu/agenvoy/internal/session/history"
 	sessionLog "github.com/pardnchiu/agenvoy/internal/session/log"
 	"github.com/pardnchiu/agenvoy/internal/tools"
 	"github.com/pardnchiu/agenvoy/internal/utils"
+	"github.com/pardnchiu/go-llm-router/core"
+	geminiSummary "github.com/pardnchiu/go-llm-router/core/gemini/summary"
 )
 
 func channelName(in go_bot_discord.Input) string {
@@ -33,6 +35,33 @@ func channelName(in go_bot_discord.Input) string {
 		return in.ChannelName
 	}
 	return in.Username
+}
+
+func recordChatter(in go_bot_discord.Input, content string) {
+	content = strings.TrimSpace(content)
+	if content == "" {
+		return
+	}
+
+	sessionID, err := sessionDiscord.New(in.GuildID, in.ChannelID, in.UserID)
+	if err != nil {
+		slog.Warn("sessionDiscord.New (chatter)",
+			slog.String("channel", channelName(in)),
+			slog.String("error", err.Error()))
+		return
+	}
+
+	username := in.Username
+	if username == "" {
+		username = "unknown"
+	}
+	if err := sessionHistory.Append(sessionID, []provider.Message{
+		{Role: "user", Content: fmt.Sprintf("%s: %s", username, content)},
+	}); err != nil {
+		slog.Warn("sessionHistory.Append (chatter)",
+			slog.String("channel", channelName(in)),
+			slog.String("error", err.Error()))
+	}
 }
 
 func run(ctx context.Context, b *Bot, in go_bot_discord.Input) error {
@@ -61,6 +90,7 @@ func run(ctx context.Context, b *Bot, in go_bot_discord.Input) error {
 			}
 		}
 		if !mentioned {
+			recordChatter(in, content)
 			return nil
 		}
 		content = strings.ReplaceAll(content, fmt.Sprintf("<@%s>", botID), "")

--- a/internal/runtime/telegram/run.go
+++ b/internal/runtime/telegram/run.go
@@ -16,7 +16,6 @@ import (
 	"github.com/pardnchiu/agenvoy/internal/agents"
 	"github.com/pardnchiu/agenvoy/internal/agents/exec"
 	"github.com/pardnchiu/agenvoy/internal/agents/external"
-	geminiSummary "github.com/pardnchiu/go-llm-router/core/gemini/summary"
 	agentTypes "github.com/pardnchiu/agenvoy/internal/agents/types"
 	"github.com/pardnchiu/agenvoy/internal/filesystem"
 	"github.com/pardnchiu/agenvoy/internal/filesystem/skill"
@@ -24,11 +23,14 @@ import (
 	"github.com/pardnchiu/agenvoy/internal/runtime/chatbot"
 	"github.com/pardnchiu/agenvoy/internal/session"
 	"github.com/pardnchiu/agenvoy/internal/session/config"
+	sessionHistory "github.com/pardnchiu/agenvoy/internal/session/history"
 	sessionLog "github.com/pardnchiu/agenvoy/internal/session/log"
 	sessionTelegram "github.com/pardnchiu/agenvoy/internal/session/telegram"
 	"github.com/pardnchiu/agenvoy/internal/tools"
 	"github.com/pardnchiu/agenvoy/internal/utils"
 	go_bot_telegram "github.com/pardnchiu/go-bot/telegram"
+	"github.com/pardnchiu/go-llm-router/core"
+	geminiSummary "github.com/pardnchiu/go-llm-router/core/gemini/summary"
 	"github.com/pardnchiu/go-pkg/filesystem/keychain"
 )
 
@@ -58,6 +60,33 @@ func inputHasVoice(in go_bot_telegram.Input) bool {
 	}
 	m := in.Raw.Message
 	return m.Voice != nil || m.Audio != nil || m.Video != nil || m.VideoNote != nil
+}
+
+func recordChatter(in go_bot_telegram.Input, content string) {
+	content = strings.TrimSpace(content)
+	if content == "" {
+		return
+	}
+
+	sessionID, err := sessionTelegram.New(in.ChatID)
+	if err != nil {
+		slog.Warn("sessionTelegram.New (chatter)",
+			slog.Int64("chat", in.ChatID),
+			slog.String("error", err.Error()))
+		return
+	}
+
+	username := in.Username
+	if username == "" {
+		username = "unknown"
+	}
+	if err := sessionHistory.Append(sessionID, []provider.Message{
+		{Role: "user", Content: fmt.Sprintf("%s: %s", username, content)},
+	}); err != nil {
+		slog.Warn("sessionHistory.Append (chatter)",
+			slog.Int64("chat", in.ChatID),
+			slog.String("error", err.Error()))
+	}
 }
 
 func run(ctx context.Context, b *Bot, in go_bot_telegram.Input, attachInputs []go_bot_telegram.Input) error {
@@ -91,6 +120,7 @@ func run(ctx context.Context, b *Bot, in go_bot_telegram.Input, attachInputs []g
 		}
 		target := "@" + botUsername
 		if !strings.Contains(content, target) {
+			recordChatter(in, content)
 			return nil
 		}
 		content = strings.TrimSpace(strings.ReplaceAll(content, target, ""))

--- a/internal/runtime/tui/handlerPopup.go
+++ b/internal/runtime/tui/handlerPopup.go
@@ -386,14 +386,23 @@ func newPopup(id string, req runtime.Request) *Popup {
 		}
 		switch req.ToolName {
 		case "patch_file", "patch_tool", "patch_skill":
-			oldLines, newLines := utils.FormatPatchDiff(req.ToolArgs)
+			hunks := utils.FormatPatchDiff(req.ToolArgs)
 			remaining := 32
-			for _, l := range oldLines[:min(len(oldLines), 16)] {
-				p.diffLines = append(p.diffLines, "- "+l)
-				remaining--
-			}
-			for _, l := range newLines[:min(len(newLines), remaining)] {
-				p.diffLines = append(p.diffLines, "+ "+l)
+			for i, h := range hunks {
+				if remaining <= 0 {
+					break
+				}
+				if i > 0 {
+					p.diffLines = append(p.diffLines, "")
+				}
+				for _, l := range h.OldLines[:min(len(h.OldLines), 16, remaining)] {
+					p.diffLines = append(p.diffLines, "- "+l)
+					remaining--
+				}
+				for _, l := range h.NewLines[:min(len(h.NewLines), remaining)] {
+					p.diffLines = append(p.diffLines, "+ "+l)
+					remaining--
+				}
 			}
 		case "write_file":
 			lines := utils.FormatWriteDiff(req.ToolArgs)

--- a/internal/runtime/tui/view.go
+++ b/internal/runtime/tui/view.go
@@ -142,11 +142,15 @@ func (t TUI) viewPopup() string {
 		body = append(body, textStyle.Render(p.subtitle))
 	}
 	body = append(body, p.styledLines...)
+	diffWidth := max(width-6, 20)
 	for _, dl := range p.diffLines {
-		if strings.HasPrefix(dl, "- ") {
-			body = append(body, diffOldStyle.Render("  "+dl))
-		} else {
-			body = append(body, diffNewStyle.Render("  "+dl))
+		switch {
+		case dl == "":
+			body = append(body, "")
+		case strings.HasPrefix(dl, "- "):
+			body = append(body, diffOldStyle.Render(padToWidth("  "+dl, diffWidth)))
+		default:
+			body = append(body, diffNewStyle.Render(padToWidth("  "+dl, diffWidth)))
 		}
 	}
 	body = append(body, "")

--- a/internal/runtime/tui/viewRender.go
+++ b/internal/runtime/tui/viewRender.go
@@ -303,10 +303,7 @@ func buildTable(header []string, rows [][]string, termWidth int) string {
 var projectVersion = "dev"
 
 var (
-	headerStyle = lipgloss.NewStyle().
-			Border(lipgloss.RoundedBorder()).
-			BorderForeground(colSystem).
-			Padding(0, 2)
+	headerStyle = lipgloss.NewStyle()
 
 	textAreaStyle = lipgloss.NewStyle().
 			Border(lipgloss.NormalBorder(), true, false, true, false).
@@ -453,7 +450,7 @@ func renderAgentEvent(ctx context.Context, ev agentTypes.Event, sessionLabel, cw
 		if ev.Source != "" {
 			bullet = "  ⎿"
 		}
-		return buildToolLine(bullet, ev.Source, ev.ToolName, ev.ToolArgs, cwd), true
+		return buildToolLine(bullet, ev.Source, ev.ToolName, ev.ToolArgs, cwd, width), true
 
 	case agentTypes.EventToolSkipped:
 		line := "  ⎿ " + srcPrefix + "skipped: " + ev.ToolName
@@ -546,11 +543,21 @@ func renderAgentEvent(ctx context.Context, ev agentTypes.Event, sessionLabel, cw
 }
 
 var (
-	diffOldStyle = lipgloss.NewStyle().Foreground(colError)
-	diffNewStyle = lipgloss.NewStyle().Foreground(colOk)
+	diffOldStyle = lipgloss.NewStyle().Background(lipgloss.Color("#400000")).Foreground(lipgloss.Color("#FFFFFF"))
+	diffNewStyle = lipgloss.NewStyle().Background(lipgloss.Color("#002a00")).Foreground(lipgloss.Color("#FFFFFF"))
 )
 
-func buildToolLine(bullet, source, name, args, cwd string) string {
+func padToWidth(s string, width int) string {
+	if w := lipgloss.Width(s); width > w {
+		return s + strings.Repeat(" ", width-w)
+	}
+	return s
+}
+
+func buildToolLine(bullet, source, name, args, cwd string, width int) string {
+	if width <= 0 {
+		width = defaultWrapWidth
+	}
 	src := strings.TrimSpace(source)
 	srcPrefix := ""
 	if src != "" {
@@ -568,21 +575,30 @@ func buildToolLine(bullet, source, name, args, cwd string) string {
 
 	switch name {
 	case "patch_file", "patch_tool", "patch_skill":
-		oldLines, newLines := utils.FormatPatchDiff(args)
-		if len(oldLines) == 0 && len(newLines) == 0 {
+		hunks := utils.FormatPatchDiff(args)
+		if len(hunks) == 0 {
 			return header
 		}
 		var sb strings.Builder
 		sb.WriteString(header)
 		remaining := 32
-		for _, l := range oldLines[:min(len(oldLines), 16)] {
-			sb.WriteByte('\n')
-			sb.WriteString(diffOldStyle.Render("  - " + l))
-			remaining--
-		}
-		for _, l := range newLines[:min(len(newLines), remaining)] {
-			sb.WriteByte('\n')
-			sb.WriteString(diffNewStyle.Render("  + " + l))
+		for i, h := range hunks {
+			if remaining <= 0 {
+				break
+			}
+			if i > 0 {
+				sb.WriteByte('\n')
+			}
+			for _, l := range h.OldLines[:min(len(h.OldLines), 16, remaining)] {
+				sb.WriteByte('\n')
+				sb.WriteString(diffOldStyle.Render(padToWidth("  - "+l, width)))
+				remaining--
+			}
+			for _, l := range h.NewLines[:min(len(h.NewLines), remaining)] {
+				sb.WriteByte('\n')
+				sb.WriteString(diffNewStyle.Render(padToWidth("  + "+l, width)))
+				remaining--
+			}
 		}
 		return sb.String()
 
@@ -595,7 +611,7 @@ func buildToolLine(bullet, source, name, args, cwd string) string {
 		sb.WriteString(header)
 		for _, l := range lines[:min(len(lines), 16)] {
 			sb.WriteByte('\n')
-			sb.WriteString(diffNewStyle.Render("  + " + l))
+			sb.WriteString(diffNewStyle.Render(padToWidth("  + "+l, width)))
 		}
 		return sb.String()
 	}

--- a/internal/tools/file/patchFile.go
+++ b/internal/tools/file/patchFile.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 
 	go_pkg_filesystem "github.com/pardnchiu/go-pkg/filesystem"
@@ -19,9 +20,12 @@ func registPatchFile() {
 	toolRegister.Regist(toolRegister.Def{
 		Name: "patch_file",
 		Description: `
-Replace an exact string match inside a file.
+Replace one or more exact string matches inside a file, or insert new lines at a given line number.
 Use for targeted edits; write_file for full rewrite; patch_skill for skill files.
-Must read_file before patching to get the exact anchor string.`,
+Must read_file before patching to get the exact anchor string or line number.
+Each target is either a replace (old_string/new_string) or a pure insert (insert_string/row) — never both.
+Targets with row are applied from the highest row to the lowest first (so line numbers stay valid against
+the original file even when other targets shift lines), then remaining targets apply top to bottom.`,
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -29,35 +33,58 @@ Must read_file before patching to get the exact anchor string.`,
 					"type":        "string",
 					"description": "File to edit (e.g. '/abs/path/foo.go', '~/notes.md', 'relative/file.md').",
 				},
-				"old_string": map[string]any{
-					"type":        "string",
-					"description": "Exact string to replace, including indentation. Must be unique unless replace_all is true.",
-				},
-				"new_string": map[string]any{
-					"type":        "string",
-					"description": "Replacement string. Empty string deletes old_string.",
-				},
-				"replace_all": map[string]any{
-					"type":        "boolean",
-					"description": "If true, replace all occurrences (e.g. when renaming a variable). Defaults to false.",
-					"default":     false,
+				"targets": map[string]any{
+					"type":        "array",
+					"description": "One or more edits. Each is either {old_string, new_string[, replace_all][, row]} or {insert_string, row}.",
+					"items": map[string]any{
+						"type": "object",
+						"properties": map[string]any{
+							"old_string": map[string]any{
+								"type":        "string",
+								"description": "Exact string to replace, including indentation. Must be unique unless replace_all is true or row is given. Omit when using insert_string.",
+							},
+							"new_string": map[string]any{
+								"type":        "string",
+								"description": "Replacement string. Empty string deletes old_string. Combine with row to delete only the occurrence on that line, leaving other occurrences of old_string untouched. Ignored when insert_string is set.",
+							},
+							"replace_all": map[string]any{
+								"type":        "boolean",
+								"description": "If true, replace all occurrences (e.g. when renaming a variable). Defaults to false.",
+								"default":     false,
+							},
+							"insert_string": map[string]any{
+								"type":        "string",
+								"description": "Text to insert as new, independent line(s) at row — not a replacement of that line, not prepended to it. The existing line at row (and everything after) shifts down. Requires row. Cannot combine with old_string/new_string.",
+							},
+							"row": map[string]any{
+								"type":        "integer",
+								"description": "1-based line number. With old_string: disambiguates which occurrence to edit when old_string is not unique. With insert_string: the line insert_string is inserted before.",
+							},
+						},
+					},
 				},
 			},
 			"required": []string{
 				"path",
-				"old_string",
-				"new_string",
+				"targets",
 			},
 		},
 		Handler: func(ctx context.Context, e *toolTypes.Executor, args json.RawMessage) (string, error) {
 			var params struct {
-				Path       string `json:"path"`
-				OldString  string `json:"old_string"`
-				NewString  string `json:"new_string"`
-				ReplaceAll bool   `json:"replace_all"`
+				Path    string `json:"path"`
+				Targets []struct {
+					OldString    string `json:"old_string"`
+					NewString    string `json:"new_string"`
+					ReplaceAll   bool   `json:"replace_all"`
+					InsertString string `json:"insert_string"`
+					Row          int    `json:"row"`
+				} `json:"targets"`
 			}
 			if err := json.Unmarshal(args, &params); err != nil {
 				return "", fmt.Errorf("json.Unmarshal: %w", err)
+			}
+			if len(params.Targets) == 0 {
+				return "", fmt.Errorf("targets is required")
 			}
 
 			baseDir := e.WorkDir
@@ -71,16 +98,6 @@ Must read_file before patching to get the exact anchor string.`,
 			}
 			if absPath == "" {
 				return "", fmt.Errorf("path or name is required")
-			}
-
-			// * not to trim string, avoid user use " " to indicate indent
-			old := params.OldString
-			new := params.NewString
-			if old == "" {
-				return "", fmt.Errorf("old_string is required")
-			}
-			if old == new {
-				return "", fmt.Errorf("no edit needed")
 			}
 
 			if parent, ok := denied.Hit(e.SessionID, absPath); ok {
@@ -108,22 +125,73 @@ Must read_file before patching to get the exact anchor string.`,
 				return "", fmt.Errorf("go_pkg_filesystem.ReadText: %w", err)
 			}
 
-			if !strings.Contains(fileContent, old) {
-				return "", fmt.Errorf("%s is not found in %s", old, absPath)
+			order := make([]int, len(params.Targets))
+			for i := range order {
+				order[i] = i
+			}
+			sort.SliceStable(order, func(a, b int) bool {
+				ra, rb := params.Targets[order[a]].Row, params.Targets[order[b]].Row
+				if ra > 0 && rb > 0 {
+					return ra > rb
+				}
+				return ra > 0 && rb == 0
+			})
+
+			for _, i := range order {
+				t := params.Targets[i]
+
+				switch {
+				case t.InsertString != "":
+					if t.OldString != "" || t.NewString != "" {
+						return "", fmt.Errorf("targets[%d]: insert_string cannot be combined with old_string/new_string", i)
+					}
+					if t.Row <= 0 {
+						return "", fmt.Errorf("targets[%d]: row is required when insert_string is set", i)
+					}
+					updated, err := insertAtRow(fileContent, t.InsertString, t.Row)
+					if err != nil {
+						return "", fmt.Errorf("targets[%d]: %w", i, err)
+					}
+					fileContent = updated
+
+				case t.OldString != "":
+					// * not to trim string, avoid user use " " to indicate indent
+					old := t.OldString
+					new := t.NewString
+					if old == new {
+						return "", fmt.Errorf("targets[%d]: no edit needed", i)
+					}
+					if !strings.Contains(fileContent, old) {
+						return "", fmt.Errorf("targets[%d]: %s is not found in %s", i, old, absPath)
+					}
+
+					search := old
+					if new == "" && !strings.HasSuffix(old, "\n") && strings.Contains(fileContent, old+"\n") {
+						search = old + "\n"
+					}
+
+					switch {
+					case t.ReplaceAll:
+						fileContent = strings.ReplaceAll(fileContent, search, new)
+					case t.Row > 0:
+						updated, err := replaceAtRow(fileContent, search, new, t.Row)
+						if err != nil {
+							return "", fmt.Errorf("targets[%d]: %w", i, err)
+						}
+						fileContent = updated
+					default:
+						if n := strings.Count(fileContent, search); n > 1 {
+							return "", fmt.Errorf("targets[%d]: %s occurs %d times in %s; set replace_all or specify row to disambiguate", i, old, n, absPath)
+						}
+						fileContent = strings.Replace(fileContent, search, new, 1)
+					}
+
+				default:
+					return "", fmt.Errorf("targets[%d]: either old_string or insert_string is required", i)
+				}
 			}
 
-			search := old
-			if new == "" && !strings.HasSuffix(old, "\n") && strings.Contains(fileContent, old+"\n") {
-				search = old + "\n"
-			}
-			var updated string
-			if params.ReplaceAll {
-				updated = strings.ReplaceAll(fileContent, search, new)
-			} else {
-				updated = strings.Replace(fileContent, search, new, 1)
-			}
-
-			if err := go_pkg_filesystem.WriteFile(absPath, updated, 0644); err != nil {
+			if err := go_pkg_filesystem.WriteFile(absPath, fileContent, 0644); err != nil {
 				if denied.IsPermission(err) {
 					denied.Register(e.SessionID, absPath)
 					return "", fmt.Errorf("permission denied: %s (recorded; further edits under this path will be skipped)", absPath)
@@ -135,4 +203,39 @@ Must read_file before patching to get the exact anchor string.`,
 			return fmt.Sprintf("successfully updated %s", absPath), nil
 		},
 	})
+}
+
+func replaceAtRow(content, search, new string, row int) (string, error) {
+	idx := 0
+	for {
+		i := strings.Index(content[idx:], search)
+		if i < 0 {
+			break
+		}
+		pos := idx + i
+		line := strings.Count(content[:pos], "\n") + 1
+		if line == row {
+			return content[:pos] + new + content[pos+len(search):], nil
+		}
+		idx = pos + 1
+	}
+	return "", fmt.Errorf("no match for %q at row %d", search, row)
+}
+
+func insertAtRow(content, insert string, row int) (string, error) {
+	lines := strings.Split(content, "\n")
+	lineCount := len(lines)
+	if lineCount > 0 && lines[lineCount-1] == "" {
+		lineCount--
+	}
+	if row < 1 || row > lineCount+1 {
+		return "", fmt.Errorf("row %d out of range (file has %d lines)", row, lineCount)
+	}
+
+	idx := row - 1
+	out := make([]string, 0, len(lines)+1)
+	out = append(out, lines[:idx]...)
+	out = append(out, strings.Split(insert, "\n")...)
+	out = append(out, lines[idx:]...)
+	return strings.Join(out, "\n"), nil
 }

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -298,17 +298,39 @@ func FormatToolArgs(name, raw, cwd string) string {
 	return raw
 }
 
-func FormatPatchDiff(raw string) (oldLines, newLines []string) {
+type PatchHunk struct {
+	OldLines []string
+	NewLines []string
+}
+
+func FormatPatchDiff(raw string) []PatchHunk {
+	var multi struct {
+		Targets []struct {
+			Old    string `json:"old_string"`
+			New    string `json:"new_string"`
+			Insert string `json:"insert_string"`
+		} `json:"targets"`
+	}
+	if json.Unmarshal([]byte(raw), &multi) == nil && len(multi.Targets) > 0 {
+		hunks := make([]PatchHunk, 0, len(multi.Targets))
+		for _, t := range multi.Targets {
+			if t.Insert != "" {
+				hunks = append(hunks, PatchHunk{NewLines: splitLines(t.Insert)})
+				continue
+			}
+			hunks = append(hunks, PatchHunk{OldLines: splitLines(t.Old), NewLines: splitLines(t.New)})
+		}
+		return hunks
+	}
+
 	var p struct {
 		Old string `json:"old_string"`
 		New string `json:"new_string"`
 	}
 	if json.Unmarshal([]byte(raw), &p) != nil {
-		return nil, nil
+		return nil
 	}
-	oldLines = splitLines(p.Old)
-	newLines = splitLines(p.New)
-	return
+	return []PatchHunk{{OldLines: splitLines(p.Old), NewLines: splitLines(p.New)}}
 }
 
 func FormatWriteDiff(raw string) []string {


### PR DESCRIPTION
Expands file patching into multi-target edits with line-level inserts and clearer TUI previews. Group chats now retain unmentioned messages so later turns keep ambient context.
