### PR TITLE
Add reasoning effort support and fix lifecycle controls

### DIFF
--- a/cmd/app/cmdDeamon.go
+++ b/cmd/app/cmdDeamon.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
@@ -302,16 +303,33 @@ func cmdDaemon() {
 		Handler: route,
 	}
 
+	listener, err := net.Listen("tcp", server.Addr)
+	if err != nil {
+		slog.Error("net.Listen",
+			slog.String("addr", server.Addr),
+			slog.String("error", err.Error()))
+		return
+	}
+
+	serveErr := make(chan error, 1)
 	go func() {
-		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			slog.Error("server.ListenAndServe",
-				slog.String("error", err.Error()))
+		if err := server.Serve(listener); err != nil && err != http.ErrServerClosed {
+			serveErr <- err
+			return
 		}
+		serveErr <- nil
 	}()
 
 	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
-	<-quit
+	select {
+	case <-quit:
+	case err := <-serveErr:
+		if err != nil {
+			slog.Error("server.Serve",
+				slog.String("error", err.Error()))
+		}
+	}
 	slog.Info("⎯ daemon shutting down")
 
 	discordMu.Lock()

--- a/doc/doc.md
+++ b/doc/doc.md
@@ -130,7 +130,7 @@ curl --fail-with-body -sS \
   http://127.0.0.1:17989/v1/send
 ```
 
-`/v1/chat/completions` is OpenAI-compatible and stateless: include prior messages in every request when continuity is needed.
+`/v1/chat/completions` is OpenAI-compatible and stateless: include prior messages in every request when continuity is needed. `reasoning_effort` accepts `none` `low` `medium` `high` `xhigh` `max` (plus the aliases `minimal` `extra` `ultra`); omitted or unrecognized values fall back to the session's reasoning setting.
 
 ### MCP server mode
 

--- a/doc/doc.md
+++ b/doc/doc.md
@@ -51,7 +51,6 @@ Agenvoy stores runtime data in `~/.config/agenvoy/` and keeps credentials in the
 
 | Setting | Default | Description |
 |---|---:|---|
-| `limits.port` | `17989` | Local HTTP daemon port |
 | `limits.max_tool_iterations` | `128` | Maximum tool iterations per run |
 | `limits.agent_send_timeout_seconds` | `600` | Model-request timeout |
 | `limits.max_history_messages` | `24` | Recent history messages retained |
@@ -121,7 +120,7 @@ agen run 'Inspect the latest Git changes and produce a summary'
 
 ### Local HTTP API
 
-The daemon listens on `127.0.0.1:17989` by default.
+The daemon listens on `127.0.0.1:17989`. The port is fixed and not configurable; Open WebUI, when deployed, is likewise fixed on `17990` and proxied at `/webui`.
 
 ```bash
 curl --fail-with-body -sS \

--- a/doc/doc.zh.md
+++ b/doc/doc.zh.md
@@ -59,7 +59,6 @@ Agenvoy 使用 `~/.config/agenvoy/` 保存執行期資料，並將憑證存放�
 
 | 設定 | 預設值 | 說明 |
 |---|---:|---|
-| `limits.port` | `17989` | 本機 HTTP daemon 連接埠 |
 | `limits.max_tool_iterations` | `128` | 單次 Agent 工作的工具迭代上限 |
 | `limits.agent_send_timeout_seconds` | `600` | 模型請求逾時秒數 |
 | `limits.max_history_messages` | `24` | 保留的近期歷史訊息數 |
@@ -76,7 +75,6 @@ Agenvoy 使用 `~/.config/agenvoy/` 保存執行期資料，並將憑證存放�
 ```json
 {
   "limits": {
-    "port": "17989",
     "max_tool_iterations": 128,
     "agent_send_timeout_seconds": 600
   }
@@ -159,7 +157,7 @@ printf '%s\n' \
 
 ### HTTP API
 
-Daemon 預設只監聽 `127.0.0.1:17989`：
+Daemon 只監聽 `127.0.0.1:17989`，連接埠固定不可調整；Open WebUI 部署後同樣固定在 `17990`，由 `/webui` 反向代理：
 
 ```bash
 curl --fail-with-body -sS \

--- a/doc/doc.zh.md
+++ b/doc/doc.zh.md
@@ -168,7 +168,7 @@ curl --fail-with-body -sS \
   http://127.0.0.1:17989/v1/send
 ```
 
-`/v1/chat/completions` 為 stateless endpoint；需在每次請求中帶入延續對話所需的 `messages`。
+`/v1/chat/completions` 為 stateless endpoint；需在每次請求中帶入延續對話所需的 `messages`。`reasoning_effort` 接受 `none` `low` `medium` `high` `xhigh` `max`（另支援別名 `minimal` `extra` `ultra`）；未帶或無法識別的值退回該 session 的 reasoning 設定。
 
 ## 命令列參考
 

--- a/internal/filesystem/runtime.go
+++ b/internal/filesystem/runtime.go
@@ -16,7 +16,6 @@ import (
 // * Runtime limits, loaded once from ~/.config/agenvoy/config.json `limits` section.
 // * Defaults below are the only fallback; env vars are no longer read.
 var (
-	Port                  = "17989"
 	MaxToolIterations     = 128
 	AgentSendTimeoutSec   = 600
 	MaxHistoryMessages    = 24
@@ -42,8 +41,9 @@ var (
 	ReadOnlyCommand []string
 )
 
+const Port = "17989"
+
 type RuntimeLimits struct {
-	Port                string `json:"port,omitempty"`
 	MaxToolIterations   int    `json:"max_tool_iterations,omitempty"`
 	AgentSendTimeoutSec int    `json:"agent_send_timeout_seconds,omitempty"`
 	MaxHistoryMessages  int    `json:"max_history_messages,omitempty"`
@@ -72,11 +72,6 @@ func LoadRuntime() error {
 	}
 
 	changed := false
-	if limits.Port == "" {
-		limits.Port = Port
-		changed = true
-	}
-	Port = limits.Port
 
 	// * legacy parameter keep for now
 	var legacy struct {

--- a/internal/runtime/routes/handler/chatCompletions/chatCompletions.go
+++ b/internal/runtime/routes/handler/chatCompletions/chatCompletions.go
@@ -18,11 +18,12 @@ var (
 )
 
 type Request struct {
-	Model         string             `json:"model"`
-	Messages      []provider.Message `json:"messages"`
-	Stream        bool               `json:"stream"`
-	workDir       string             `json:"-"`
-	systemPrompts []provider.Message `json:"-"`
+	Model           string             `json:"model"`
+	Messages        []provider.Message `json:"messages"`
+	Stream          bool               `json:"stream"`
+	ReasoningEffort string             `json:"reasoning_effort"`
+	workDir         string             `json:"-"`
+	systemPrompts   []provider.Message `json:"-"`
 }
 
 func ChatCompletions() gin.HandlerFunc {
@@ -37,6 +38,10 @@ func ChatCompletions() gin.HandlerFunc {
 		}
 
 		normalizeContent(req.Messages)
+
+		if _, ok := provider.ParseReasoning(req.ReasoningEffort); !ok {
+			req.ReasoningEffort = "medium"
+		}
 
 		workDir := extractWorkDirFromZed(req.Messages)
 		if workDir != "" {

--- a/internal/runtime/routes/handler/chatCompletions/run.go
+++ b/internal/runtime/routes/handler/chatCompletions/run.go
@@ -60,6 +60,7 @@ func run(ctx context.Context, req Request, userContent string, events chan<- age
 		FallbackAgents: fallbacks,
 		WorkDir:        workDir,
 		Content:        trimContent,
+		Reasoning:      req.ReasoningEffort,
 		ExcludeTools:   tools.TUIOnlyTools,
 		ExcludeSkills:  tools.TUIOnlySkills,
 		AllowAll:       true,

--- a/internal/runtime/routes/handler/webuiProxy.go
+++ b/internal/runtime/routes/handler/webuiProxy.go
@@ -13,13 +13,7 @@ import (
 
 func WebuiProxy() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		port := webui.Port()
-		if port == "" {
-			c.AbortWithStatus(http.StatusNotFound)
-			return
-		}
-
-		target, err := url.Parse("http://127.0.0.1:" + port)
+		target, err := url.Parse(webui.URL)
 		if err != nil {
 			c.AbortWithStatus(http.StatusNotFound)
 			return

--- a/internal/runtime/tui/cmdSelector.go
+++ b/internal/runtime/tui/cmdSelector.go
@@ -44,7 +44,7 @@ var commands = []Command{
 	{"telegram", "enable / disable Telegram bot · getMe validated on enable"},
 	{"voice", "enable / disable voice message · gemini tts"},
 	{"kuradb", "enable / disable / update / start / stop KuraDB RAG"},
-	{"webui", "enable / disable Open WebUI container · podman / docker auto-detected"},
+	{"webui", "deploy / start / stop / remove Open WebUI container · podman / docker auto-detected"},
 	{"admin-channel", "set / clear relay for new-chat verification codes · pick authorized chat or tg@<id>/dc@<id>"},
 	{"cron", "add / remove / edit scheduled recurring task"},
 	{"task", "add / remove / edit one-shot scheduled task"},

--- a/internal/runtime/tui/commandWebui.go
+++ b/internal/runtime/tui/commandWebui.go
@@ -23,32 +23,37 @@ type WebuiDone struct {
 func (t TUI) commandWebui(parts []string) (TUI, tea.Cmd, bool) {
 	if len(parts) > 1 {
 		switch parts[1] {
-		case "enable", "disable":
+		case "enable", "start", "stop", "disable":
 			action := parts[1]
 			return t, func() tea.Msg { return WebuiAction{action: action} }, true
 		}
 	}
 
 	engine := webui.Engine()
-	_, running := webui.Status(engine)
+	options := webuiActions(webui.Status(engine))
 
-	options := []string{"enable", "disable"}
-	cursor := 0
-	if running {
-		cursor = 1
-	}
 	t.popup = &Popup{
 		kind:        popupSingleSelect,
 		title:       "Open WebUI",
 		styledLines: webuiStatus(engine),
 		options:     options,
 		values:      options,
-		cursor:      cursor,
 		onConfirm: func(chosen string) any {
 			return WebuiAction{action: chosen}
 		},
 	}
 	return t, nil, true
+}
+
+func webuiActions(exists, running bool) []string {
+	switch {
+	case running:
+		return []string{"stop", "disable"}
+	case exists:
+		return []string{"start", "disable"}
+	default:
+		return []string{"enable"}
+	}
 }
 
 func webuiStatus(engine string) []string {
@@ -59,7 +64,7 @@ func webuiStatus(engine string) []string {
 	exists, running := webui.Status(engine)
 	switch {
 	case running:
-		return []string{prefix + okayStyle.Render("● running ("+webui.URL()+")")}
+		return []string{prefix + okayStyle.Render("● running ("+webui.URL+")")}
 	case exists:
 		return []string{prefix + errorStyle.Render("○ stopped")}
 	default:

--- a/internal/runtime/tui/update.go
+++ b/internal/runtime/tui/update.go
@@ -969,36 +969,32 @@ func (t TUI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return t, nil
 
 	case WebuiAction:
-		switch msg.action {
-		case "enable":
-			return t, tea.Sequence(
-				tea.Println(hintStyle.Render("⎯ webui deploying")+"\n"),
-				runWebuiExec("enable"),
-			)
-		case "disable":
-			return t, tea.Sequence(
-				tea.Println(hintStyle.Render("⎯ webui removing")+"\n"),
-				runWebuiExec("disable"),
-			)
+		progress, ok := map[string]string{
+			"enable":  "deploying",
+			"start":   "starting",
+			"stop":    "stopping",
+			"disable": "removing",
+		}[msg.action]
+		if !ok {
+			return t, nil
 		}
-		return t, nil
+		return t, tea.Sequence(
+			tea.Println(hintStyle.Render("⎯ webui "+progress)+"\n"),
+			runWebuiExec(msg.action),
+		)
 
 	case WebuiDone:
 		if msg.err != nil {
 			return t, tea.Println(errorStyle.Render(fmt.Sprintf("[!] webui %s: %v", msg.action, msg.err)) + "\n")
 		}
-		if msg.action == "enable" {
-			port := webui.HostPort(webui.Engine())
-			if port == "" {
-				return t, tea.Println(errorStyle.Render("[!] webui enable: container has no published port") + "\n")
-			}
-			if err := webui.SavePort(port); err != nil {
-				return t, tea.Println(errorStyle.Render(fmt.Sprintf("[!] webui save port: %v", err)) + "\n")
-			}
+		switch msg.action {
+		case "enable", "start":
 			return t, tea.Println(hintStyle.Render(
-				fmt.Sprintf("⎯ webui enabled · http://127.0.0.1:%s · proxied at /webui", port)) + "\n")
+				fmt.Sprintf("⎯ webui running · %s · proxied at /webui", webui.URL)) + "\n")
+		case "stop":
+			return t, tea.Println(hintStyle.Render("⎯ webui stopped · still deployed") + "\n")
 		}
-		return t, tea.Println(hintStyle.Render("⎯ webui disabled") + "\n")
+		return t, tea.Println(hintStyle.Render("⎯ webui disabled · container and volume removed") + "\n")
 
 	case KuradbKeySubmit:
 		token := strings.TrimSpace(msg.token)

--- a/internal/runtime/webui/webui.go
+++ b/internal/runtime/webui/webui.go
@@ -1,16 +1,15 @@
 package webui
 
 import (
-	"fmt"
 	"os/exec"
 	"strings"
-
-	"github.com/pardnchiu/agenvoy/internal/session/config"
 )
 
 const (
 	Container  = "open-webui"
+	Port       = "17990"
 	InstallURL = "https://agenvoy.com/scripts/webui.sh"
+	URL        = "http://127.0.0.1:" + Port
 )
 
 func Engine() string {
@@ -31,54 +30,4 @@ func Status(engine string) (exists, running bool) {
 		return false, false
 	}
 	return true, strings.TrimSpace(string(raw)) == "true"
-}
-
-func HostPort(engine string) string {
-	if engine == "" {
-		return ""
-	}
-	const format = "{{range $p, $conf := .NetworkSettings.Ports}}{{if $conf}}{{(index $conf 0).HostPort}} {{end}}{{end}}"
-	raw, err := exec.Command(engine, "container", "inspect", "-f", format, Container).Output()
-	if err != nil {
-		return ""
-	}
-	mapped, _, _ := strings.Cut(strings.TrimSpace(string(raw)), " ")
-	return mapped
-}
-
-func Port() string {
-	if cfg, err := config.Load(); err == nil && cfg != nil && cfg.WebuiPort != "" {
-		return cfg.WebuiPort
-	}
-	port := HostPort(Engine())
-	if port == "" {
-		return ""
-	}
-	if err := SavePort(port); err != nil {
-		return port
-	}
-	return port
-}
-
-func SavePort(port string) error {
-	cfg, err := config.Load()
-	if err != nil {
-		return fmt.Errorf("config.Load: %w", err)
-	}
-	if cfg == nil || cfg.WebuiPort == port {
-		return nil
-	}
-	cfg.WebuiPort = port
-	if err := config.Save(cfg); err != nil {
-		return fmt.Errorf("config.Save: %w", err)
-	}
-	return nil
-}
-
-func URL() string {
-	port := Port()
-	if port == "" {
-		return ""
-	}
-	return "http://127.0.0.1:" + port
 }

--- a/internal/session/config/config.go
+++ b/internal/session/config/config.go
@@ -25,7 +25,6 @@ type Config struct {
 	TelegramEnabled  bool          `json:"telegram_enabled"`
 	TelegramUsername string        `json:"telegram_username"`
 	KuradbEnabled    bool          `json:"kuradb_enabled"`
-	WebuiPort        string        `json:"webui_port,omitempty"`
 	EnableVoice      bool          `json:"enable_voice"`
 	AdminChannel     string        `json:"admin_channel"`
 }


### PR DESCRIPTION
The daemon and Open WebUI ports are now represented by fixed values (`17989` and `17990`) instead of configurable settings. This is an internal refactor; user-facing behavior and access paths remain unchanged.
