### PR TITLE
Refactor textarea input initialization for TUI popups

### DIFF
--- a/internal/runtime/tui/commandAllowCmd.go
+++ b/internal/runtime/tui/commandAllowCmd.go
@@ -26,6 +26,7 @@ func (t TUI) commandAllowCmd(parts []string) (TUI, tea.Cmd, bool) {
 	t.popup = &Popup{
 		kind:  popupText,
 		title: "Command to allow (appended to config.json white_list)",
+		input: newPopupInput("", false),
 		onConfirm: func(value string) any {
 			return AllowCmdSubmit{name: strings.TrimSpace(value)}
 		},

--- a/internal/runtime/tui/commandCronAdd.go
+++ b/internal/runtime/tui/commandCronAdd.go
@@ -15,6 +15,7 @@ func (t TUI) commandCronAdd() (TUI, tea.Cmd, bool) {
 		kind:      popupText,
 		title:     "Cron add — describe schedule (when + what)",
 		multiline: true,
+		input:     newPopupInput("", true),
 		onConfirm: func(value string) any {
 			return CronAddSubmit{requirement: strings.TrimSpace(value)}
 		},

--- a/internal/runtime/tui/commandCronEdit.go
+++ b/internal/runtime/tui/commandCronEdit.go
@@ -59,6 +59,7 @@ func (t TUI) openCronEditRequirement(skill, expression string) (TUI, tea.Cmd) {
 		kind:      popupText,
 		title:     fmt.Sprintf("Cron edit %s (current: %s) — describe change", skill, expression),
 		multiline: true,
+		input:     newPopupInput("", true),
 		onConfirm: func(value string) any {
 			return CronEditSubmit{
 				skill:       skill,

--- a/internal/runtime/tui/commandDiscord.go
+++ b/internal/runtime/tui/commandDiscord.go
@@ -62,6 +62,7 @@ func (t TUI) openDiscordTokenPrompt() (TUI, tea.Cmd) {
 	t.popup = &Popup{
 		kind:     popupText,
 		title:    "Discord Bot Token",
+		input:    newPopupInput("", false),
 		subtitle: "from Discord Developer Portal · Enter to submit · Esc to cancel",
 		onConfirm: func(value string) any {
 			return DiscordTokenSubmit{token: strings.TrimSpace(value)}

--- a/internal/runtime/tui/commandKey.go
+++ b/internal/runtime/tui/commandKey.go
@@ -52,6 +52,7 @@ func (t TUI) openKeyValuePrompt(key string) (TUI, tea.Cmd) {
 	t.popup = &Popup{
 		kind:     popupText,
 		title:    fmt.Sprintf("Key · %s", key),
+		input:    newPopupInput("", false),
 		subtitle: "Enter new value · Enter to submit · Esc to cancel",
 		onConfirm: func(value string) any {
 			return KeySubmit{key: key, value: strings.TrimSpace(value)}

--- a/internal/runtime/tui/commandKuradb.go
+++ b/internal/runtime/tui/commandKuradb.go
@@ -86,6 +86,7 @@ func (t TUI) openKuradbKeyPrompt() (TUI, tea.Cmd) {
 	t.popup = &Popup{
 		kind:     popupText,
 		title:    "KuraDB · OPENAI_API_KEY",
+		input:    newPopupInput("", false),
 		subtitle: "required for embedding (text-embedding-3-small) · Enter to submit · Esc to cancel",
 		onConfirm: func(value string) any {
 			return KuradbKeySubmit{token: strings.TrimSpace(value)}

--- a/internal/runtime/tui/commandMcpAdd.go
+++ b/internal/runtime/tui/commandMcpAdd.go
@@ -93,6 +93,7 @@ func (t TUI) commandMcpAdd() (TUI, tea.Cmd, bool) {
 		kind:     popupText,
 		title:    "MCP server name",
 		subtitle: "only [A-Za-z0-9_-]",
+		input:    newPopupInput("", false),
 		onConfirm: func(value string) any {
 			return McpAddName{name: strings.TrimSpace(value)}
 		},
@@ -117,6 +118,7 @@ func (t TUI) openMcpAddCommand() (TUI, tea.Cmd) {
 	t.popup = &Popup{
 		kind:  popupText,
 		title: "Command (executable path or name)",
+		input: newPopupInput("", false),
 		onConfirm: func(value string) any {
 			return McpAddCommand{command: strings.TrimSpace(value)}
 		},
@@ -129,6 +131,7 @@ func (t TUI) openMcpAddArgs() (TUI, tea.Cmd) {
 		kind:     popupText,
 		title:    "Args (comma-separated, blank to skip)",
 		subtitle: "example: --port,8080,--config,./cfg.json",
+		input:    newPopupInput("", false),
 		onConfirm: func(value string) any {
 			return McpAddArgs{raw: value}
 		},
@@ -142,6 +145,7 @@ func (t TUI) openMcpAddEnv() (TUI, tea.Cmd) {
 		multiline: true,
 		title:     "Env (KEY=VALUE per line · ctrl+s submit · blank to skip)",
 		subtitle:  "example:\nAPI_KEY=${MY_KEY}\nREGION=us-west-1",
+		input:     newPopupInput("", true),
 		onConfirm: func(value string) any {
 			return McpAddEnv{raw: value}
 		},
@@ -153,6 +157,7 @@ func (t TUI) openMcpAddURL() (TUI, tea.Cmd) {
 	t.popup = &Popup{
 		kind:  popupText,
 		title: "URL",
+		input: newPopupInput("", false),
 		onConfirm: func(value string) any {
 			return McpAddURL{url: strings.TrimSpace(value)}
 		},
@@ -179,6 +184,7 @@ func (t TUI) openMcpAddHeaders() (TUI, tea.Cmd) {
 		multiline: true,
 		title:     "Extra headers (KEY=VALUE per line · ctrl+s submit · blank to skip)",
 		subtitle:  "example:\nX-Trace=1\nX-Client=agenvoy",
+		input:     newPopupInput("", true),
 		onConfirm: func(value string) any {
 			return McpAddHeaders{raw: value}
 		},
@@ -209,6 +215,7 @@ func (t TUI) openMcpAddBearerToken() (TUI, tea.Cmd) {
 		kind:     popupText,
 		title:    "Bearer token",
 		subtitle: "raw token or ${TOKEN}; Bearer is added automatically",
+		input:    newPopupInput("", false),
 		onConfirm: func(value string) any {
 			return McpAddBearerToken{token: strings.TrimSpace(value)}
 		},
@@ -221,6 +228,7 @@ func (t TUI) openMcpAddAPIKeyHeader() (TUI, tea.Cmd) {
 		kind:     popupText,
 		title:    "API key header name",
 		subtitle: "blank uses X-API-Key",
+		input:    newPopupInput("", false),
 		onConfirm: func(value string) any {
 			return McpAddAPIKeyHeader{header: strings.TrimSpace(value)}
 		},
@@ -233,6 +241,7 @@ func (t TUI) openMcpAddAPIKeyValue(header string) (TUI, tea.Cmd) {
 		kind:     popupText,
 		title:    fmt.Sprintf("%s value", header),
 		subtitle: "raw key or ${TOKEN}",
+		input:    newPopupInput("", false),
 		onConfirm: func(value string) any {
 			return McpAddAPIKeyValue{value: strings.TrimSpace(value)}
 		},
@@ -245,6 +254,7 @@ func (t TUI) openMcpAddBasicToken() (TUI, tea.Cmd) {
 		kind:     popupText,
 		title:    "Basic auth token",
 		subtitle: "base64 user:pass or ${BASIC_TOKEN}; Basic is added automatically",
+		input:    newPopupInput("", false),
 		onConfirm: func(value string) any {
 			return McpAddBasicToken{token: strings.TrimSpace(value)}
 		},

--- a/internal/runtime/tui/commandModelAdd.go
+++ b/internal/runtime/tui/commandModelAdd.go
@@ -304,6 +304,7 @@ func (t TUI) openModelAddAPIKey() (TUI, tea.Cmd) {
 	t.popup = &Popup{
 		kind:  popupSecret,
 		title: fmt.Sprintf("%s API key", label),
+		input: newPopupInput("", false),
 		onConfirm: func(value string) any {
 			return ModelAddAPIKeySubmit{key: value}
 		},
@@ -320,6 +321,7 @@ func (t TUI) runModelAddAPIKeyReplace(replace string) (TUI, tea.Cmd) {
 		t.popup = &Popup{
 			kind:  popupSecret,
 			title: fmt.Sprintf("%s API key (new)", label),
+			input: newPopupInput("", false),
 			onConfirm: func(value string) any {
 				return ModelAddAPIKeySubmit{key: value}
 			},
@@ -375,6 +377,7 @@ func (t TUI) openModelAddAccountID() (TUI, tea.Cmd) {
 	t.popup = &Popup{
 		kind:  popupText,
 		title: "Cloudflare account ID",
+		input: newPopupInput("", false),
 		onConfirm: func(value string) any {
 			return ModelAddAccountIDSubmit{id: strings.TrimSpace(value)}
 		},
@@ -390,6 +393,7 @@ func (t TUI) runModelAddAccountIDReplace(replace string) (TUI, tea.Cmd) {
 		t.popup = &Popup{
 			kind:  popupText,
 			title: "Cloudflare account ID (new)",
+			input: newPopupInput("", false),
 			onConfirm: func(value string) any {
 				return ModelAddAccountIDSubmit{id: strings.TrimSpace(value)}
 			},
@@ -435,6 +439,7 @@ func (t TUI) runModelAddGatewayIDPick(chosen string) (TUI, tea.Cmd) {
 		t.popup = &Popup{
 			kind:  popupText,
 			title: "Cloudflare AI Gateway ID",
+			input: newPopupInput("", false),
 			onConfirm: func(value string) any {
 				return ModelAddGatewayIDSubmit{id: strings.TrimSpace(value)}
 			},
@@ -467,6 +472,7 @@ func (t TUI) openModelAddCompatName() (TUI, tea.Cmd) {
 	t.popup = &Popup{
 		kind:  popupText,
 		title: "Compat provider name (ex. ollama)",
+		input: newPopupInput("", false),
 		onConfirm: func(value string) any {
 			return ModelAddCompatNameSubmit{name: strings.TrimSpace(value)}
 		},
@@ -491,6 +497,7 @@ func (t TUI) openModelAddCompatURL() (TUI, tea.Cmd) {
 		kind:     popupText,
 		title:    "URL (blank = scan local)",
 		subtitle: "enter up to /v1 — e.g. http://localhost:11434/v1",
+		input:    newPopupInput("", false),
 		onConfirm: func(value string) any {
 			return ModelAddCompatURLSubmit{url: strings.TrimSpace(value)}
 		},
@@ -518,6 +525,7 @@ func (t TUI) openModelAddCompatKey() (TUI, tea.Cmd) {
 	t.popup = &Popup{
 		kind:  popupSecret,
 		title: "API key (blank to skip)",
+		input: newPopupInput("", false),
 		onConfirm: func(value string) any {
 			return ModelAddCompatKeySubmit{key: strings.TrimSpace(value)}
 		},
@@ -598,6 +606,7 @@ func (t TUI) openModelAddModelPick() (TUI, tea.Cmd) {
 	t.popup = &Popup{
 		kind:  popupText,
 		title: fmt.Sprintf("Model name (prefix: %s)", prefix),
+		input: newPopupInput("", false),
 		onConfirm: func(value string) any {
 			name := strings.TrimSpace(value)
 			if name == "" {

--- a/internal/runtime/tui/commandTaskAdd.go
+++ b/internal/runtime/tui/commandTaskAdd.go
@@ -15,6 +15,7 @@ func (t TUI) commandTaskAdd() (TUI, tea.Cmd, bool) {
 		kind:      popupText,
 		title:     "Task add — describe one-shot task (when + what)",
 		multiline: true,
+		input:     newPopupInput("", true),
 		onConfirm: func(value string) any {
 			return TaskAddSubmit{requirement: strings.TrimSpace(value)}
 		},

--- a/internal/runtime/tui/commandTaskEdit.go
+++ b/internal/runtime/tui/commandTaskEdit.go
@@ -60,6 +60,7 @@ func (t TUI) openTaskEditRequirement(skill string, at time.Time) (TUI, tea.Cmd) 
 		kind:      popupText,
 		title:     fmt.Sprintf("Task edit %s (current: %s) — describe change", skill, at.Local().Format("2006-01-02 15:04")),
 		multiline: true,
+		input:     newPopupInput("", true),
 		onConfirm: func(value string) any {
 			return TaskEditSubmit{
 				skill:       skill,

--- a/internal/runtime/tui/commandTelegram.go
+++ b/internal/runtime/tui/commandTelegram.go
@@ -62,6 +62,7 @@ func (t TUI) openTelegramTokenPrompt() (TUI, tea.Cmd) {
 	t.popup = &Popup{
 		kind:     popupText,
 		title:    "Telegram Bot Token",
+		input:    newPopupInput("", false),
 		subtitle: "from @BotFather · Enter to submit · Esc to cancel",
 		onConfirm: func(value string) any {
 			return TelegramTokenSubmit{token: strings.TrimSpace(value)}

--- a/internal/runtime/tui/commandVoice.go
+++ b/internal/runtime/tui/commandVoice.go
@@ -66,6 +66,7 @@ func (t TUI) openVoiceKeyPrompt() (TUI, tea.Cmd) {
 	t.popup = &Popup{
 		kind:     popupText,
 		title:    "Voice · GEMINI_API_KEY",
+		input:    newPopupInput("", false),
 		subtitle: "required for voice transcription / voice reply · Enter to submit · Esc to cancel",
 		onConfirm: func(value string) any {
 			return VoiceKeySubmit{token: strings.TrimSpace(value)}


### PR DESCRIPTION
Hotfix finishes the TUI popup migration so every text and secret prompt boots with textarea input instead of the retired custom field.
