### PR TITLE
Implement per-task cancellation and document task lifecycle

### DIFF
--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -48,7 +48,7 @@ graph TB
 
 ## Module: Daemon and HTTP API
 
-The daemon initializes the filesystem, runtime limits, ToriiDB/history storage, registered tools, agents, schedulers, chatbots, and Gin routes. The HTTP API binds locally and exposes agent execution, OpenAI-compatible chat completions, direct tool calls, sessions, models, logs, and pending-task recovery.
+The daemon initializes the filesystem, runtime limits, ToriiDB/history storage, registered tools, agents, schedulers, chatbots, and Gin routes. The HTTP API binds to `127.0.0.1` and covers two tiers: an agent-execution surface (send, chat completions, tool calls, sessions, models, SSE logs, pending-task recovery) reachable without extra checks, and a much larger config/management surface — credentials, providers, MCP servers, cron/task automation, KuraDB lifecycle, command/skill allowlists, and read-only session-artifact/error-memory inspection — gated behind an additional `localhostOnly()` middleware since it touches credentials, config files, or process state. A separate web dashboard (hosted independently, not part of this repo) is the intended client for the config tier.
 
 ```mermaid
 graph TB
@@ -58,10 +58,14 @@ graph TB
         ToolInit --> AgentInit[Agent Registry & Skill Scanner]
         AgentInit --> Services[Scheduler & Integrations]
         Services --> Routes[Gin Routes]
-        Routes --> HTTP[127.0.0.1 HTTP API]
         Config[config.json Watcher] --> Reload[Reload agents / integrations]
         Reload --> AgentInit
     end
+    Routes --> ExecAPI[Agent-execution API<br/>send · chat/completions · tools · sessions · models · SSE logs]
+    Routes --> ConfigAPI[Config / management API<br/>keys · providers · MCP · cron/task · kuradb · allowlists · torii inspection]
+    ConfigAPI --> LocalGuard[localhostOnly guard]
+    ExecAPI --> Client[CLI / TUI / remote agents]
+    LocalGuard --> Dashboard[Web dashboard, separate repo]
 ```
 
 ## Module: Agent Execution and Routing
@@ -129,6 +133,29 @@ graph TB
     end
 ```
 
+## Module: Task Lifecycle, Concurrency, and Cancellation
+
+Every execution registers itself in `status.json` — and registers its cancel function — *before* competing for a per-session concurrency slot, so a task queued behind the limit stays observable and cancellable instead of blocking invisibly. Each task records the PID of the process running it; any reader that finds a task whose PID is no longer alive treats it as stale and clears it, so a killed or crashed process cannot leave a session permanently marked online.
+
+Concurrency is per session (`limits.max_session_tasks`, defaulting to twice the CPU count). Sessions never block or cancel one another, and exceeding the limit queues a task rather than rejecting it.
+
+```mermaid
+graph TB
+    subgraph Lifecycle[Task Lifecycle]
+        Start[Execute] --> Register[Register task and PID in status.json]
+        Register --> CancelReg[Register cancel func under task ID]
+        CancelReg --> Gate{Concurrency slot free}
+        Gate -->|Yes| Run[Run agent loop]
+        Gate -->|No| Queue[Queued: visible and cancellable]
+        Queue --> Run
+        Run --> Terminal[Completed / Failed / Canceled]
+        Terminal --> Clear[Remove task from status.json]
+    end
+    CancelAPI[POST /v1/session/:id/cancel/:task_id] --> Registry[Task ID to cancel func registry]
+    Registry --> Run
+    StaleCheck[Reader finds dead PID] --> Clear
+```
+
 ## Module: Chat and MCP Integrations
 
 Telegram and Discord use a shared event pipeline with channel-specific authorization, attachment handling, pending confirmations, formatting, and push delivery. External MCP servers are consumed through stdio or streamable HTTP; Agenvoy can also expose local tools as a stdin JSON-RPC MCP server.
@@ -188,6 +215,8 @@ stateDiagram-v2
     [*] --> Initialized
     Initialized --> Ready: Tools and agents loaded
     Ready --> Selecting: Request received
+    Selecting --> Queued: No concurrency slot
+    Queued --> Running: Slot released
     Selecting --> Running: Agent resolved
     Running --> WaitingConfirmation: Tool confirmation
     WaitingConfirmation --> Running: Approved or skipped
@@ -198,8 +227,11 @@ stateDiagram-v2
     Running --> Fallback: Send failure
     Fallback --> Running: Fallback selected
     Running --> Completed: Final response
+    Running --> Canceled: Cancel requested
+    Queued --> Canceled: Cancel requested
     Running --> Failed: Unrecoverable error
     Completed --> Ready
+    Canceled --> Ready
     Failed --> Ready
     Ready --> [*]: Shutdown
 ```
@@ -221,6 +253,7 @@ flowchart LR
     Sessions --> History[history.json]
     Sessions --> Summary[summary.json]
     Sessions --> Pending[pending metadata]
+    Sessions --> Status[status.json: active tasks and owning PID]
     SQLite[~/.config/agenvoy/.store/history.db] --> Search[History search]
     MCP[~/.config/agenvoy/mcp.json] --> MCPClients[MCP clients]
     Tools[~/.config/agenvoy/tools] --> Registry[Tool registry]

--- a/doc/architecture.zh.md
+++ b/doc/architecture.zh.md
@@ -48,7 +48,7 @@ graph TB
 
 ## 模組：Daemon 與 HTTP API
 
-Daemon 初始化檔案系統、runtime limits、ToriiDB／history 儲存、已註冊工具、Agent、排程器、聊天整合與 Gin routes。HTTP API 僅綁定本機，提供 Agent 執行、OpenAI-compatible chat completions、直接工具呼叫、session、模型、log 與 pending task 恢復能力。
+Daemon 初始化檔案系統、runtime limits、ToriiDB／history 儲存、已註冊工具、Agent、排程器、聊天整合與 Gin routes。HTTP API 僅綁定 `127.0.0.1`，分兩層：不需額外檢查即可用的 Agent 執行層（send、chat completions、工具呼叫、session、模型、SSE log、pending task 恢復），以及規模大得多的設定／管理層——憑證、provider、MCP server、cron/task 自動化、KuraDB 生命週期、指令／skill 白名單、以及唯讀的 session artifact／error memory 查閱——這層額外掛上 `localhostOnly()` middleware，因為會動到憑證、設定檔或行程狀態。設定層的預期用戶端是一個獨立托管的 web dashboard（不在本 repo 內）。
 
 ```mermaid
 graph TB
@@ -58,10 +58,14 @@ graph TB
         ToolInit --> AgentInit[Agent 註冊表與 Skill Scanner]
         AgentInit --> Services[Scheduler 與整合服務]
         Services --> Routes[Gin Routes]
-        Routes --> HTTP[127.0.0.1 HTTP API]
         Config[config.json Watcher] --> Reload[重新載入 Agent／整合]
         Reload --> AgentInit
     end
+    Routes --> ExecAPI[Agent 執行層 API<br/>send · chat/completions · 工具 · session · 模型 · SSE log]
+    Routes --> ConfigAPI[設定／管理層 API<br/>憑證 · provider · MCP · cron/task · kuradb · 白名單 · torii 查閱]
+    ConfigAPI --> LocalGuard[localhostOnly 守衛]
+    ExecAPI --> Client[CLI／TUI／遠端 Agent]
+    LocalGuard --> Dashboard[Web dashboard（獨立 repo）]
 ```
 
 ## 模組：Agent 執行與路由
@@ -129,6 +133,29 @@ graph TB
     end
 ```
 
+## 模組：任務生命週期、併發與取消
+
+每次執行都會**先**把任務登記進 `status.json`、並登記自己的取消函式，**才**去競爭該 session 的併發名額，因此被上限擋住而排隊中的任務依然看得到、也取消得掉，不會無聲卡住。每筆任務都記錄執行它的行程 PID；任何讀取端只要發現某筆任務的 PID 已不存在，就視為 stale 並清除——被砍掉或崩潰的行程因此無法讓 session 永久停留在 online 狀態。
+
+併發上限是 per session（`limits.max_session_tasks`，預設為 CPU 數量的兩倍）。不同 session 之間不會互相阻塞或取消，超過上限的任務是排隊等待，而不是被拒絕。
+
+```mermaid
+graph TB
+    subgraph Lifecycle[任務生命週期]
+        Start[Execute] --> Register[於 status.json 登記任務與 PID]
+        Register --> CancelReg[以任務 ID 登記取消函式]
+        CancelReg --> Gate{併發名額是否可用}
+        Gate -->|是| Run[執行 Agent 迴圈]
+        Gate -->|否| Queue[排隊中：可觀察、可取消]
+        Queue --> Run
+        Run --> Terminal[完成／失敗／已取消]
+        Terminal --> Clear[從 status.json 移除任務]
+    end
+    CancelAPI[POST /v1/session/:id/cancel/:task_id] --> Registry[任務 ID 對應取消函式的登記表]
+    Registry --> Run
+    StaleCheck[讀取端發現 PID 已死] --> Clear
+```
+
 ## 模組：聊天與 MCP 整合
 
 Telegram 與 Discord 採用共用 event pipeline，但保有頻道專屬的授權、附件處理、pending confirmation、格式化與 push delivery。外部 MCP server 可經由 stdio 或 streamable HTTP 使用；Agenvoy 也能以 stdin JSON-RPC MCP server 形式暴露本機工具。
@@ -188,6 +215,8 @@ stateDiagram-v2
     [*] --> Initialized
     Initialized --> Ready: 工具與 Agent 已載入
     Ready --> Selecting: 收到請求
+    Selecting --> Queued: 無可用併發名額
+    Queued --> Running: 名額釋出
     Selecting --> Running: Agent 已解析
     Running --> WaitingConfirmation: 工具確認
     WaitingConfirmation --> Running: 已核准或略過
@@ -198,8 +227,11 @@ stateDiagram-v2
     Running --> Fallback: 傳送失敗
     Fallback --> Running: 已選擇 Fallback
     Running --> Completed: 最終回應
+    Running --> Canceled: 收到取消請求
+    Queued --> Canceled: 收到取消請求
     Running --> Failed: 無法復原的錯誤
     Completed --> Ready
+    Canceled --> Ready
     Failed --> Ready
     Ready --> [*]: 關閉
 ```
@@ -221,6 +253,7 @@ flowchart LR
     Sessions --> History[history.json]
     Sessions --> Summary[summary.json]
     Sessions --> Pending[Pending Metadata]
+    Sessions --> Status[status.json：執行中任務與所屬 PID]
     SQLite[~/.config/agenvoy/.store/history.db] --> Search[History Search]
     MCP[~/.config/agenvoy/mcp.json] --> MCPClients[MCP Clients]
     Tools[~/.config/agenvoy/tools] --> Registry[工具註冊表]

--- a/doc/doc.md
+++ b/doc/doc.md
@@ -47,7 +47,8 @@ Agenvoy stores runtime data in `~/.config/agenvoy/` and keeps credentials in the
 | `limits.agent_send_timeout_seconds` | `600` | Model-request timeout |
 | `limits.max_history_messages` | `8` | Recent history messages retained |
 | `limits.max_history_bytes` | `5242880` | History-size ceiling |
-| `limits.max_session_tasks` | `3` | Concurrent tasks per session |
+| `limits.max_session_tasks` | `NumCPU × 2` | Concurrent tasks per session; further tasks queue rather than fail (hard-capped at `NumCPU × 4`) |
+| `limits.max_subagent_timeout_min` | `10` | Subagent timeout in minutes (hard-capped at `60` regardless of config) |
 
 ### MCP client configuration
 
@@ -128,16 +129,109 @@ printf '%s\n' \
 
 ### HTTP endpoints
 
+The daemon binds to `127.0.0.1` only. Endpoints marked **local** additionally require the request to originate from `127.0.0.1`/`::1` (`localhostOnly()` guard) — they manage credentials, config files, or process lifecycle and are meant for a same-machine dashboard, not remote clients.
+
+**Agent execution**
+
 | Method | Path | Description |
 |---|---|---|
 | `POST` | `/v1/send` | Run an agent request. |
 | `POST` | `/v1/chat/completions` | Stateless OpenAI-compatible chat completion. |
+| `GET` | `/v1/log` | SSE stream of events across all sessions. |
 | `GET` | `/v1/tools` | List current tools. |
-| `POST` | `/v1/tool/:tool_name` | Run a named tool. |
-| `GET` | `/v1/sessions` | List sessions. |
-| `GET` | `/v1/models` | List models. |
-| `GET` | `/v1/session/:session_id/status` | Get session status and usage. |
-| `GET` | `/v1/session/:session_id/pending` | List pending tasks. |
+| `POST` | `/v1/tool/:tool_name` | Run a named tool directly. |
+
+**Models**
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/v1/models` | List registered models. |
+| `POST` `DELETE` | `/v1/models` `/v1/models/*name` | **local** — add / remove a model. |
+| `GET` `POST` | `/v1/model/dispatcher` | **local** — get/set the dispatcher model. |
+| `GET` `POST` | `/v1/model/summary` | **local** — get/set the summary model. |
+
+**Sessions**
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/v1/sessions` | List sessions and status. |
+| `POST` `PUT` `DELETE` | `/v1/session` | **local** — create / rename / delete a session. |
+| `POST` | `/v1/session/:id/model` | Set the model for a session. |
+| `GET` | `/v1/session/:id/status` | Get session status and usage. |
+| `GET` | `/v1/session/:id/log` | SSE stream of events for one session. |
+| `POST` | `/v1/session/:id/event` | **local** — publish an event into a session's stream. |
+| `GET` | `/v1/session/:id/pending` | List pending (`ask_user`/confirm) tasks. |
+| `GET` | `/v1/session/:id/pending/:task_hash/questions` | Get a pending task's questions. |
+| `POST` | `/v1/session/:id/pending/:task_hash/resume` | Answer a pending task and resume. |
+| `DELETE` | `/v1/session/:id/pending/:task_hash` | Discard a pending task without answering it. |
+| `POST` | `/v1/session/:id/cancel/:task_id` | Cancel one running task. `task_id` comes from `/status`; cancelling is per-task by design, there is no cancel-everything variant. |
+| `GET` `POST` | `/v1/session/:id/persona` | **local** — get/set a session's persona. |
+| `POST` | `/v1/session/:id/compact` | **local** — compact history in the background (fire-and-forget, `202 Accepted`). |
+| `GET` | `/v1/session/:id/daemon` | **local** — `daemon.log` lines mentioning this session ID (best-effort grep, not a true per-session log). |
+| `GET` | `/v1/session/:id/action` | **local** — that session's `action.log` content. |
+| `GET` | `/v1/session/:id/usage` | **local** — 24h/7d/28d per-model token usage (same aggregation as the TUI `/usage` screen). |
+| `GET` | `/v1/session/:id/history` | **local** — list archived completed pending-task files. |
+| `GET` | `/v1/session/:id/history/*file` | **local** — read one archived pending-task file. |
+
+**Channels**
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/v1/channel/status` | **local** — Telegram/Discord enabled state, bot username, whether a token is stored. |
+| `POST` | `/v1/channel/telegram` `/v1/channel/discord` | **local** — `{action:"enable"\|"disable", token?}`. Enable stores the token and flips the config flag only; the `GetMe` verification the TUI does is intentionally skipped, since the daemon's existing config-file watcher already reconnects the bot and fills in its username. |
+
+**Files & credentials**
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` `PUT` | `/v1/file` | **local** — read/write a file. |
+| `GET` | `/v1/file/open` | **local** — open a file/URL with the OS default handler. |
+| `GET` `DELETE` | `/v1/key` | **local** — check/delete a single credential in the keychain. |
+| `GET` `POST` | `/v1/keys` | **local** — list/set credentials. |
+
+**Providers**
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/v1/providers` | **local** — list providers and their available operations. |
+| `GET` | `/v1/provider/:provider/check` | **local** — whether a credential exists for this provider. |
+| `POST` | `/v1/provider/:provider/key` | **local** — set an API key. |
+| `GET` | `/v1/provider/:provider/oauth` | **local** — SSE device-code OAuth flow. |
+| `GET` | `/v1/provider/:provider/models` | **local** — list models available to this provider. |
+
+**MCP**
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` `POST` | `/v1/mcp` | **local** — list/add MCP servers. |
+| `POST` | `/v1/mcp/remove` | **local** — remove an MCP server. |
+| `GET` | `/v1/mcp/status` | **local** — connection status per server. |
+| `GET` | `/v1/mcp/health` | **local** — health probe per server. |
+| `POST` | `/v1/mcp/reconnect` | **local** — reconnect all MCP clients and re-register tools. |
+
+**Automation**
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/v1/schedule/*skill` | **local** — read a scheduler skill's contents. |
+| `GET` `DELETE` | `/v1/cron` | **local** — list/delete cron entries. |
+| `POST` | `/v1/cron/run` | **local** — fire a cron entry now (`202 Accepted`). |
+| `GET` `DELETE` | `/v1/task` | **local** — list/delete one-off tasks. |
+| `POST` | `/v1/task/run` | **local** — fire a task now (`202 Accepted`). |
+
+**KuraDB & allowlists**
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` `POST` | `/v1/kuradb` | **local** — status/enable/disable/start/stop/restart KuraDB. Install/uninstall stay TUI-only (need a real terminal for `sudo`/install-script prompts); this API only flips the `enabled` flag and controls an already-installed `kura` process. |
+| `GET` `POST` | `/v1/allowlist/cmd` | **local** — list/append the command allowlist (append-only, restart required to take effect). |
+| `GET` `POST` | `/v1/allowlist/skill` | **local** — list/toggle the skill allowlist (`scope=global\|project`). |
+
+**Inspection**
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/v1/torii/error` | **local** — read the tool-error memory store; unfiltered when `tool`/`keyword` are both omitted. |
 
 ## Architecture
 

--- a/doc/doc.zh.md
+++ b/doc/doc.zh.md
@@ -65,7 +65,8 @@ Agenvoy 使用 `~/.config/agenvoy/` 保存執行期資料，並將憑證存放�
 | `limits.max_tool_iterations` | `128` | 單次 Agent 工作的工具迭代上限 |
 | `limits.agent_send_timeout_seconds` | `600` | 模型請求逾時秒數 |
 | `limits.max_history_messages` | `8` | 保留的近期歷史訊息數 |
-| `limits.max_session_tasks` | `3` | 每個 session 的並行工作數上限 |
+| `limits.max_session_tasks` | `NumCPU × 2` | 每個 session 的並行工作數上限；超出的任務排隊等待而非失敗（硬上限 `NumCPU × 4`） |
+| `limits.max_subagent_timeout_min` | `10` | Subagent 逾時分鐘數（無論設定值為何，硬上限固定 `60`） |
 
 ```json
 {
@@ -166,16 +167,109 @@ curl --fail-with-body -sS \
 
 ## HTTP API 參考
 
+Daemon 只綁定 `127.0.0.1`。標示 **local** 的 endpoint 另外要求請求來源必須是 `127.0.0.1`／`::1`（`localhostOnly()` 守衛）——這些會動到 credential、設定檔或行程生命週期，設計上是給同機器的 dashboard 用，不是給遠端 client 呼叫。
+
+**Agent 執行**
+
 | Method | Path | 說明 |
 |---|---|---|
-| `POST` | `/v1/send` | 執行 Agent，支援 SSE、session、model 與工具排除 |
+| `POST` | `/v1/send` | 執行 Agent |
 | `POST` | `/v1/chat/completions` | OpenAI 相容且 stateless 的 chat completions |
+| `GET` | `/v1/log` | SSE：跨所有 session 的事件串流 |
 | `GET` | `/v1/tools` | 列出工具 |
 | `POST` | `/v1/tool/:tool_name` | 直接呼叫工具 |
+
+**模型**
+
+| Method | Path | 說明 |
+|---|---|---|
+| `GET` | `/v1/models` | 列出已註冊模型 |
+| `POST` `DELETE` | `/v1/models` `/v1/models/*name` | **local** — 新增／移除模型 |
+| `GET` `POST` | `/v1/model/dispatcher` | **local** — 讀取／設定 dispatcher 模型 |
+| `GET` `POST` | `/v1/model/summary` | **local** — 讀取／設定 summary 模型 |
+
+**Session**
+
+| Method | Path | 說明 |
+|---|---|---|
 | `GET` | `/v1/sessions` | 列出 session 與狀態 |
-| `GET` | `/v1/models` | 列出模型 |
-| `GET` | `/v1/session/:session_id/status` | 查詢 session 狀態與用量 |
-| `GET` | `/v1/session/:session_id/pending` | 列出待完成工作 |
+| `POST` `PUT` `DELETE` | `/v1/session` | **local** — 建立／重新命名／刪除 session |
+| `POST` | `/v1/session/:id/model` | 設定該 session 的模型 |
+| `GET` | `/v1/session/:id/status` | 查詢 session 狀態與用量 |
+| `GET` | `/v1/session/:id/log` | SSE：單一 session 的事件串流 |
+| `POST` | `/v1/session/:id/event` | **local** — 對某 session 的事件串流手動發布事件 |
+| `GET` | `/v1/session/:id/pending` | 列出待完成（`ask_user`／confirm）工作 |
+| `GET` | `/v1/session/:id/pending/:task_hash/questions` | 取得待完成工作的問題內容 |
+| `POST` | `/v1/session/:id/pending/:task_hash/resume` | 回答待完成工作並恢復執行 |
+| `DELETE` | `/v1/session/:id/pending/:task_hash` | 直接捨棄待完成工作，不回答 |
+| `POST` | `/v1/session/:id/cancel/:task_id` | 取消單一執行中的任務。`task_id` 由 `/status` 取得；設計上只做逐一取消，沒有一次砍全部的版本 |
+| `GET` `POST` | `/v1/session/:id/persona` | **local** — 讀取／設定 session persona |
+| `POST` | `/v1/session/:id/compact` | **local** — 背景壓縮歷史（fire-and-forget,立即回 `202 Accepted`） |
+| `GET` | `/v1/session/:id/daemon` | **local** — `daemon.log` 中提到該 sessionID 的行（best-effort grep,非真正的 per-session 檔） |
+| `GET` | `/v1/session/:id/action` | **local** — 該 session 的 `action.log` 全文 |
+| `GET` | `/v1/session/:id/usage` | **local** — 24h/7d/28d 各模型 token 用量（與 TUI `/usage` 畫面同一套聚合邏輯） |
+| `GET` | `/v1/session/:id/history` | **local** — 列出已歸檔的完成 pending task 檔案 |
+| `GET` | `/v1/session/:id/history/*file` | **local** — 讀取單一歸檔的 pending task 檔案 |
+
+**Channel**
+
+| Method | Path | 說明 |
+|---|---|---|
+| `GET` | `/v1/channel/status` | **local** — Telegram／Discord 啟用狀態、bot 使用者名稱、是否已存 token |
+| `POST` | `/v1/channel/telegram` `/v1/channel/discord` | **local** — `{action:"enable"\|"disable", token?}`。enable 只存 token 並切換設定 flag,刻意不做 TUI 那套 `GetMe` 驗證——daemon 既有的設定檔監看機制會自動重連 bot 並填回使用者名稱 |
+
+**檔案與憑證**
+
+| Method | Path | 說明 |
+|---|---|---|
+| `GET` `PUT` | `/v1/file` | **local** — 讀取／寫入檔案 |
+| `GET` | `/v1/file/open` | **local** — 以系統預設程式開啟檔案／URL |
+| `GET` `DELETE` | `/v1/key` | **local** — 查詢／刪除 keychain 中單一憑證 |
+| `GET` `POST` | `/v1/keys` | **local** — 列出／設定憑證 |
+
+**Provider**
+
+| Method | Path | 說明 |
+|---|---|---|
+| `GET` | `/v1/providers` | **local** — 列出 provider 及其可用操作 |
+| `GET` | `/v1/provider/:provider/check` | **local** — 該 provider 是否已有憑證 |
+| `POST` | `/v1/provider/:provider/key` | **local** — 設定 API key |
+| `GET` | `/v1/provider/:provider/oauth` | **local** — SSE device-code OAuth 流程 |
+| `GET` | `/v1/provider/:provider/models` | **local** — 列出該 provider 可用模型 |
+
+**MCP**
+
+| Method | Path | 說明 |
+|---|---|---|
+| `GET` `POST` | `/v1/mcp` | **local** — 列出／新增 MCP server |
+| `POST` | `/v1/mcp/remove` | **local** — 移除 MCP server |
+| `GET` | `/v1/mcp/status` | **local** — 各 server 連線狀態 |
+| `GET` | `/v1/mcp/health` | **local** — 各 server health probe |
+| `POST` | `/v1/mcp/reconnect` | **local** — 重連全部 MCP client 並重新註冊工具 |
+
+**排程與自動化**
+
+| Method | Path | 說明 |
+|---|---|---|
+| `GET` | `/v1/schedule/*skill` | **local** — 讀取 scheduler skill 內容 |
+| `GET` `DELETE` | `/v1/cron` | **local** — 列出／刪除 cron 項目 |
+| `POST` | `/v1/cron/run` | **local** — 立即觸發 cron 項目（`202 Accepted`） |
+| `GET` `DELETE` | `/v1/task` | **local** — 列出／刪除單次任務 |
+| `POST` | `/v1/task/run` | **local** — 立即觸發任務（`202 Accepted`） |
+
+**KuraDB 與白名單**
+
+| Method | Path | 說明 |
+|---|---|---|
+| `GET` `POST` | `/v1/kuradb` | **local** — 查詢狀態／enable／disable／start／stop／restart。安裝／解除安裝仍只走 TUI（需要真實終端機處理 `sudo`／安裝腳本的互動提示）,此 API 只切換 `enabled` flag 並控制已安裝好的 `kura` 行程 |
+| `GET` `POST` | `/v1/allowlist/cmd` | **local** — 列出／新增指令白名單（append-only,需重啟 daemon 生效） |
+| `GET` `POST` | `/v1/allowlist/skill` | **local** — 列出／切換 skill 白名單（`scope=global\|project`） |
+
+**查閱**
+
+| Method | Path | 說明 |
+|---|---|---|
+| `GET` | `/v1/torii/error` | **local** — 查閱工具錯誤記憶；`tool`／`keyword` 皆未帶時回傳無過濾全表掃 |
 
 ## 工具參考
 

--- a/internal/agents/exec/execute.go
+++ b/internal/agents/exec/execute.go
@@ -204,28 +204,34 @@ func Execute(ctx context.Context, data ExecData, session *agentTypes.AgentSessio
 		ctx = context.WithValue(ctx, parentWorkDirKey{}, data.WorkDir)
 	}
 
+	parentCtx := ctx
+	execCtx, execCancel := context.WithCancel(ctx)
+	defer execCancel()
+	ctx = execCtx
+
 	var taskID string
 	if session.ID != "" {
-		if err := sessionManager.AddConcurrent(ctx, session.ID); err != nil {
-			return fmt.Errorf("EnterConcurrent: %w", err)
-		}
-		defer sessionManager.RemoveConcurrent(session.ID)
-		defer ClearSteer(session.ID)
-
 		var inputText string
 		if s, ok := session.UserInput.Content.(string); ok {
 			inputText = s
 		}
 		taskID = configStatus.Online(session.ID, inputText)
 		defer configStatus.Idle(session.ID, taskID)
+		registerCancel(taskID, execCancel)
 		defer unregisterCancel(taskID)
+
+		if err := sessionManager.AddConcurrent(ctx, session.ID); err != nil {
+			return fmt.Errorf("EnterConcurrent: %w", err)
+		}
+		defer sessionManager.RemoveConcurrent(session.ID)
+		defer ClearSteer(session.ID)
 
 		original := events
 		teed := make(chan agentTypes.Event, 64)
 		done := make(chan struct{})
 		sid := session.ID
 		pushHook, hasPush := lookupPushHook(sid)
-		pushCtx := ctx
+		pushCtx := parentCtx
 		isDcPush := hasPush && !isDcPushSuppressed(pushCtx)
 		var pushTextBuf strings.Builder
 		var pushDoneEv agentTypes.Event
@@ -296,11 +302,7 @@ func Execute(ctx context.Context, data ExecData, session *agentTypes.AgentSessio
 		return fmt.Errorf("tools.NewExecutor: %w", err)
 	}
 
-	execCtx, execCancel := context.WithCancel(ctx)
-	defer execCancel()
-	ctx = execCtx
 	exec.CancelExecution = execCancel
-	registerCancel(taskID, execCancel)
 
 	keepPending := true
 	if !session.Stateless && session.ID != "" {

--- a/internal/filesystem/runtime.go
+++ b/internal/filesystem/runtime.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"runtime"
 
 	go_pkg_filesystem "github.com/pardnchiu/go-pkg/filesystem"
 	go_pkg_filesystem_reader "github.com/pardnchiu/go-pkg/filesystem/reader"
@@ -20,7 +21,7 @@ var (
 	AgentSendTimeoutSec   = 600
 	MaxHistoryMessages    = 8
 	MaxHistoryBytes       = 5 * 1024 * 1024
-	MaxSessionTasks       = 3
+	MaxSessionTasks       = runtime.NumCPU() * 2
 	MaxSubagentTimeoutMin = 10
 )
 
@@ -39,10 +40,9 @@ var (
 	ReadOnlyCommand []string
 )
 
-const (
-	hardCapMaxSessionTasks       = 10
-	hardCapMaxSubagentTimeoutMin = 60
-)
+const hardCapMaxSubagentTimeoutMin = 60
+
+var hardCapMaxSessionTasks = runtime.NumCPU() * 4
 
 type RuntimeLimits struct {
 	Port                  string `json:"port,omitempty"`

--- a/internal/runtime/routes/handler/cancel.go
+++ b/internal/runtime/routes/handler/cancel.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"net/http"
+	"slices"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -10,26 +11,21 @@ import (
 	configStatus "github.com/pardnchiu/agenvoy/internal/session/config/status"
 )
 
-func CancelSession() gin.HandlerFunc {
+func CancelSessionTask() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		sessionID := strings.TrimSpace(c.Param("session_id"))
-		if sessionID == "" {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "session_id is required"})
+		taskID := strings.TrimSpace(c.Param("task_id"))
+		if sessionID == "" || taskID == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "session_id and task_id are required"})
 			return
 		}
 
 		status := configStatus.Get(sessionID)
-		if len(status.Active) == 0 {
-			c.JSON(http.StatusOK, gin.H{"ok": true, "cancelled": []string{}})
+		if !slices.ContainsFunc(status.Active, func(t configStatus.Task) bool { return t.ID == taskID }) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "task not active in this session"})
 			return
 		}
 
-		cancelled := make([]string, 0, len(status.Active))
-		for _, task := range status.Active {
-			if exec.CancelTask(task.ID) {
-				cancelled = append(cancelled, task.ID)
-			}
-		}
-		c.JSON(http.StatusOK, gin.H{"ok": true, "cancelled": cancelled})
+		c.JSON(http.StatusOK, gin.H{"ok": true, "cancelled": exec.CancelTask(taskID)})
 	}
 }

--- a/internal/runtime/routes/new.go
+++ b/internal/runtime/routes/new.go
@@ -36,7 +36,7 @@ func New() *gin.Engine {
 	r.PUT("/v1/session", localhostOnly(), handler.UpdateSession())
 	r.DELETE("/v1/session", localhostOnly(), handler.DeleteSession())
 	r.POST("/v1/session/:session_id/model", handler.SetSessionModel())
-	r.POST("/v1/session/:session_id/cancel", handler.CancelSession())
+	r.POST("/v1/session/:session_id/cancel/:task_id", handler.CancelSessionTask())
 	r.GET("/v1/session/:session_id/status", handler.GetSessionStatus())
 	r.GET("/v1/session/:session_id/log", handler.StreamSessionLog())
 	r.POST("/v1/session/:session_id/event", localhostOnly(), handler.PublishSessionEvent())


### PR DESCRIPTION
Narrows cancellation from whole sessions to individual tasks and scales concurrent task limits with host capacity. Documents the resulting task lifecycle and HTTP API management tiers.