### PR TITLE
Store sendAt and sender as structured history fields

### DIFF
--- a/configs/prompts/system_prompt/chatcompletions_system_prompt.md
+++ b/configs/prompts/system_prompt/chatcompletions_system_prompt.md
@@ -16,7 +16,7 @@
 
 ---
 
-The `當前時間:` prefix at the start of each message is the local timestamp (format `YYYY-MM-DD HH:mm:ss`) and can be used to judge message recency.
+Each message opens with a system-injected `sendAt: <YYYY-MM-DD HH:mm:ss>` line — the local send time, usable for recency judgment. Read it, never emit it: your reply starts with the answer itself.
 
 Host OS: {{.SystemOS}}
 Work directory: {{.WorkPath}}

--- a/configs/prompts/system_prompt/system_prompt.md
+++ b/configs/prompts/system_prompt/system_prompt.md
@@ -1,6 +1,6 @@
 {{.BotPersona}}{{.PermissionMode}}
 
-`當前時間:` prefix per message — local timestamp (`YYYY-MM-DD HH:mm:ss`), for recency judgment.
+`sendAt: <YYYY-MM-DD HH:mm:ss>[, sender: <name>][, channelId: <id>]` — first line of each message, system-injected on both sides of history. Read it for recency and sender identity; never write it. Replies open with the answer, no metadata line of your own.
 
 Host OS: {{.SystemOS}}
 Work directory: {{.WorkPath}}

--- a/internal/agents/exec/compact/sessionHistory.go
+++ b/internal/agents/exec/compact/sessionHistory.go
@@ -15,7 +15,6 @@ import (
 	agentTypes "github.com/pardnchiu/agenvoy/internal/agents/types"
 	"github.com/pardnchiu/agenvoy/internal/filesystem"
 	sessionHistory "github.com/pardnchiu/agenvoy/internal/session/history"
-	historyStore "github.com/pardnchiu/agenvoy/internal/session/history/store"
 	sessionLog "github.com/pardnchiu/agenvoy/internal/session/log"
 	provider "github.com/pardnchiu/go-llm-router/core"
 	go_pkg_utils "github.com/pardnchiu/go-pkg/utils"
@@ -27,8 +26,7 @@ type compactExchange struct {
 }
 
 var (
-	compactJSONRegex   = regexp.MustCompile(`\{[^{}]*"remove"\s*:\s*\[[^]]*\][^{}]*\}`)
-	metadataBlockRegex = regexp.MustCompile(`(?s)^---\n.*?\n---\n?`)
+	compactJSONRegex = regexp.MustCompile(`\{[^{}]*"remove"\s*:\s*\[[^]]*\][^{}]*\}`)
 )
 
 func SessionHistory(ctx context.Context, sessionID string) (int, error) {
@@ -86,7 +84,7 @@ func SessionHistory(ctx context.Context, sessionID string) (int, error) {
 		return 0, nil
 	}
 
-	kept := make([]provider.Message, 0, len(old))
+	kept := make([]sessionHistory.Record, 0, len(old))
 	removed := 0
 	for i, ex := range exchanges {
 		if removeSet[i] {
@@ -108,17 +106,17 @@ func SessionHistory(ctx context.Context, sessionID string) (int, error) {
 	return removed, nil
 }
 
-func syncActionLog(sessionID string, messages []provider.Message) {
+func syncActionLog(sessionID string, messages []sessionHistory.Record) {
 	var keptContents []string
 	for _, msg := range messages {
 		if msg.Role == "user" {
-			keptContents = append(keptContents, historyStore.ExtractContent(msg.Content))
+			keptContents = append(keptContents, msg.Text())
 		}
 	}
 	sessionLog.RetainExchanges(sessionID, keptContents)
 }
 
-func groupExchanges(messages []provider.Message) []compactExchange {
+func groupExchanges(messages []sessionHistory.Record) []compactExchange {
 	var list []compactExchange
 	current := -1
 	for i, msg := range messages {
@@ -135,12 +133,12 @@ func groupExchanges(messages []provider.Message) []compactExchange {
 	return list
 }
 
-func preFilter(messages []provider.Message, exchanges []compactExchange) map[int]bool {
+func preFilter(messages []sessionHistory.Record, exchanges []compactExchange) map[int]bool {
 	removeSet := make(map[int]bool)
 	seen := make(map[string]bool)
 
 	for i := len(exchanges) - 1; i >= 0; i-- {
-		content := extractUserContent(messages[exchanges[i].start])
+		content := strings.TrimSpace(messages[exchanges[i].start].Text())
 		if content == "" || seen[content] {
 			removeSet[i] = true
 			continue
@@ -151,45 +149,13 @@ func preFilter(messages []provider.Message, exchanges []compactExchange) map[int
 	return removeSet
 }
 
-func extractUserContent(msg provider.Message) string {
-	content := historyStore.ExtractContent(msg.Content)
-	content = metadataBlockRegex.ReplaceAllString(content, "")
-	lines := strings.SplitN(content, "\n", 20)
-	start := 0
-	for start < len(lines) {
-		line := strings.TrimSpace(lines[start])
-		if line == "" || strings.HasPrefix(line, "當前時間:") || strings.HasPrefix(line, "工作目錄:") || strings.HasPrefix(line, "傳送者:") || strings.HasPrefix(line, "當前 ") {
-			start++
-			continue
-		}
-		break
-	}
-	if start >= len(lines) {
-		return ""
-	}
-	return strings.TrimSpace(strings.Join(lines[start:], "\n"))
-}
-
-func identifyRemovable(ctx context.Context, agent agentTypes.Agent, messages []provider.Message, exchanges []compactExchange, indices []int) (map[int]bool, error) {
+func identifyRemovable(ctx context.Context, agent agentTypes.Agent, messages []sessionHistory.Record, exchanges []compactExchange, indices []int) (map[int]bool, error) {
 	var sb strings.Builder
 	for _, i := range indices {
 		ex := exchanges[i]
 		fmt.Fprintf(&sb, "=== Exchange %d ===\n", i)
 		for _, msg := range messages[ex.start:ex.end] {
-			content := historyStore.ExtractContent(msg.Content)
-			if content == "" && len(msg.ToolCalls) > 0 {
-				var names []string
-				for _, tc := range msg.ToolCalls {
-					names = append(names, tc.Function.Name)
-				}
-				fmt.Fprintf(&sb, "[%s] <tool_calls: %s>\n", msg.Role, strings.Join(names, ", "))
-				continue
-			}
-			if msg.ToolCallID != "" {
-				fmt.Fprintf(&sb, "[tool] %s\n", go_pkg_utils.TruncateString(content, 200))
-				continue
-			}
-			fmt.Fprintf(&sb, "[%s] %s\n", msg.Role, go_pkg_utils.TruncateString(content, 500))
+			fmt.Fprintf(&sb, "[%s] %s\n", msg.Role, go_pkg_utils.TruncateString(msg.Text(), 500))
 		}
 		sb.WriteString("\n")
 	}

--- a/internal/agents/exec/execWithSubagent.go
+++ b/internal/agents/exec/execWithSubagent.go
@@ -105,19 +105,16 @@ func ExecWithSubagent(ctx context.Context, task, sessionIDInput, model, reasonin
 		AllowAll:          allowAll,
 	}
 
-	oldHistory, maxHistory := sessionHistory.Get(sessionID)
-	if oldHistory == nil {
-		oldHistory = []provider.Message{}
-	}
-	if maxHistory == nil {
-		maxHistory = []provider.Message{}
-	}
+	oldRecords, maxRecords := sessionHistory.Get(sessionID)
+	oldHistory := sessionHistory.Messages(oldRecords)
+	maxHistory := sessionHistory.Messages(maxRecords)
 
-	userText := fmt.Sprintf("---\n當前時間: %s\n工作目錄: %s\n---\n%s",
-		time.Now().Format("2006-01-02 15:04:05"), execData.WorkDir, task)
+	sendAt := time.Now().UnixNano()
+	userText := task
+	prefixed := sessionHistory.WithPrefix(sessionHistory.Record{SendAt: sendAt}.Prefix(), userText)
 
 	histories := append([]provider.Message{}, oldHistory...)
-	histories = append(histories, provider.Message{Role: "user", Content: userText})
+	histories = append(histories, provider.Message{Role: "user", Content: prefixed})
 
 	session := &agentTypes.AgentSession{
 		ID:            sessionID,
@@ -127,9 +124,10 @@ func ExecWithSubagent(ctx context.Context, task, sessionIDInput, model, reasonin
 		Tools:         []provider.Message{},
 		Histories:     histories,
 		BaseLen:       len(oldHistory),
-		UserInput:     provider.Message{Role: "user", Content: userText},
+		UserSendAt:    sendAt,
+		UserInput:     provider.Message{Role: "user", Content: prefixed},
 	}
-	if summary := summary.GetPrompt(sessionID, OldestMessageTime(maxHistory)); summary != "" {
+	if summary := summary.GetPrompt(sessionID, OldestMessageTime(maxRecords)); summary != "" {
 		session.SummaryMessage = provider.Message{Role: "user", Content: summary}
 	}
 

--- a/internal/agents/exec/execute.go
+++ b/internal/agents/exec/execute.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pardnchiu/agenvoy/internal/session/config"
 	configBot "github.com/pardnchiu/agenvoy/internal/session/config/bot"
 	configStatus "github.com/pardnchiu/agenvoy/internal/session/config/status"
+	sessionHistory "github.com/pardnchiu/agenvoy/internal/session/history"
 	sessionLog "github.com/pardnchiu/agenvoy/internal/session/log"
 	usagelog "github.com/pardnchiu/agenvoy/internal/session/usage"
 	"github.com/pardnchiu/agenvoy/internal/tools"
@@ -55,6 +56,7 @@ type ExecuteMeta struct {
 	PendingTask       string
 	ReplyMessageID    string
 	HistoryContent    string
+	Sender            string
 }
 
 type (
@@ -635,7 +637,10 @@ func Execute(ctx context.Context, data ExecuteMeta, session *agentTypes.AgentSes
 				sendText(events, responseText)
 			}
 
-			choice.Message.Content = fmt.Sprintf("---\n當前時間: %s\n---\n%s", time.Now().Format("2006-01-02 15:04:05"), stripped)
+			choice.Message.Content = sessionHistory.WithPrefix(
+				sessionHistory.Record{SendAt: time.Now().UnixNano()}.Prefix(),
+				stripped,
+			)
 			session.ToolHistories = append(session.ToolHistories, choice.Message)
 
 			if err := saveNewHistory(execCtx, choice, session); err != nil {

--- a/internal/agents/exec/getSession.go
+++ b/internal/agents/exec/getSession.go
@@ -12,7 +12,6 @@ import (
 	_ "image/png"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"time"
 
@@ -87,32 +86,40 @@ func GetSession(ctx context.Context, execData ExecuteMeta) (*agentTypes.AgentSes
 	}
 
 	oldHistory, maxHistory := sessionHistory.Get(overrideID)
-	session.Histories = oldHistory
-	session.BaseLen = len(oldHistory)
+	session.Histories = sessionHistory.Messages(oldHistory)
+	session.BaseLen = len(session.Histories)
 
 	session.SystemPrompts = BuildSystemPrompts(execData.WorkDir, execData.ExtraSystemPrompt, scanner, overrideID, execData.AllowAll, execData.ExcludeSkills)
 	if summary := summary.GetPrompt(overrideID, OldestMessageTime(maxHistory)); summary != "" {
 		session.SummaryMessage = provider.Message{Role: "user", Content: summary}
 	}
 
-	session.OldHistories = maxHistory
+	session.OldHistories = sessionHistory.Messages(maxHistory)
 	session.ToolHistories = []provider.Message{}
 
 	userText := strings.TrimSpace(execData.Input)
 	if userText == "" {
-		userText = fmt.Sprintf("---\n當前時間: %s\n工作目錄: %s\n---\n%s", time.Now().Format("2006-01-02 15:04:05"), execData.WorkDir, trimInput)
+		userText = trimInput
 	}
 	histText := userText
 	if h := strings.TrimSpace(execData.HistoryContent); h != "" {
 		histText = h
 	}
+
+	session.Sender = execData.Sender
+	session.UserSendAt = time.Now().UnixNano()
+	prefix := sessionHistory.Record{
+		SendAt: session.UserSendAt,
+		Sender: session.Sender,
+	}.Prefix()
+
 	session.Histories = append(session.Histories, provider.Message{
 		Role:    "user",
-		Content: histText,
+		Content: sessionHistory.WithPrefix(prefix, histText),
 	})
 	session.UserInput = provider.Message{
 		Role:    "user",
-		Content: buildContent(userText, execData.ImageInputs, execData.FileInputs),
+		Content: sessionHistory.WithPrefix(prefix, buildContent(userText, execData.ImageInputs, execData.FileInputs)),
 	}
 	SaveUserInputHistory(ctx, overrideID, histText)
 
@@ -120,18 +127,10 @@ func GetSession(ctx context.Context, execData ExecuteMeta) (*agentTypes.AgentSes
 	return &session, nil
 }
 
-var msgTimeRegex = regexp.MustCompile(`當前時間:\s*(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})`)
-
-func OldestMessageTime(histories []provider.Message) time.Time {
-	for _, m := range histories {
-		s, ok := m.Content.(string)
-		if !ok {
-			continue
-		}
-		if matches := msgTimeRegex.FindStringSubmatch(s); len(matches) > 1 {
-			if t, err := time.ParseInLocation("2006-01-02 15:04:05", matches[1], time.Local); err == nil {
-				return t
-			}
+func OldestMessageTime(histories []sessionHistory.Record) time.Time {
+	for _, record := range histories {
+		if record.SendAt > 0 {
+			return time.Unix(0, record.SendAt)
 		}
 	}
 	return time.Time{}

--- a/internal/agents/exec/modelResponse.go
+++ b/internal/agents/exec/modelResponse.go
@@ -6,12 +6,11 @@ import (
 	"strings"
 
 	"github.com/pardnchiu/agenvoy/configs"
+	sessionHistory "github.com/pardnchiu/agenvoy/internal/session/history"
 	internalUtils "github.com/pardnchiu/agenvoy/internal/utils"
 )
 
 var (
-	timestampHeaderRegex   = regexp.MustCompile(`\A\s*-{3,}\n(?:(?:當前時間|工作目錄|傳送者|當前 chat ID|當前 channel)[^\n]*\n)+-{3,}\n`)
-	contextMetaLineRegex   = regexp.MustCompile(`\A\s*(?:當前時間|工作目錄|傳送者|當前 chat ID|當前 channel)\s*[:：][^\n]*\n?`)
 	summaryBlockRegex      = regexp.MustCompile(`(?s)<summary>\s*[\s\S]*?\s*</summary>|\[summary\]\s*[\s\S]*?\s*\[/summary\]`)
 	summaryLeakMarkerRegex = regexp.MustCompile(`(?i)(?:Prior Conversation Context|Prior summary|background summary of prior discussion|Strict rules:|"key_decisions"\s*:\s*\[|"current_discussion"\s*:\s*\{)`)
 	thinkTagRegex          = regexp.MustCompile(`(?is)<think>(.*?)</think>\s*`)
@@ -45,14 +44,7 @@ func isGuardrailRefusal(content string) bool {
 }
 
 func StripModelResponse(str string) string {
-	str = timestampHeaderRegex.ReplaceAllString(str, "")
-	for {
-		trimmed := contextMetaLineRegex.ReplaceAllString(str, "")
-		if trimmed == str {
-			break
-		}
-		str = trimmed
-	}
+	str = sessionHistory.StripPrefix(str)
 	str = summaryBlockRegex.ReplaceAllString(str, "")
 	if loc := summaryLeakMarkerRegex.FindStringIndex(str); loc != nil {
 		dropped := strings.TrimSpace(str[loc[0]:])

--- a/internal/agents/exec/run.go
+++ b/internal/agents/exec/run.go
@@ -57,7 +57,7 @@ func Run(ctx context.Context, bot agentTypes.Agent, registry agentTypes.AgentReg
 		routingInput = "use " + hint + " " + trimInput
 	}
 
-	userText := fmt.Sprintf("---\n當前時間: %s\n工作目錄: %s\n---\n%s", time.Now().Format("2006-01-02 15:04:05"), workDir, trimInput)
+	userText := trimInput
 	sessionLog.Append(sessionOverride, userText)
 
 	executeStart := time.Now()

--- a/internal/agents/exec/saveHistory.go
+++ b/internal/agents/exec/saveHistory.go
@@ -23,7 +23,8 @@ func saveNewHistory(ctx context.Context, choice provider.OutputChoices, session 
 	}
 
 	base := min(max(session.BaseLen, 0), len(session.Histories))
-	delta := make([]provider.Message, 0, len(session.Histories)-base)
+	now := time.Now().UnixNano()
+	delta := make([]sessionHistory.Record, 0, len(session.Histories)-base)
 	for _, message := range session.Histories[base:] {
 		if message.Role == "system" ||
 			message.Role == "tool" ||
@@ -33,7 +34,18 @@ func saveNewHistory(ctx context.Context, choice provider.OutputChoices, session 
 		if content, ok := message.Content.(string); ok && (strings.Contains(content, configs.PoisonRefusal) || strings.Contains(content, configs.GuardrailSentinel)) {
 			continue
 		}
-		delta = append(delta, message)
+
+		record := sessionHistory.Record{Role: message.Role, Content: message.Content, SendAt: now}
+		if content, ok := message.Content.(string); ok {
+			record.Content = sessionHistory.StripPrefix(content)
+		}
+		if message.Role == "user" {
+			record.Sender = session.Sender
+			if session.UserSendAt > 0 {
+				record.SendAt = session.UserSendAt
+			}
+		}
+		delta = append(delta, record)
 	}
 
 	if err := sessionHistory.Append(session.ID, delta); err != nil {
@@ -55,6 +67,9 @@ func SaveUserInputHistory(ctx context.Context, sessionID, userText string) {
 }
 
 func writeSessionHistEntry(ctx context.Context, sessionID string, msg provider.Message) {
+	if content, ok := msg.Content.(string); ok {
+		msg.Content = sessionHistory.StripPrefix(content)
+	}
 	msgBytes, err := json.Marshal(msg)
 	if err != nil {
 		return

--- a/internal/agents/exec/streamText.go
+++ b/internal/agents/exec/streamText.go
@@ -4,19 +4,17 @@ import (
 	"context"
 	"errors"
 	"log/slog"
-	"regexp"
 	"strings"
 
 	"github.com/pardnchiu/agenvoy/configs"
 	agentTypes "github.com/pardnchiu/agenvoy/internal/agents/types"
+	sessionHistory "github.com/pardnchiu/agenvoy/internal/session/history"
 	internalUtils "github.com/pardnchiu/agenvoy/internal/utils"
 	provider "github.com/pardnchiu/go-llm-router/core"
 )
 
 var (
-	partialMarkers  = []string{"<think>", configs.GuardrailSentinel}
-	headerRuleRegex = regexp.MustCompile(`^-{3,}$`)
-	headerMetaRegex = regexp.MustCompile(`^(?:當前時間|工作目錄|傳送者|當前 chat ID|當前 channel)\s*[:：]`)
+	partialMarkers = []string{"<think>", configs.GuardrailSentinel}
 )
 
 func streamSend(
@@ -182,10 +180,7 @@ type lineEmitter struct {
 	line        strings.Builder
 	inThink     bool
 	fence       internalUtils.FenceState
-	inHeader    bool
 	headerDone  bool
-	replaying   bool
-	headerBuf   []string
 	headerBytes int
 	deltaHold   strings.Builder
 	sent        bool
@@ -238,29 +233,15 @@ func (e *lineEmitter) close() {
 		return
 	}
 	e.feed(e.raw.String())
-	e.flushHeader()
 	e.setRaw("")
 	if tail := e.line.String(); tail != "" {
 		e.line.Reset()
 		e.emit(tail)
 	}
-}
-
-func (e *lineEmitter) flushHeader() {
-	if !e.inHeader {
-		return
+	if !e.headerDone {
+		e.headerDone = true
+		e.releaseDelta()
 	}
-	buf := e.headerBuf
-	e.inHeader = false
-	e.headerDone = true
-	e.headerBuf = nil
-	e.headerBytes = 0
-	e.releaseDelta()
-	e.replaying = true
-	for _, line := range buf {
-		e.emit(line)
-	}
-	e.replaying = false
 }
 
 func (e *lineEmitter) releaseDelta() {
@@ -323,48 +304,25 @@ func (e *lineEmitter) header(line string) bool {
 	}
 
 	trimmed := strings.TrimSpace(line)
-	if !e.inHeader {
-		if trimmed == "" {
-			e.headerBytes += len(line) + 1
-			return true
-		}
-		if !headerRuleRegex.MatchString(trimmed) {
-			e.headerDone = true
-			e.releaseDelta()
-			return false
-		}
-		e.inHeader = true
-		e.headerBuf = append(e.headerBuf, line)
+	if trimmed == "" {
 		e.headerBytes += len(line) + 1
 		return true
 	}
 
-	if headerRuleRegex.MatchString(trimmed) {
-		e.inHeader = false
-		e.headerDone = true
-		e.headerBuf = nil
-		e.headerBytes += len(line) + 1
+	e.headerDone = true
+	if !sessionHistory.HasPrefix(trimmed) {
 		e.releaseDelta()
-		return true
-	}
-
-	if trimmed != "" && !headerMetaRegex.MatchString(trimmed) {
-		e.flushHeader()
 		return false
 	}
 
-	e.headerBuf = append(e.headerBuf, line)
 	e.headerBytes += len(line) + 1
+	e.releaseDelta()
 	return true
 }
 
 func (e *lineEmitter) normalize(line string) (string, bool) {
 	out, marker := e.fence.Normalize(line)
 	if marker || e.fence.InFence {
-		return out, true
-	}
-
-	if e.replaying {
 		return out, true
 	}
 

--- a/internal/agents/exec/summary/generate.go
+++ b/internal/agents/exec/summary/generate.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"regexp"
 	"strings"
+	"time"
 	"unicode/utf8"
 
 	go_pkg_utils "github.com/pardnchiu/go-pkg/utils"
@@ -14,6 +15,7 @@ import (
 	"github.com/pardnchiu/agenvoy/configs"
 	"github.com/pardnchiu/agenvoy/internal/agents"
 	agentTypes "github.com/pardnchiu/agenvoy/internal/agents/types"
+	sessionHistory "github.com/pardnchiu/agenvoy/internal/session/history"
 	"github.com/pardnchiu/agenvoy/internal/session/summary"
 	provider "github.com/pardnchiu/go-llm-router/core"
 )
@@ -26,10 +28,9 @@ var (
 	fencedBlockRegex    = regexp.MustCompile("(?s)" + "```" + `(?:json|summary)\s*\n([\s\S]*?)\s*\n` + "```")
 	summaryTagRegex     = regexp.MustCompile(`(?s)<summary>\s*([\s\S]*?)\s*</summary>`)
 	summaryBracketRegex = regexp.MustCompile(`(?s)\[summary\]\s*([\s\S]*?)\s*\[/summary\]`)
-	hisroryTimeRegex    = regexp.MustCompile(`當前時間:\s*(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})`)
 )
 
-func Generate(ctx context.Context, sessionID string, histories []provider.Message) error {
+func Generate(ctx context.Context, sessionID string, histories []sessionHistory.Record) error {
 	// * caller supplies no agent, Send layers the summary model preference on top
 	agent := agents.Registry().Fallback
 	if agent == nil {
@@ -77,9 +78,9 @@ func Generate(ctx context.Context, sessionID string, histories []provider.Messag
 	return nil
 }
 
-func chunkHistories(histories []provider.Message, cursor string) [][]provider.Message {
+func chunkHistories(histories []sessionHistory.Record, cursor string) [][]sessionHistory.Record {
 	if cursor != "" {
-		latest := make([]provider.Message, 0, len(histories))
+		latest := make([]sessionHistory.Record, 0, len(histories))
 		for _, message := range histories {
 			t := extractTime(message)
 			if t == "" || t > cursor {
@@ -92,7 +93,7 @@ func chunkHistories(histories []provider.Message, cursor string) [][]provider.Me
 		return nil
 	}
 
-	var list [][]provider.Message
+	var list [][]sessionHistory.Record
 	for i := 0; i < len(histories); {
 		end, total := i, 0
 		for end < len(histories) {
@@ -112,26 +113,22 @@ func chunkHistories(histories []provider.Message, cursor string) [][]provider.Me
 	return list
 }
 
-func contentRunes(msg provider.Message) int {
-	str, ok := msg.Content.(string)
-	if !ok {
-		return 0
-	}
-	return utf8.RuneCountInString(str)
+func contentRunes(msg sessionHistory.Record) int {
+	return utf8.RuneCountInString(msg.Text())
 }
 
-func generateSmmary(ctx context.Context, agent agentTypes.Agent, oldSummary string, histories []provider.Message) map[string]any {
+func generateSmmary(ctx context.Context, agent agentTypes.Agent, oldSummary string, histories []sessionHistory.Record) map[string]any {
 	prompt := strings.NewReplacer(
 		"{{.Summary}}", oldSummary,
 	).Replace(strings.TrimSpace(configs.SummaryPrompt))
 
 	var sb strings.Builder
 	for _, hist := range histories {
-		content, ok := hist.Content.(string)
-		if !ok {
+		content := strings.TrimSpace(hist.Text())
+		if content == "" {
 			continue
 		}
-		fmt.Fprintf(&sb, "[%s]\n%s\n\n", hist.Role, strings.TrimSpace(content))
+		fmt.Fprintf(&sb, "[%s]\n%s\n\n", hist.Role, content)
 	}
 
 	raw := fmt.Sprintf(`<conversation>
@@ -173,7 +170,7 @@ Merge it into the previous summary per the rules above and return exactly one <s
 	return nil
 }
 
-func latestTime(messages []provider.Message) string {
+func latestTime(messages []sessionHistory.Record) string {
 	var str string
 	for _, message := range messages {
 		t := extractTime(message)
@@ -184,15 +181,9 @@ func latestTime(messages []provider.Message) string {
 	return str
 }
 
-func extractTime(msg provider.Message) string {
-	str, ok := msg.Content.(string)
-	if !ok {
+func extractTime(msg sessionHistory.Record) string {
+	if msg.SendAt <= 0 {
 		return ""
 	}
-
-	list := hisroryTimeRegex.FindStringSubmatch(str)
-	if len(list) < 2 {
-		return ""
-	}
-	return list[1]
+	return time.Unix(0, msg.SendAt).Format(sessionHistory.TimeLayout)
 }

--- a/internal/agents/types/agent.go
+++ b/internal/agents/types/agent.go
@@ -39,6 +39,8 @@ type AgentSession struct {
 	Tools          []provider.Message
 	Histories      []provider.Message
 	BaseLen        int
+	Sender         string
+	UserSendAt     int64
 	Stateless      bool
 	ToolCheckpoint int
 }

--- a/internal/filesystem/runtime.go
+++ b/internal/filesystem/runtime.go
@@ -44,10 +44,10 @@ var (
 const Port = "17989"
 
 type RuntimeLimits struct {
-	MaxToolIterations   int    `json:"max_tool_iterations,omitempty"`
-	AgentSendTimeoutSec int    `json:"agent_send_timeout_seconds,omitempty"`
-	MaxHistoryMessages  int    `json:"max_history_messages,omitempty"`
-	MaxHistoryBytes     int    `json:"max_history_bytes,omitempty"`
+	MaxToolIterations   int `json:"max_tool_iterations,omitempty"`
+	AgentSendTimeoutSec int `json:"agent_send_timeout_seconds,omitempty"`
+	MaxHistoryMessages  int `json:"max_history_messages,omitempty"`
+	MaxHistoryBytes     int `json:"max_history_bytes,omitempty"`
 }
 
 func LoadRuntime() error {

--- a/internal/runtime/discord/resume.go
+++ b/internal/runtime/discord/resume.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 	"os"
 	"strings"
-	"time"
 
 	go_bot_discord "github.com/pardnchiu/go-bot/discord"
 
@@ -62,7 +61,7 @@ func (b *Bot) resumeFromPending(sessionID, taskHash string, answers []any) {
 		scanner.Scan()
 	}
 
-	userText := fmt.Sprintf("---\n當前時間: %s\n工作目錄: %s\n---\n%s", time.Now().Format("2006-01-02 15:04:05"), workDir, full)
+	userText := full
 	sessionLog.Append(sessionID, userText)
 
 	primary, rest, err := exec.ResolveAgent(ctx, agents.DispatcherBot(), agents.Registry(), full, false, sessionID)
@@ -79,6 +78,7 @@ func (b *Bot) resumeFromPending(sessionID, taskHash string, answers []any) {
 		WorkDir:        workDir,
 		Content:        full,
 		Input:          userText,
+		Sender:         "user",
 		ExcludeTools:   tools.TUIOnlyTools,
 		ExcludeSkills:  tools.TUIOnlySkills,
 		PendingTask:    taskHash,

--- a/internal/runtime/discord/run.go
+++ b/internal/runtime/discord/run.go
@@ -25,7 +25,6 @@ import (
 	sessionLog "github.com/pardnchiu/agenvoy/internal/session/log"
 	"github.com/pardnchiu/agenvoy/internal/tools"
 	"github.com/pardnchiu/agenvoy/internal/utils"
-	provider "github.com/pardnchiu/go-llm-router/core"
 	geminiSummary "github.com/pardnchiu/go-llm-router/core/gemini/summary"
 )
 
@@ -54,9 +53,12 @@ func recordChatter(in go_bot_discord.Input, content string) {
 	if username == "" {
 		username = "unknown"
 	}
-	if err := sessionHistory.Append(sessionID, []provider.Message{
-		{Role: "user", Content: fmt.Sprintf("%s: %s", username, content)},
-	}); err != nil {
+	if err := sessionHistory.Append(sessionID, []sessionHistory.Record{{
+		Role:    "user",
+		Content: content,
+		SendAt:  time.Now().UnixNano(),
+		Sender:  username,
+	}}); err != nil {
 		slog.Warn("sessionHistory.Append (chatter)",
 			slog.String("channel", channelName(in)),
 			slog.String("error", err.Error()))
@@ -217,14 +219,7 @@ func run(ctx context.Context, b *Bot, in go_bot_discord.Input) error {
 		return fmt.Errorf("github.com/pardnchiu/agenvoy/internal/session GetDiscordSession: %w", err)
 	}
 
-	header := fmt.Sprintf("當前時間: %s\n工作目錄: %s\n傳送者: %s\n當前 channel: %s",
-		time.Now().Format("2006-01-02 15:04:05"),
-		workDir,
-		in.Username,
-		channelName(in),
-	)
-	userText := fmt.Sprintf("---\n%s\n---\n%s", header, content)
-	sessionLog.Append(discordSessionID, userText)
+	sessionLog.Append(discordSessionID, content)
 
 	agent, fallbacks, err := exec.ResolveAgent(ctx, agents.DispatcherBot(), agents.Registry(), content, matchedSkill != nil, discordSessionID)
 	if err != nil {
@@ -245,11 +240,12 @@ func run(ctx context.Context, b *Bot, in go_bot_discord.Input) error {
 		WorkDir:        workDir,
 		Skill:          matchedSkill,
 		Content:        content,
-		Input:          userText,
+		Input:          content,
 		ExcludeTools:   chatbot.RuntimeExcludeTools(autoTranscribed),
 		ExcludeSkills:  tools.TUIOnlySkills,
 		AllowAll:       false,
 		ReplyMessageID: in.MessageID,
+		Sender:         in.Username,
 	}
 
 	sess, err := getSession(ctx, in, content, execData)

--- a/internal/runtime/discord/session.go
+++ b/internal/runtime/discord/session.go
@@ -30,39 +30,44 @@ func getSession(ctx context.Context, in go_bot_discord.Input, content string, da
 	}
 
 	oldHistory, maxHistory := sessionHistory.Get(sessionID)
-	sess.Histories = oldHistory
-	sess.BaseLen = len(oldHistory)
+	sess.Histories = sessionHistory.Messages(oldHistory)
+	sess.BaseLen = len(sess.Histories)
 
 	sess.SystemPrompts = exec.BuildSystemPrompts(data.WorkDir, data.ExtraSystemPrompt, agents.Scanner(), sessionID, data.AllowAll, data.ExcludeSkills)
 	if summary := summary.GetPrompt(sessionID, exec.OldestMessageTime(maxHistory)); summary != "" {
 		sess.SummaryMessage = provider.Message{Role: "user", Content: summary}
 	}
 
-	sess.OldHistories = maxHistory
+	sess.OldHistories = sessionHistory.Messages(maxHistory)
 	sess.ToolHistories = []provider.Message{}
 
 	userText := strings.TrimSpace(data.Input)
 	if userText == "" {
-		header := fmt.Sprintf("當前時間: %s\n工作目錄: %s\n傳送者: %s\n當前 channel: %s",
-			time.Now().Format("2006-01-02 15:04:05"),
-			data.WorkDir,
-			in.Username,
-			channelName(in),
-		)
-		userText = fmt.Sprintf("---\n%s\n---\n%s", header, strings.TrimSpace(content))
+		userText = strings.TrimSpace(content)
 	}
 
 	histText := userText
 	if h := strings.TrimSpace(data.HistoryContent); h != "" {
 		histText = h
 	}
+
+	sess.Sender = strings.TrimSpace(in.Username)
+	if sess.Sender == "" {
+		sess.Sender = strings.TrimSpace(data.Sender)
+	}
+	sess.UserSendAt = time.Now().UnixNano()
+	prefix := sessionHistory.Record{
+		SendAt: sess.UserSendAt,
+		Sender: sess.Sender,
+	}.Prefix()
+
 	sess.Histories = append(sess.Histories, provider.Message{
 		Role:    "user",
-		Content: histText,
+		Content: sessionHistory.WithPrefix(prefix, histText),
 	})
 	sess.UserInput = provider.Message{
 		Role:    "user",
-		Content: userText,
+		Content: sessionHistory.WithPrefix(prefix, userText),
 	}
 	exec.SaveUserInputHistory(ctx, sessionID, histText)
 

--- a/internal/runtime/routes/handler/chatCompletions/run.go
+++ b/internal/runtime/routes/handler/chatCompletions/run.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pardnchiu/agenvoy/internal/agents/exec"
 	agentTypes "github.com/pardnchiu/agenvoy/internal/agents/types"
 	"github.com/pardnchiu/agenvoy/internal/runtime"
+	sessionHistory "github.com/pardnchiu/agenvoy/internal/session/history"
 	"github.com/pardnchiu/agenvoy/internal/tools"
 	provider "github.com/pardnchiu/go-llm-router/core"
 )
@@ -89,8 +90,10 @@ func buildStatelessSession(req Request, userInput, workDir string, scanner *runt
 		oldHistories = append(oldHistories, req.Messages[:lastUserIdx]...)
 	}
 
-	wrappedUser := fmt.Sprintf("---\n當前時間: %s\n工作目錄: %s\n---\n%s",
-		time.Now().Format("2006-01-02 15:04:05"), workDir, userInput)
+	wrappedUser := sessionHistory.WithPrefix(
+		sessionHistory.Record{SendAt: time.Now().UnixNano()}.Prefix(),
+		userInput,
+	)
 
 	return &agentTypes.AgentSession{
 		SystemPrompts: systemPrompts,

--- a/internal/runtime/routes/handler/send.go
+++ b/internal/runtime/routes/handler/send.go
@@ -2,7 +2,6 @@ package handler
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
@@ -94,8 +93,7 @@ func Send() gin.HandlerFunc {
 			}
 
 			workDir, _ := os.UserHomeDir()
-			userText := fmt.Sprintf("---\n當前時間: %s\n工作目錄: %s\n---\n%s",
-				time.Now().Format("2006-01-02 15:04:05"), workDir, trimContent)
+			userText := trimContent
 			if sessionID != "" {
 				sessionLog.Append(sessionID, userText)
 			}
@@ -178,9 +176,9 @@ func newSession(ctx context.Context, data exec.ExecuteMeta, sessionID string) (*
 	session.SystemPrompts = exec.BuildSystemPrompts(data.WorkDir, data.ExtraSystemPrompt, scanner, sessionID, data.AllowAll, data.ExcludeSkills)
 
 	oldHistory, maxHistory := sessionHistory.Get(sessionID)
-	session.Histories = oldHistory
-	session.BaseLen = len(oldHistory)
-	session.OldHistories = maxHistory
+	session.Histories = sessionHistory.Messages(oldHistory)
+	session.BaseLen = len(session.Histories)
+	session.OldHistories = sessionHistory.Messages(maxHistory)
 
 	if summary := summary.GetPrompt(sessionID, exec.OldestMessageTime(maxHistory)); summary != "" {
 		session.SummaryMessage = provider.Message{Role: "user", Content: summary}
@@ -189,13 +187,20 @@ func newSession(ctx context.Context, data exec.ExecuteMeta, sessionID string) (*
 
 	userText := strings.TrimSpace(data.Input)
 	if userText == "" {
-		userText = fmt.Sprintf("---\n當前時間: %s\n工作目錄: %s\n---\n%s",
-			time.Now().Format("2006-01-02 15:04:05"), data.WorkDir, data.Content)
+		userText = strings.TrimSpace(data.Content)
 	}
-	session.UserInput = provider.Message{Role: "user", Content: userText}
+
+	session.Sender = data.Sender
+	session.UserSendAt = time.Now().UnixNano()
+	prefixed := sessionHistory.WithPrefix(sessionHistory.Record{
+		SendAt: session.UserSendAt,
+		Sender: session.Sender,
+	}.Prefix(), userText)
+
+	session.UserInput = provider.Message{Role: "user", Content: prefixed}
 	session.Histories = append(session.Histories, provider.Message{
 		Role:    "user",
-		Content: userText,
+		Content: prefixed,
 	})
 	exec.SaveUserInputHistory(ctx, sessionID, userText)
 

--- a/internal/runtime/telegram/resume.go
+++ b/internal/runtime/telegram/resume.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/pardnchiu/agenvoy/internal/agents"
 	"github.com/pardnchiu/agenvoy/internal/agents/exec"
@@ -62,7 +61,7 @@ func (b *Bot) resumeFromPending(sessionID, taskHash string, answers []any) {
 		scanner.Scan()
 	}
 
-	userText := fmt.Sprintf("---\n當前時間: %s\n工作目錄: %s\n---\n%s", time.Now().Format("2006-01-02 15:04:05"), workDir, full)
+	userText := full
 	sessionLog.Append(sessionID, userText)
 
 	primary, rest, err := exec.ResolveAgent(ctx, agents.DispatcherBot(), agents.Registry(), full, false, sessionID)
@@ -80,6 +79,7 @@ func (b *Bot) resumeFromPending(sessionID, taskHash string, answers []any) {
 		WorkDir:        workDir,
 		Content:        full,
 		Input:          userText,
+		Sender:         "user",
 		ExcludeTools:   tools.TUIOnlyTools,
 		ExcludeSkills:  tools.TUIOnlySkills,
 		PendingTask:    taskHash,

--- a/internal/runtime/telegram/run.go
+++ b/internal/runtime/telegram/run.go
@@ -28,7 +28,6 @@ import (
 	"github.com/pardnchiu/agenvoy/internal/tools"
 	"github.com/pardnchiu/agenvoy/internal/utils"
 	go_bot_telegram "github.com/pardnchiu/go-bot/telegram"
-	provider "github.com/pardnchiu/go-llm-router/core"
 	geminiSummary "github.com/pardnchiu/go-llm-router/core/gemini/summary"
 	"github.com/pardnchiu/go-pkg/filesystem/keychain"
 )
@@ -79,9 +78,12 @@ func recordChatter(in go_bot_telegram.Input, content string) {
 	if username == "" {
 		username = "unknown"
 	}
-	if err := sessionHistory.Append(sessionID, []provider.Message{
-		{Role: "user", Content: fmt.Sprintf("%s: %s", username, content)},
-	}); err != nil {
+	if err := sessionHistory.Append(sessionID, []sessionHistory.Record{{
+		Role:    "user",
+		Content: content,
+		SendAt:  time.Now().UnixNano(),
+		Sender:  username,
+	}}); err != nil {
 		slog.Warn("sessionHistory.Append (chatter)",
 			slog.Int64("chat", in.ChatID),
 			slog.String("error", err.Error()))
@@ -268,13 +270,7 @@ func run(ctx context.Context, b *Bot, in go_bot_telegram.Input, attachInputs []g
 		routingSessionID = cs
 	}
 
-	header := fmt.Sprintf("當前時間: %s\n工作目錄: %s\n傳送者: %s\n當前 chat ID: %d",
-		time.Now().Format("2006-01-02 15:04:05"),
-		workDir,
-		in.Username,
-		in.ChatID,
-	)
-	userText := fmt.Sprintf("---\n%s\n---\n%s", header, content)
+	userText := content
 	sessionLog.Append(routingSessionID, userText)
 
 	agent, fallbacks, err := exec.ResolveAgent(ctx, agents.DispatcherBot(), agents.Registry(), content, matchedSkill != nil, routingSessionID)
@@ -303,6 +299,7 @@ func run(ctx context.Context, b *Bot, in go_bot_telegram.Input, attachInputs []g
 		Skill:          matchedSkill,
 		Content:        content,
 		Input:          userText,
+		Sender:         in.Username,
 		ExcludeTools:   chatbot.RuntimeExcludeTools(autoTranscribed),
 		ExcludeSkills:  tools.TUIOnlySkills,
 		AllowAll:       false,

--- a/internal/runtime/telegram/session.go
+++ b/internal/runtime/telegram/session.go
@@ -33,39 +33,44 @@ func getSession(ctx context.Context, chatID int64, username, content string, dat
 	}
 
 	oldHistory, maxHistory := sessionHistory.Get(histSessionID)
-	sess.Histories = oldHistory
-	sess.BaseLen = len(oldHistory)
+	sess.Histories = sessionHistory.Messages(oldHistory)
+	sess.BaseLen = len(sess.Histories)
 
 	sess.SystemPrompts = exec.BuildSystemPrompts(data.WorkDir, data.ExtraSystemPrompt, agents.Scanner(), chatSessionID, data.AllowAll, data.ExcludeSkills)
 	if summary := summary.GetPrompt(histSessionID, exec.OldestMessageTime(maxHistory)); summary != "" {
 		sess.SummaryMessage = provider.Message{Role: "user", Content: summary}
 	}
 
-	sess.OldHistories = maxHistory
+	sess.OldHistories = sessionHistory.Messages(maxHistory)
 	sess.ToolHistories = []provider.Message{}
 
 	userText := strings.TrimSpace(data.Input)
 	if userText == "" {
-		header := fmt.Sprintf("當前時間: %s\n工作目錄: %s\n傳送者: %s\n當前 chat ID: %d",
-			time.Now().Format("2006-01-02 15:04:05"),
-			data.WorkDir,
-			username,
-			chatID,
-		)
-		userText = fmt.Sprintf("---\n%s\n---\n%s", header, strings.TrimSpace(content))
+		userText = strings.TrimSpace(content)
 	}
 
 	histText := userText
 	if h := strings.TrimSpace(data.HistoryContent); h != "" {
 		histText = h
 	}
+
+	sess.Sender = strings.TrimSpace(username)
+	if sess.Sender == "" {
+		sess.Sender = strings.TrimSpace(data.Sender)
+	}
+	sess.UserSendAt = time.Now().UnixNano()
+	prefix := sessionHistory.Record{
+		SendAt: sess.UserSendAt,
+		Sender: sess.Sender,
+	}.Prefix()
+
 	sess.Histories = append(sess.Histories, provider.Message{
 		Role:    "user",
-		Content: histText,
+		Content: sessionHistory.WithPrefix(prefix, histText),
 	})
 	sess.UserInput = provider.Message{
 		Role:    "user",
-		Content: userText,
+		Content: sessionHistory.WithPrefix(prefix, userText),
 	}
 	exec.SaveUserInputHistory(ctx, histSessionID, histText)
 

--- a/internal/runtime/tui/handlerLogFormat.go
+++ b/internal/runtime/tui/handlerLogFormat.go
@@ -9,12 +9,12 @@ import (
 	"time"
 
 	agentTypes "github.com/pardnchiu/agenvoy/internal/agents/types"
+	sessionHistory "github.com/pardnchiu/agenvoy/internal/session/history"
 	sessionLog "github.com/pardnchiu/agenvoy/internal/session/log"
 	sessionTUI "github.com/pardnchiu/agenvoy/internal/session/tui"
 	provider "github.com/pardnchiu/go-llm-router/core"
 )
 
-var userWrapperRe = regexp.MustCompile(`^---\n當前時間:[^\n]*\n(?:[^\n]+\n)*?---\n`)
 var cacheHitPctRe = regexp.MustCompile(`^\((\d+)%\)$`)
 
 type parsedAction struct {
@@ -65,7 +65,7 @@ func renderActionLine(p parsedAction, width int) string {
 
 	switch p.kind {
 	case "user":
-		body = userWrapperRe.ReplaceAllString(body, "")
+		body = sessionHistory.StripPrefix(body)
 		if strings.Contains(body, "[Resumed Task") {
 			return ""
 		}

--- a/internal/session/history/compact.go
+++ b/internal/session/history/compact.go
@@ -9,10 +9,9 @@ import (
 	"github.com/pardnchiu/agenvoy/internal/filesystem"
 	"github.com/pardnchiu/agenvoy/internal/runtime/torii"
 	historyStore "github.com/pardnchiu/agenvoy/internal/session/history/store"
-	provider "github.com/pardnchiu/go-llm-router/core"
 )
 
-func compact(sessionID, historyPath string, messages []provider.Message, currentBytes int) {
+func compact(sessionID, historyPath string, messages []Record, currentBytes int) {
 	if len(messages) < 4 {
 		return
 	}
@@ -109,12 +108,10 @@ func getTimestamp(key string) (int64, bool) {
 	return ts, true
 }
 
-func getStartAt(messages []provider.Message) int64 {
+func getStartAt(messages []Record) int64 {
 	for _, msg := range messages {
-		content := historyStore.ExtractContent(msg.Content)
-		ts := historyStore.ExtractTimestamp(content)
-		if ts > 0 {
-			return ts
+		if msg.SendAt > 0 {
+			return msg.SendAt
 		}
 	}
 	return 0

--- a/internal/session/history/history.go
+++ b/internal/session/history/history.go
@@ -10,12 +10,11 @@ import (
 
 	"github.com/pardnchiu/agenvoy/internal/filesystem"
 	historyStore "github.com/pardnchiu/agenvoy/internal/session/history/store"
-	provider "github.com/pardnchiu/go-llm-router/core"
 )
 
 var muMap sync.Map
 
-func Append(sessionID string, delta []provider.Message) error {
+func Append(sessionID string, delta []Record) error {
 	if sessionID == "" || len(delta) == 0 {
 		return nil
 	}
@@ -27,10 +26,11 @@ func Append(sessionID string, delta []provider.Message) error {
 
 	historyPath := filesystem.HistoryPath(sessionID)
 
-	latest, err := go_pkg_filesystem.ReadJSON[[]provider.Message](historyPath)
+	latest, err := go_pkg_filesystem.ReadJSON[[]Record](historyPath)
 	if err != nil {
 		latest = nil
 	}
+	latest = normalize(latest)
 	latest = append(latest, delta...)
 
 	raw, err := json.Marshal(latest)
@@ -42,13 +42,13 @@ func Append(sessionID string, delta []provider.Message) error {
 	}
 
 	if historyStore.IsReady() && !historyStore.IsExist(sessionID) && len(latest) > len(delta) {
-		if err := historyStore.Write(sessionID, latest); err != nil {
+		if err := historyStore.Write(sessionID, rows(latest)); err != nil {
 			slog.Warn("historyStore Write",
 				slog.String("session", sessionID),
 				slog.String("error", err.Error()))
 		}
 	} else {
-		if err := historyStore.Write(sessionID, delta); err != nil {
+		if err := historyStore.Write(sessionID, rows(delta)); err != nil {
 			slog.Warn("historyStore Write",
 				slog.String("session", sessionID),
 				slog.String("error", err.Error()))
@@ -66,12 +66,13 @@ func ClearMutex(sessionID string) {
 	muMap.Delete(sessionID)
 }
 
-func Get(sessionID string) (old, max []provider.Message) {
+func Get(sessionID string) (old, max []Record) {
 	historyPath := filesystem.HistoryPath(sessionID)
-	oldHistory, err := go_pkg_filesystem.ReadJSON[[]provider.Message](historyPath)
+	oldHistory, err := go_pkg_filesystem.ReadJSON[[]Record](historyPath)
 	if err != nil {
 		return nil, nil
 	}
+	oldHistory = normalize(oldHistory)
 
 	maxHistory := oldHistory
 	if len(oldHistory) > filesystem.MaxHistoryMessages {

--- a/internal/session/history/record.go
+++ b/internal/session/history/record.go
@@ -1,0 +1,145 @@
+package history
+
+import (
+	"regexp"
+	"strings"
+	"time"
+
+	historyStore "github.com/pardnchiu/agenvoy/internal/session/history/store"
+	provider "github.com/pardnchiu/go-llm-router/core"
+)
+
+const TimeLayout = "2006-01-02 15:04:05"
+
+var (
+	prefixRegex       = regexp.MustCompile(`\A\s*(?:sendAt|sender|channelId)\s*:[^\n]*\n`)
+	prefixHeadRegex   = regexp.MustCompile(`^(?:sendAt|sender|channelId)\s*:`)
+	legacyBlockRegex  = regexp.MustCompile(`\A\s*-{3,}\n?(?:(?:當前時間|工作目錄|傳送者|當前 chat ID|當前 channel)[^\n]*\n?)+-{3,}\n?`)
+	legacyLineRegex   = regexp.MustCompile(`\A\s*(?:當前時間|工作目錄|傳送者|當前 chat ID|當前 channel)\s*[:：][^\n]*\n?`)
+	legacyTimeRegex   = regexp.MustCompile(`當前時間:\s*(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})`)
+	legacySenderRegex = regexp.MustCompile(`傳送者:\s*([^\n]*)`)
+)
+
+type Record struct {
+	Role    string `json:"role"`
+	Content any    `json:"content"`
+	SendAt  int64  `json:"sendAt,omitempty"`
+	Sender  string `json:"sender,omitempty"`
+}
+
+func (r Record) Prefix() string {
+	var parts []string
+	if r.SendAt > 0 {
+		parts = append(parts, "sendAt: "+time.Unix(0, r.SendAt).Format(TimeLayout))
+	}
+	if r.Sender != "" {
+		parts = append(parts, "sender: "+r.Sender)
+	}
+	return strings.Join(parts, ", ")
+}
+
+func (r Record) Message() provider.Message {
+	return provider.Message{
+		Role:    r.Role,
+		Content: WithPrefix(r.Prefix(), r.Content),
+	}
+}
+
+func (r Record) Text() string {
+	return historyStore.ExtractContent(r.Content)
+}
+
+func WithPrefix(prefix string, content any) any {
+	if prefix == "" {
+		return content
+	}
+
+	switch value := content.(type) {
+	case string:
+		return prefix + "\n" + value
+
+	case []provider.ContentPart:
+		for i, part := range value {
+			if part.Type != "text" {
+				continue
+			}
+			out := append([]provider.ContentPart(nil), value...)
+			out[i].Text = prefix + "\n" + part.Text
+			return out
+		}
+		return append([]provider.ContentPart{{Type: "text", Text: prefix}}, value...)
+
+	case nil:
+		return prefix
+
+	default:
+		return content
+	}
+}
+
+func StripPrefix(content string) string {
+	content = legacyBlockRegex.ReplaceAllString(content, "")
+	for {
+		trimmed := legacyLineRegex.ReplaceAllString(content, "")
+		if trimmed == content {
+			break
+		}
+		content = trimmed
+	}
+	return prefixRegex.ReplaceAllString(content, "")
+}
+
+func HasPrefix(line string) bool {
+	return prefixHeadRegex.MatchString(line)
+}
+
+func Messages(list []Record) []provider.Message {
+	if len(list) == 0 {
+		return nil
+	}
+	out := make([]provider.Message, 0, len(list))
+	for _, r := range list {
+		out = append(out, r.Message())
+	}
+	return out
+}
+
+func normalize(list []Record) []Record {
+	for i, r := range list {
+		str, ok := r.Content.(string)
+		if !ok {
+			continue
+		}
+		if r.SendAt == 0 {
+			if match := legacyTimeRegex.FindStringSubmatch(str); len(match) > 1 {
+				if t, err := time.ParseInLocation(TimeLayout, match[1], time.Local); err == nil {
+					list[i].SendAt = t.UnixNano()
+				}
+			}
+		}
+		if r.Sender == "" {
+			if match := legacySenderRegex.FindStringSubmatch(str); len(match) > 1 {
+				list[i].Sender = strings.TrimSpace(match[1])
+			}
+		}
+		list[i].Content = StripPrefix(str)
+	}
+	return list
+}
+
+func rows(list []Record) []historyStore.Row {
+	out := make([]historyStore.Row, 0, len(list))
+	for _, r := range list {
+		content := r.Text()
+		if strings.TrimSpace(content) == "" {
+			continue
+		}
+		out = append(out, historyStore.Row{
+			SendAt:  r.SendAt,
+			Role:    r.Role,
+			Content: content,
+			Sender:  r.Sender,
+		})
+	}
+	return out
+}

--- a/internal/session/history/replace.go
+++ b/internal/session/history/replace.go
@@ -9,10 +9,9 @@ import (
 
 	"github.com/pardnchiu/agenvoy/internal/filesystem"
 	"github.com/pardnchiu/agenvoy/internal/runtime/torii"
-	provider "github.com/pardnchiu/go-llm-router/core"
 )
 
-func Replace(sessionID string, messages []provider.Message) error {
+func Replace(sessionID string, messages []Record) error {
 	if sessionID == "" {
 		return fmt.Errorf("session id is required")
 	}

--- a/internal/session/history/store/migrate.sql
+++ b/internal/session/history/store/migrate.sql
@@ -3,7 +3,8 @@ CREATE TABLE IF NOT EXISTS messages (
     session_id   TEXT    NOT NULL,
     send_at      INTEGER NOT NULL DEFAULT 0,
     role         TEXT    NOT NULL,
-    content      TEXT    NOT NULL
+    content      TEXT    NOT NULL,
+    sender       TEXT    NOT NULL DEFAULT ''
 );
 
 CREATE INDEX IF NOT EXISTS idx_messages_session_send_at

--- a/internal/session/history/store/search.go
+++ b/internal/session/history/store/search.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"fmt"
+	"math"
 	"strings"
 	"time"
 )
@@ -10,6 +11,7 @@ type Result struct {
 	Timestamp int64
 	Role      string
 	Content   string
+	Sender    string
 }
 
 var searchTimeRanges = map[string]time.Duration{
@@ -34,10 +36,13 @@ func Search(sessionID, keyword, timeRange string, limit int) ([]Result, error) {
 		after = time.Now().Add(-d).UnixNano()
 	}
 
-	before := max(jsonStart, 0)
+	before := int64(math.MaxInt64)
+	if jsonStart > 0 {
+		before = jsonStart
+	}
 
 	rows, err := conn.Query(`
-	SELECT m.send_at, m.role, m.content
+	SELECT m.send_at, m.role, m.content, m.sender
 	FROM messages m
 	WHERE m.session_id = ?
 	AND m.id IN (SELECT rowid FROM messages_fts5 WHERE messages_fts5 MATCH ?)
@@ -54,7 +59,7 @@ func Search(sessionID, keyword, timeRange string, limit int) ([]Result, error) {
 	var list []Result
 	for rows.Next() {
 		var result Result
-		if err := rows.Scan(&result.Timestamp, &result.Role, &result.Content); err != nil {
+		if err := rows.Scan(&result.Timestamp, &result.Role, &result.Content, &result.Sender); err != nil {
 			continue
 		}
 		list = append(list, result)

--- a/internal/session/history/store/store.go
+++ b/internal/session/history/store/store.go
@@ -30,9 +30,57 @@ func New(dbPath string) error {
 			initErr = fmt.Errorf("sql.DB Exec [migrate]: %w", err)
 			return
 		}
+		if err := syncColumns(c); err != nil {
+			c.Close()
+			initErr = err
+			return
+		}
 		conn = c
 	})
 	return initErr
+}
+
+func syncColumns(c *go_sqlkit_core.Connector) error {
+	rows, err := c.Query(`PRAGMA table_info(messages)`)
+	if err != nil {
+		return fmt.Errorf("sql.DB Query [PRAGMA table_info]: %w", err)
+	}
+	defer rows.Close()
+
+	existing := make(map[string]bool)
+	for rows.Next() {
+		var (
+			cid, notNull, pk int
+			name, dataType   string
+			defaultValue     any
+		)
+		if err := rows.Scan(&cid, &name, &dataType, &notNull, &defaultValue, &pk); err != nil {
+			return fmt.Errorf("sql.Rows Scan [PRAGMA table_info]: %w", err)
+		}
+		existing[name] = true
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("sql.Rows Err [PRAGMA table_info]: %w", err)
+	}
+
+	for _, name := range []string{"sender"} {
+		if existing[name] {
+			continue
+		}
+		if _, err := c.Exec(fmt.Sprintf(`ALTER TABLE messages ADD COLUMN %s TEXT NOT NULL DEFAULT ''`, name)); err != nil {
+			return fmt.Errorf("sql.DB Exec [ALTER TABLE messages ADD COLUMN %s]: %w", name, err)
+		}
+	}
+
+	for _, name := range []string{"channel_id"} {
+		if !existing[name] {
+			continue
+		}
+		if _, err := c.Exec(fmt.Sprintf(`ALTER TABLE messages DROP COLUMN %s`, name)); err != nil {
+			return fmt.Errorf("sql.DB Exec [ALTER TABLE messages DROP COLUMN %s]: %w", name, err)
+		}
+	}
+	return nil
 }
 
 func Close() {

--- a/internal/session/history/store/write.go
+++ b/internal/session/history/store/write.go
@@ -2,17 +2,20 @@ package store
 
 import (
 	"fmt"
-	"regexp"
 	"strings"
-	"time"
 
 	provider "github.com/pardnchiu/go-llm-router/core"
 )
 
-var timestampRegex = regexp.MustCompile(`當前時間:\s*(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})`)
+type Row struct {
+	SendAt  int64
+	Role    string
+	Content string
+	Sender  string
+}
 
-func Write(sessionID string, messages []provider.Message) error {
-	if conn == nil || len(messages) == 0 {
+func Write(sessionID string, list []Row) error {
+	if conn == nil || len(list) == 0 {
 		return nil
 	}
 
@@ -23,21 +26,20 @@ func Write(sessionID string, messages []provider.Message) error {
 	defer tx.Rollback()
 
 	stmt, err := tx.Prepare(`
-	INSERT INTO messages (session_id, send_at, role, content)
-	VALUES (?, ?, ?, ?)`)
+	INSERT INTO messages (session_id, send_at, role, content, sender)
+	VALUES (?, ?, ?, ?, ?)`)
 	if err != nil {
 		return fmt.Errorf("sql.Tx Prepare [INSERT messages]: %w", err)
 	}
 	defer stmt.Close()
 
 	var lastTS int64
-	for _, msg := range messages {
-		content := ExtractContent(msg.Content)
-		if strings.TrimSpace(content) == "" {
+	for _, row := range list {
+		if strings.TrimSpace(row.Content) == "" {
 			continue
 		}
 
-		ts := ExtractTimestamp(content)
+		ts := row.SendAt
 		if ts == 0 && lastTS > 0 {
 			ts = lastTS + 1
 		}
@@ -45,7 +47,7 @@ func Write(sessionID string, messages []provider.Message) error {
 			lastTS = ts
 		}
 
-		if _, err := stmt.Exec(sessionID, ts, msg.Role, content); err != nil {
+		if _, err := stmt.Exec(sessionID, ts, row.Role, row.Content, row.Sender); err != nil {
 			return fmt.Errorf("sql.Stmt Exec: %w", err)
 		}
 	}
@@ -57,6 +59,15 @@ func ExtractContent(content any) string {
 	switch val := content.(type) {
 	case string:
 		return val
+
+	case []provider.ContentPart:
+		var parts []string
+		for _, part := range val {
+			if part.Type == "text" && part.Text != "" {
+				parts = append(parts, part.Text)
+			}
+		}
+		return strings.Join(parts, "\n")
 
 	case []any:
 		var parts []string
@@ -79,19 +90,6 @@ func ExtractContent(content any) string {
 		}
 		return fmt.Sprint(content)
 	}
-}
-
-func ExtractTimestamp(content string) int64 {
-	match := timestampRegex.FindStringSubmatch(content)
-	if len(match) < 2 {
-		return 0
-	}
-
-	t, err := time.ParseInLocation("2006-01-02 15:04:05", match[1], time.Local)
-	if err != nil {
-		return 0
-	}
-	return t.UnixNano()
 }
 
 func Clear(sessionID string) error {

--- a/internal/session/log/compact.go
+++ b/internal/session/log/compact.go
@@ -7,6 +7,7 @@ import (
 	go_pkg_filesystem "github.com/pardnchiu/go-pkg/filesystem"
 
 	"github.com/pardnchiu/agenvoy/internal/filesystem"
+	sessionHistory "github.com/pardnchiu/agenvoy/internal/session/history"
 )
 
 func RetainExchanges(sessionID string, keptRawContents []string) {
@@ -18,7 +19,7 @@ func RetainExchanges(sessionID string, keptRawContents []string) {
 
 	keepSet := make(map[string]bool, len(keptRawContents))
 	for _, c := range keptRawContents {
-		keepSet[flatten(strings.TrimSpace(c))] = true
+		keepSet[canonical(c)] = true
 	}
 
 	lines := strings.Split(text, "\n")
@@ -44,7 +45,7 @@ func RetainExchanges(sessionID string, keptRawContents []string) {
 
 	removeLine := make([]bool, len(lines))
 	for _, b := range blocks {
-		if !keepSet[b.userBody] {
+		if !keepSet[canonical(b.userBody)] {
 			for j := b.start; j < b.end; j++ {
 				removeLine[j] = true
 			}
@@ -66,6 +67,11 @@ func RetainExchanges(sessionID string, keptRawContents []string) {
 			slog.String("session", sessionID),
 			slog.String("error", err.Error()))
 	}
+}
+
+func canonical(str string) string {
+	str = strings.ReplaceAll(str, ActionNewlineMarker, "\n")
+	return flatten(strings.TrimSpace(sessionHistory.StripPrefix(str)))
 }
 
 func extractKindBody(line, kind string) (string, bool) {

--- a/internal/tools/searchConversationHistory.go
+++ b/internal/tools/searchConversationHistory.go
@@ -133,7 +133,11 @@ func keywordHandler(_ context.Context, sessionID, keyword, timeRange string, lim
 		sb.WriteString("[archive]\n")
 		for _, r := range reults {
 			tsStr := time.Unix(0, r.Timestamp).Format(time.RFC3339)
-			sb.WriteString(fmt.Sprintf("[%s · %s] %s\n", tsStr, r.Role, r.Content))
+			who := r.Role
+			if r.Sender != "" {
+				who = r.Role + " · " + r.Sender
+			}
+			sb.WriteString(fmt.Sprintf("[%s · %s] %s\n", tsStr, who, r.Content))
 		}
 	}
 
@@ -338,8 +342,9 @@ func decodeHit(key string, ts int64, val string) (historyHit, bool) {
 	if err := json.Unmarshal([]byte(val), &msg); err != nil {
 		return historyHit{}, false
 	}
-	if strings.TrimSpace(msg.Content) == "" {
+	content := strings.TrimSpace(sessionHistory.StripPrefix(msg.Content))
+	if content == "" {
 		return historyHit{}, false
 	}
-	return historyHit{Key: key, TS: ts, Role: msg.Role, Content: msg.Content}, true
+	return historyHit{Key: key, TS: ts, Role: msg.Role, Content: content}, true
 }


### PR DESCRIPTION
Session history moves send time and sender out of message text into structured fields, with one-way on-read migration from legacy prefixes. Runtime and store paths follow the new shape end to end. **Do not downgrade after upgrading** — written history is not backward-compatible with older readers.
