### PR TITLE
Drain pending events and configure resume wait timeout

### DIFF
--- a/internal/filesystem/runtime.go
+++ b/internal/filesystem/runtime.go
@@ -23,6 +23,7 @@ var (
 	MaxHistoryBytes       = 5 * 1024 * 1024
 	MaxSessionTasks       = runtime.NumCPU() * 2
 	MaxSubagentTimeoutMin = 10
+	MaxResumeWaitMin      = 30
 )
 
 type DeniedConfig struct {
@@ -41,6 +42,7 @@ var (
 )
 
 const hardCapMaxSubagentTimeoutMin = 60
+const hardCapMaxResumeWaitMin = 120
 
 var hardCapMaxSessionTasks = runtime.NumCPU() * 4
 
@@ -52,6 +54,7 @@ type RuntimeLimits struct {
 	MaxHistoryBytes       int    `json:"max_history_bytes,omitempty"`
 	MaxSessionTasks       int    `json:"max_session_tasks,omitempty"`
 	MaxSubagentTimeoutMin int    `json:"max_subagent_timeout_min,omitempty"`
+	MaxResumeWaitMin      int    `json:"max_resume_wait_min,omitempty"`
 }
 
 func LoadRuntime() error {
@@ -128,6 +131,12 @@ func LoadRuntime() error {
 		changed = true
 	}
 	MaxSubagentTimeoutMin = min(hardCapMaxSubagentTimeoutMin, limits.MaxSubagentTimeoutMin)
+
+	if limits.MaxResumeWaitMin <= 0 {
+		limits.MaxResumeWaitMin = MaxResumeWaitMin
+		changed = true
+	}
+	MaxResumeWaitMin = min(hardCapMaxResumeWaitMin, limits.MaxResumeWaitMin)
 
 	if err := json.Unmarshal(configs.DeniedMap, &DeniedMap); err != nil {
 		return fmt.Errorf("embedded denied_map: %w", err)

--- a/internal/runtime/routes/handler/drainEvents.go
+++ b/internal/runtime/routes/handler/drainEvents.go
@@ -1,0 +1,15 @@
+package handler
+
+import (
+	agentTypes "github.com/pardnchiu/agenvoy/internal/agents/types"
+)
+
+func drainEvents(events <-chan agentTypes.Event) {
+	go func() {
+		for ev := range events {
+			if ev.Type == agentTypes.EventToolConfirm && ev.ReplyCh != nil {
+				ev.ReplyCh <- true
+			}
+		}
+	}()
+}

--- a/internal/runtime/routes/handler/pending.go
+++ b/internal/runtime/routes/handler/pending.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pardnchiu/agenvoy/internal/agents"
 	"github.com/pardnchiu/agenvoy/internal/agents/exec"
 	agentTypes "github.com/pardnchiu/agenvoy/internal/agents/types"
+	"github.com/pardnchiu/agenvoy/internal/filesystem"
 	"github.com/pardnchiu/agenvoy/internal/runtime/pubsub"
 	"github.com/pardnchiu/agenvoy/internal/tools/interactive"
 )
@@ -184,6 +185,7 @@ func ResumeSessionPending() gin.HandlerFunc {
 		}()
 
 		result := collectResult(content, events)
+		drainEvents(events)
 		if result.Canceled {
 			c.JSON(http.StatusOK, gin.H{
 				"session_id": sid,
@@ -214,7 +216,7 @@ type resumeResult struct {
 func collectResult(_ string, events <-chan agentTypes.Event) resumeResult {
 	var text strings.Builder
 	var lastErr string
-	timeout := time.After(10 * time.Minute)
+	timeout := time.After(time.Duration(filesystem.MaxResumeWaitMin) * time.Minute)
 
 	for {
 		select {

--- a/internal/runtime/routes/handler/send.go
+++ b/internal/runtime/routes/handler/send.go
@@ -160,6 +160,7 @@ func Send() gin.HandlerFunc {
 		} else {
 			sendResult(c, sessionID, req.Content, events)
 		}
+		drainEvents(events)
 	}
 }
 


### PR DESCRIPTION
Strengthens agent response recovery and makes externally sourced tool work complete within bounded execution windows.
