### PR TITLE
Upgrade go-llm-router dependency to v0.4.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/pardnchiu/ToriiDB v0.5.1
 	github.com/pardnchiu/go-bot v0.4.3
 	github.com/pardnchiu/go-browser v0.3.0
-	github.com/pardnchiu/go-llm-router v0.4.0
+	github.com/pardnchiu/go-llm-router v0.4.1
 	github.com/pardnchiu/go-pkg v0.13.7
 	github.com/pardnchiu/go-scheduler v1.2.0
 	github.com/pardnchiu/go-sqlkit v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -135,12 +135,8 @@ github.com/pardnchiu/go-bot v0.4.3 h1:N+uQv+cdNZgNXMeSEfCRfYBaAULYsCIFcRVJYIAYDT
 github.com/pardnchiu/go-bot v0.4.3/go.mod h1:9eE+MLerrx6XTz/WS0tGPiPdjKCGGeOHPRhIGfD1HfI=
 github.com/pardnchiu/go-browser v0.3.0 h1:AYvPM9zEizY119QXJmqOumIX+OVoUNFuGKO0Mur/m90=
 github.com/pardnchiu/go-browser v0.3.0/go.mod h1:F4Ms8dIbPb23MX0FMZ6w3PKnjFs+wNsd4QJmirXkEd0=
-github.com/pardnchiu/go-llm-router v0.3.0 h1:AkVcvjmNGEu0P9aKNy1+4VCJ/qmoDAMZVk1WB7l8oiQ=
-github.com/pardnchiu/go-llm-router v0.3.0/go.mod h1:yyou5VYxxvqwrmwwrm5f1RFPXHiSIQ0x1rZ+okpN91g=
-github.com/pardnchiu/go-llm-router v0.3.1 h1:iqxwP0VzrjkAaPt4U+oZC/ZQH54JcjtZE4gLBFlvR0k=
-github.com/pardnchiu/go-llm-router v0.3.1/go.mod h1:yyou5VYxxvqwrmwwrm5f1RFPXHiSIQ0x1rZ+okpN91g=
-github.com/pardnchiu/go-llm-router v0.4.0 h1:I6A6+6UoLNwL98iv9iSke+oT14VGadvunkG9buOfvL8=
-github.com/pardnchiu/go-llm-router v0.4.0/go.mod h1:yyou5VYxxvqwrmwwrm5f1RFPXHiSIQ0x1rZ+okpN91g=
+github.com/pardnchiu/go-llm-router v0.4.1 h1:BS01+2tEbfZAcCAbrjrjymRkLBUewl6Y2rPW6mMlZI4=
+github.com/pardnchiu/go-llm-router v0.4.1/go.mod h1:yyou5VYxxvqwrmwwrm5f1RFPXHiSIQ0x1rZ+okpN91g=
 github.com/pardnchiu/go-pkg v0.13.7 h1:H9WpmfHjIRviHsq3W54FJMTpjEnG6boopjxG+dkPpHM=
 github.com/pardnchiu/go-pkg v0.13.7/go.mod h1:DUCX9mbGQ2YCULGvoMOgagVJBMjSyiTzuwt29fw1qfQ=
 github.com/pardnchiu/go-scheduler v1.2.0 h1:DBmFWOPjGUzQEKYHZNeLS9v9PmJrKk/VwxQeVO754Ns=


### PR DESCRIPTION
Upgrades the go-llm-router dependency to v0.4.1, picking up the latest router fixes and improvements.
