### PR TITLE
Filter metadata headers from streamed model responses

### DIFF
--- a/internal/agents/exec/modelResponse.go
+++ b/internal/agents/exec/modelResponse.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	timestampHeaderRegex   = regexp.MustCompile(`\A\s*-{3,}\n(?:[^\n]*\n)*?-{3,}\n`)
+	timestampHeaderRegex   = regexp.MustCompile(`\A\s*-{3,}\n(?:(?:當前時間|工作目錄|傳送者|當前 chat ID|當前 channel)[^\n]*\n)+-{3,}\n`)
 	contextMetaLineRegex   = regexp.MustCompile(`\A\s*(?:當前時間|工作目錄|傳送者|當前 chat ID|當前 channel)\s*[:：][^\n]*\n?`)
 	summaryBlockRegex      = regexp.MustCompile(`(?s)<summary>\s*[\s\S]*?\s*</summary>|\[summary\]\s*[\s\S]*?\s*\[/summary\]`)
 	summaryLeakMarkerRegex = regexp.MustCompile(`(?i)(?:Prior Conversation Context|Prior summary|background summary of prior discussion|Strict rules:|"key_decisions"\s*:\s*\[|"current_discussion"\s*:\s*\{)`)

--- a/internal/agents/exec/streamText.go
+++ b/internal/agents/exec/streamText.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"regexp"
 	"strings"
 
 	"github.com/pardnchiu/agenvoy/configs"
@@ -12,7 +13,11 @@ import (
 	provider "github.com/pardnchiu/go-llm-router/core"
 )
 
-var partialMarkers = []string{"<think>", configs.GuardrailSentinel}
+var (
+	partialMarkers  = []string{"<think>", configs.GuardrailSentinel}
+	headerRuleRegex = regexp.MustCompile(`^-{3,}$`)
+	headerMetaRegex = regexp.MustCompile(`^(?:當前時間|工作目錄|傳送者|當前 chat ID|當前 channel)\s*[:：]`)
+)
 
 func streamSend(
 	ctx context.Context,
@@ -168,19 +173,23 @@ func consumeStream(stream <-chan provider.StreamEvent, events chan<- agentTypes.
 }
 
 type lineEmitter struct {
-	events    chan<- agentTypes.Event
-	kind      agentTypes.EventType
-	emitDelta bool
-
-	shown *[]string
-
-	seen    strings.Builder
-	raw     strings.Builder
-	line    strings.Builder
-	inThink bool
-	fence   internalUtils.FenceState
-	sent    bool
-	stopped bool
+	events      chan<- agentTypes.Event
+	kind        agentTypes.EventType
+	emitDelta   bool
+	shown       *[]string
+	seen        strings.Builder
+	raw         strings.Builder
+	line        strings.Builder
+	inThink     bool
+	fence       internalUtils.FenceState
+	inHeader    bool
+	headerDone  bool
+	replaying   bool
+	headerBuf   []string
+	headerBytes int
+	deltaHold   strings.Builder
+	sent        bool
+	stopped     bool
 }
 
 func (e *lineEmitter) write(delta string) {
@@ -229,10 +238,45 @@ func (e *lineEmitter) close() {
 		return
 	}
 	e.feed(e.raw.String())
+	e.flushHeader()
 	e.setRaw("")
 	if tail := e.line.String(); tail != "" {
 		e.line.Reset()
 		e.emit(tail)
+	}
+}
+
+func (e *lineEmitter) flushHeader() {
+	if !e.inHeader {
+		return
+	}
+	buf := e.headerBuf
+	e.inHeader = false
+	e.headerDone = true
+	e.headerBuf = nil
+	e.headerBytes = 0
+	e.releaseDelta()
+	e.replaying = true
+	for _, line := range buf {
+		e.emit(line)
+	}
+	e.replaying = false
+}
+
+func (e *lineEmitter) releaseDelta() {
+	if !e.emitDelta {
+		return
+	}
+	rest := e.deltaHold.String()
+	e.deltaHold.Reset()
+	if e.headerBytes >= len(rest) {
+		e.headerBytes = 0
+		return
+	}
+	rest = rest[e.headerBytes:]
+	e.headerBytes = 0
+	if rest != "" {
+		e.events <- agentTypes.Event{Type: agentTypes.EventTextDelta, Text: rest}
 	}
 }
 
@@ -242,7 +286,11 @@ func (e *lineEmitter) feed(text string) {
 	}
 
 	if e.emitDelta {
-		e.events <- agentTypes.Event{Type: agentTypes.EventTextDelta, Text: text}
+		if e.headerDone {
+			e.events <- agentTypes.Event{Type: agentTypes.EventTextDelta, Text: text}
+		} else {
+			e.deltaHold.WriteString(text)
+		}
 	}
 
 	e.line.WriteString(text)
@@ -258,6 +306,9 @@ func (e *lineEmitter) feed(text string) {
 }
 
 func (e *lineEmitter) emit(line string) {
+	if e.header(line) {
+		return
+	}
 	line, ok := e.normalize(line)
 	if !ok || e.duplicate(line) {
 		return
@@ -266,12 +317,54 @@ func (e *lineEmitter) emit(line string) {
 	e.sent = true
 }
 
-// * StripModelResponse restarts its fence tracking on every call, so feeding it
-// * one line at a time would trim the indentation of every code line and drop
-// * the blank ones. Fenced lines bypass it entirely.
+func (e *lineEmitter) header(line string) bool {
+	if e.headerDone {
+		return false
+	}
+
+	trimmed := strings.TrimSpace(line)
+	if !e.inHeader {
+		if trimmed == "" {
+			e.headerBytes += len(line) + 1
+			return true
+		}
+		if !headerRuleRegex.MatchString(trimmed) {
+			e.headerDone = true
+			e.releaseDelta()
+			return false
+		}
+		e.inHeader = true
+		e.headerBuf = append(e.headerBuf, line)
+		e.headerBytes += len(line) + 1
+		return true
+	}
+
+	if headerRuleRegex.MatchString(trimmed) {
+		e.inHeader = false
+		e.headerDone = true
+		e.headerBuf = nil
+		e.headerBytes += len(line) + 1
+		e.releaseDelta()
+		return true
+	}
+
+	if trimmed != "" && !headerMetaRegex.MatchString(trimmed) {
+		e.flushHeader()
+		return false
+	}
+
+	e.headerBuf = append(e.headerBuf, line)
+	e.headerBytes += len(line) + 1
+	return true
+}
+
 func (e *lineEmitter) normalize(line string) (string, bool) {
 	out, marker := e.fence.Normalize(line)
 	if marker || e.fence.InFence {
+		return out, true
+	}
+
+	if e.replaying {
 		return out, true
 	}
 


### PR DESCRIPTION
Tightens streamed response handling so metadata is filtered without losing legitimate content. Preserves code-fence and replay behavior while keeping incremental output clean.
