### PR TITLE
Fix release version stamping and ldflags symbol resolution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,8 +53,22 @@ jobs:
           GOARCH: ${{ matrix.goarch }}
         run: |
           go build -trimpath -tags fts5 \
-            -ldflags "-s -w -X github.com/pardnchiu/agenvoy/internal/version.Current=${GITHUB_REF_NAME}" \
+            -ldflags "-s -w -X github.com/pardnchiu/agenvoy/internal/runtime.CurrentVersion=${GITHUB_REF_NAME}" \
             -o agen ./cmd/app/
+
+      # -X against a symbol that no longer resolves is silently ignored by the
+      # linker — v0.32.12 shipped printing "dev" because the variable had moved
+      # package. Nothing in the built artifact reveals that, so check the symbol
+      # named in the ldflags above still exists in the source being built.
+      - name: Verify ldflags symbol resolves
+        run: |
+          set -euo pipefail
+          sym="$(grep -o 'X github.com/pardnchiu/agenvoy/[^=]*' .github/workflows/release.yml | head -1 | cut -d' ' -f2)"
+          pkg="${sym%.*}"
+          name="${sym##*.}"
+          dir="${pkg#github.com/pardnchiu/agenvoy/}"
+          grep -Rqs "^var ${name} " "${dir}" \
+            || { echo "::error::ldflags target ${sym} does not exist — the version stamp would be silently dropped"; exit 1; }
 
       - name: Package
         env:

--- a/makefile
+++ b/makefile
@@ -27,7 +27,7 @@ help:
 build:
 	@git fetch --tags --force 2>/dev/null || true
 	@ver=$$(git describe --tags --exact-match 2>/dev/null || echo '(dev)'); \
-	go build -tags "fts5" -ldflags "-X github.com/pardnchiu/agenvoy/internal/version.Current=$$ver" -o agen ./cmd/app/ && sudo mkdir -p /usr/local/bin && sudo mv agen /usr/local/bin/agen
+	go build -tags "fts5" -ldflags "-X github.com/pardnchiu/agenvoy/internal/runtime.CurrentVersion=$$ver" -o agen ./cmd/app/ && sudo mkdir -p /usr/local/bin && sudo mv agen /usr/local/bin/agen
 	@rm -rf "$$HOME/.config/agenvoy/skills/.system" "$$HOME/.config/agenvoy/tools/.system"
 	@mkdir -p "$$HOME/.config/agenvoy/skills/.system" "$$HOME/.config/agenvoy/tools/.system"
 	@[ -d extensions/skills ] && cp -R extensions/skills/. "$$HOME/.config/agenvoy/skills/.system/" || true


### PR DESCRIPTION
Fixes release version stamping in the release workflow and Makefile by targeting the relocated runtime version variable. Adds a CI verification step that fails when the `-ldflags -X` target no longer exists, preventing silently incorrect version metadata in released binaries.
